### PR TITLE
Fixed getResourceAsStream 

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/openapi/util/Utils.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/util/Utils.java
@@ -219,15 +219,13 @@ public class Utils {
      */
     public static InputStream getResourceAsStream(Object obj, String location) throws FileNotFoundException {
         try {
-            URL url = obj.getClass().getResource(location);
-            if (url == null) {
-                LOG.warn("Resource {} not found", location);
-                throw new FileNotFoundException(location);
+            InputStream inputStream = obj.getClass().getResourceAsStream(new URI(location).getPath());
+
+            if (inputStream == null) {
+                throw new FileNotFoundException("Resource " + location + " not found");
             }
 
-            // Uses wrapping in URI and FileInputStream because of:
-            // https://stackoverflow.com/questions/3263560/sysloader-getresource-problem-in-java
-            return new FileInputStream(new URI(url.toString()).getPath());
+            return inputStream;
         } catch (URISyntaxException e) {
             LOG.error(e.getMessage());
             throw new RuntimeException(e);


### PR DESCRIPTION
Membrane did not start when packaged in jar: 

```sh
Membrane Router running...
16:09:03,482  INFO 1 main OpenAPIRecordFactory:83 - Parsing spec fruitshop-api.yml
org.springframework.context.ApplicationContextException: Failed to start bean 'router'
	at org.springframework.context.support.DefaultLifecycleProcessor.doStart(DefaultLifecycleProcessor.java:288)
	at org.springframework.context.support.DefaultLifecycleProcessor$LifecycleGroup.start(DefaultLifecycleProcessor.java:472)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at org.springframework.context.support.DefaultLifecycleProcessor.startBeans(DefaultLifecycleProcessor.java:257)
	at org.springframework.context.support.DefaultLifecycleProcessor.start(DefaultLifecycleProcessor.java:170)
	at org.springframework.context.support.AbstractApplicationContext.start(AbstractApplicationContext.java:1530)
	at com.predic8.membrane.core.Router.init(Router.java:147)
	at com.predic8.membrane.core.RouterCLI.main(RouterCLI.java:39)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at com.predic8.membrane.core.Starter.main(Starter.java:47)
Caused by: java.lang.RuntimeException: java.lang.NullPointerException
	at com.predic8.membrane.core.Router.start(Router.java:316)
	at org.springframework.context.support.DefaultLifecycleProcessor.doStart(DefaultLifecycleProcessor.java:285)
	... 10 more
Caused by: java.lang.NullPointerException
	at java.base/java.io.FileInputStream.<init>(FileInputStream.java:144)
	at java.base/java.io.FileInputStream.<init>(FileInputStream.java:106)
	at com.predic8.membrane.core.openapi.util.Utils.getResourceAsStream(Utils.java:230)
	at com.predic8.membrane.core.openapi.serviceproxy.OpenAPIPublisherInterceptor.createTemplate(OpenAPIPublisherInterceptor.java:72)
	at com.predic8.membrane.core.openapi.serviceproxy.OpenAPIPublisherInterceptor.<init>(OpenAPIPublisherInterceptor.java:66)
	at com.predic8.membrane.core.openapi.serviceproxy.APIProxy.initOpenAPI(APIProxy.java:96)
	at com.predic8.membrane.core.openapi.serviceproxy.APIProxy.init(APIProxy.java:82)
	at com.predic8.membrane.core.rules.AbstractProxy.init(AbstractProxy.java:163)
	at com.predic8.membrane.core.Router.initRemainingRules(Router.java:269)
	at com.predic8.membrane.core.Router.init(Router.java:263)
	at com.predic8.membrane.core.Router.start(Router.java:288)
	... 11 more

```