### PR TITLE
Fix issue #1349 by setting body to empty string after 0 content-length.

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/http/Response.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/Response.java
@@ -119,6 +119,7 @@ public class Response extends Message {
 
 		public ResponseBuilder bodyEmpty() {
 			res.getHeader().setContentLength(0);
+			this.body("");
 			return this;
 		}
 

--- a/core/src/main/java/com/predic8/membrane/core/http/Response.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/Response.java
@@ -117,9 +117,12 @@ public class Response extends Message {
 			return this;
 		}
 
+		/**
+		 * Overwrites the body with an empty body and sets the Content-Length to 0
+		 */
 		public ResponseBuilder bodyEmpty() {
 			res.getHeader().setContentLength(0);
-			this.body("");
+			res.body = new EmptyBody();
 			return this;
 		}
 

--- a/core/src/test/java/com/predic8/membrane/core/http/ResponseBuilderTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/http/ResponseBuilderTest.java
@@ -16,15 +16,37 @@ package com.predic8.membrane.core.http;
 
 import org.junit.jupiter.api.*;
 
+import java.io.*;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ResponseBuilderTest {
 
     @Test
-    void simpleOk() throws Exception {
+    void okPlain() throws Exception {
+        Response res = Response.ok().build();
+        assertEquals(200,res.getStatusCode());
+        assertEquals(res.header.getContentLength(), 0);
+        assertInstanceOf( EmptyBody.class,res.getBody());
+    }
+
+    @Test
+    void okWithBody() throws Exception {
         Response res = Response.ok("Hello").contentType("glue/instant").build();
         assertEquals(200,res.getStatusCode());
         assertEquals("Hello",res.getBodyAsStringDecoded());
         assertEquals("glue/instant",res.getHeader().getContentType());
+        assertEquals(res.header.getContentLength(), 5);
+        assertEquals("Hello", res.getBodyAsStringDecoded());
+    }
+
+    @Test
+    void bodyEmpty() throws Exception {
+        Response res = Response.ok("Empty me!").bodyEmpty().build();
+        assertEquals(200,res.getStatusCode());
+        assertEquals(res.header.getContentLength(), 0);
+        assertInstanceOf( EmptyBody.class,res.getBody());
+        assertEquals(0, res.getBody().getLength());
+        assertEquals("", res.getBodyAsStringDecoded());
     }
 }


### PR DESCRIPTION
I have added the body("") into bodyEmpty method.

I can also replace other existing body("") calls on a Response.redirect builder with new bodyEmpty method in another pull request if you want to consolidate the usage.