### PR TITLE
Changed setter type of GreaseInterceptor.setRate() from Double to String

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/grease/GreaseInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/grease/GreaseInterceptor.java
@@ -24,6 +24,7 @@ import java.util.*;
 
 import static com.predic8.membrane.core.interceptor.Interceptor.Flow.*;
 import static com.predic8.membrane.core.interceptor.Outcome.*;
+import static java.lang.Double.parseDouble;
 import static java.util.EnumSet.*;
 
 @MCElement(name = "greaser")
@@ -63,8 +64,8 @@ public class GreaseInterceptor extends AbstractInterceptor {
     }
 
     @MCAttribute
-    public void setRate(double rate) {
-        this.rate = Math.max(0, Math.min(1, rate));
+    public void setRate(String rate) {
+        this.rate = Math.max(0, Math.min(1, parseDouble(rate)));
     }
 
     public double getRate() {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/grease/GreaseInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/grease/GreaseInterceptorTest.java
@@ -39,7 +39,7 @@ class GreaseInterceptorTest {
     @BeforeEach
     void setup() {
         greaseInterceptor = new GreaseInterceptor();
-        greaseInterceptor.setRate(1);
+        greaseInterceptor.setRate("1");
         greaseInterceptor.setStrategies(List.of(new JsonGrease() {{
             setAdditionalProperties(false);}}));
     }
@@ -65,25 +65,25 @@ class GreaseInterceptorTest {
         // Test with rate = 1
         assertNotEquals(json, requestExc.getRequest().getBodyAsStringDecoded());
 
-        greaseInterceptor.setRate(0.1);
+        greaseInterceptor.setRate("0.1");
         assertEquals(0.1, calculateRate(greaseInterceptor, json), 0.02);
 
-        greaseInterceptor.setRate(0.5);
+        greaseInterceptor.setRate("0.5");
         assertEquals(0.5, calculateRate(greaseInterceptor, json), 0.02);
 
-        greaseInterceptor.setRate(0.01);
+        greaseInterceptor.setRate("0.01");
         assertEquals(0.01, calculateRate(greaseInterceptor, json), 0.02);
     }
 
     @Test
     void testSetRate() {
-        greaseInterceptor.setRate(0.5);
+        greaseInterceptor.setRate("0.5");
         assertEquals(0.5, greaseInterceptor.getRate());
-        greaseInterceptor.setRate(1.5);
+        greaseInterceptor.setRate("1.5");
         assertEquals(1.0, greaseInterceptor.getRate());
-        greaseInterceptor.setRate(-0.5);
+        greaseInterceptor.setRate("-0.5");
         assertEquals(0.0, greaseInterceptor.getRate());
-        greaseInterceptor.setRate(0.0001);
+        greaseInterceptor.setRate("0.0001");
         assertEquals(0.0001, greaseInterceptor.getRate());
     }
 


### PR DESCRIPTION
Changed setter type of GreaseInterceptor.setRate() from Double to String, whereas the String gets parsed as double internally