### PR TITLE
Remove depended dependencies, upgrade jackson-mapper-asl to 1.9.11

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,16 +23,10 @@
         <relativePath>../pom.xml</relativePath>
         <version>4.0.18-SNAPSHOT</version>
     </parent>
-    
 	<dependencies>
 		<dependency>
 			<groupId>org.membrane-soa.service-proxy</groupId>
 			<artifactId>service-proxy-annot</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>javax.activation</groupId>
-			<artifactId>activation</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>commons-cli</groupId>
@@ -51,32 +45,8 @@
 			<artifactId>commons-discovery</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>commons-logging</groupId>
-			<artifactId>commons-logging</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>commons-pool</groupId>
-			<artifactId>commons-pool</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.codehaus.groovy</groupId>
-			<artifactId>groovy</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-core-asl</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.codehaus.jackson</groupId>
 			<artifactId>jackson-mapper-asl</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.googlecode.jatl</groupId>
@@ -110,10 +80,6 @@
 			<groupId>com.springsource</groupId>
 			<artifactId>com.springsource.javax.annotation</artifactId>
 		</dependency>
-		<dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
         <dependency>
         	<groupId>commons-fileupload</groupId>
         	<artifactId>commons-fileupload</artifactId>
@@ -121,10 +87,6 @@
 		<dependency>
 			<groupId>com.floreysoft</groupId>
 			<artifactId>jmte</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.google.code.findbugs</groupId>
-			<artifactId>jsr305</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.google.api-client</groupId>
@@ -138,7 +100,6 @@
 			<groupId>javax.mail</groupId>
 			<artifactId>mail</artifactId>
 		</dependency>
-                        
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-beans</artifactId>
@@ -159,7 +120,6 @@
 			<artifactId>org.apache.aries.blueprint.api</artifactId>
 			<scope>provided</scope>
 		</dependency>
- 
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
 		<project.reporting.outputEncoding>ISO-8859-1</project.reporting.outputEncoding>
 		<javac.source>1.6</javac.source>
 		<javac.target>1.6</javac.target>
+        <jackson.version>1.9.11</jackson.version> <!-- This version is used by google-http-client-jackson -->
 	</properties>
 
 	<dependencyManagement>
@@ -149,12 +150,12 @@
 			<dependency>
 				<groupId>org.codehaus.jackson</groupId>
 				<artifactId>jackson-core-asl</artifactId>
-				<version>1.9.9</version>
+				<version>${jackson.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.codehaus.jackson</groupId>
 				<artifactId>jackson-mapper-asl</artifactId>
-				<version>1.9.9</version>
+				<version>${jackson.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>log4j</groupId>


### PR DESCRIPTION
Hello all, 

I've removed from core/pom.xml all dependecies, which could be reached from other projects.
Also I've upgraded version of jackson-mapper-asl, because this version is used by google-http-client-jackson.

List of used libraries is still the same, the only change is 
[INFO]    org.codehaus.jackson:jackson-core-asl:jar 1.9.9 => 1.9.11
[INFO]    org.codehaus.jackson:jackson-mapper-asl 1.9.9 => 1.9.11

Please review this simple change.

```
        thanks

                   vlk
```
