### PR TITLE
Added check and block for external entity references in XMLProtection 

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/xmlprotection/XMLProtectionException.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/xmlprotection/XMLProtectionException.java
@@ -1,0 +1,7 @@
+package com.predic8.membrane.core.interceptor.xmlprotection;
+
+public class XMLProtectionException extends Exception {
+    public XMLProtectionException(String message) {
+        super(message);
+    }
+}

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/xmlprotection/XMLProtector.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/xmlprotection/XMLProtector.java
@@ -39,15 +39,15 @@ import static javax.xml.stream.XMLInputFactory.*;
  * an error response should be returned to the requestor.
  */
 public class XMLProtector {
-	private static Logger log = LoggerFactory.getLogger(XMLProtector.class.getName());
-	private static XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+	private static final Logger log = LoggerFactory.getLogger(XMLProtector.class.getName());
+	private static final XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
 	static {
 		xmlInputFactory.setProperty(IS_REPLACING_ENTITY_REFERENCES, false);
 		xmlInputFactory.setProperty(IS_SUPPORTING_EXTERNAL_ENTITIES, false);
 		xmlInputFactory.setProperty(SUPPORT_DTD,false);
 	}
 
-	private XMLEventWriter writer;
+	private final XMLEventWriter writer;
 	private final int maxAttibuteCount;
 	private final int maxElementNameLength;
 	private final boolean removeDTD;
@@ -64,7 +64,7 @@ public class XMLProtector {
 
 	/**
 	 * Is XML secure?
-	 * @param isr
+	 * @param isr Stream with XML
 	 * @return false if there is any security problem in the XML
 	 * @throws XMLProtectionException if there are critical issues like external entity references
 	 */

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/xmlprotection/XMLProtectionInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/xmlprotection/XMLProtectionInterceptorTest.java
@@ -25,52 +25,52 @@ import static com.predic8.membrane.core.interceptor.Outcome.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class XMLProtectionInterceptorTest {
-	private static Exchange exc;
-	private static XMLProtectionInterceptor interceptor;
+    private static Exchange exc;
+    private static XMLProtectionInterceptor interceptor;
 
-	@BeforeAll
-	public static void setUp() throws Exception {
-		exc = new Exchange(null);
-		exc.setRequest(MessageUtil.getGetRequest("/axis2/services/BLZService"));
-		exc.setOriginalHostHeader("thomas-bayer.com:80");
+    @BeforeAll
+    public static void setUp() throws Exception {
+        exc = new Exchange(null);
+        exc.setRequest(MessageUtil.getGetRequest("/axis2/services/BLZService"));
+        exc.setOriginalHostHeader("thomas-bayer.com:80");
 
-		interceptor = new XMLProtectionInterceptor();
-	}
+        interceptor = new XMLProtectionInterceptor();
+    }
 
-	private void runOn(String resource, boolean expectSuccess) throws Exception {
-		exc.getRequest().getHeader().setContentType(APPLICATION_XML);
-		exc.getRequest().setBodyContent(ByteUtil.getByteArrayData(this.getClass().getResourceAsStream(resource)));
-		Outcome outcome = interceptor.handleRequest(exc);
-		assertEquals(expectSuccess ? CONTINUE : ABORT, outcome);
-	}
+    private void runOn(String resource, boolean expectSuccess) throws Exception {
+        exc.getRequest().getHeader().setContentType(APPLICATION_XML);
+        exc.getRequest().setBodyContent(ByteUtil.getByteArrayData(this.getClass().getResourceAsStream(resource)));
+        Outcome outcome = interceptor.handleRequest(exc);
+        assertEquals(expectSuccess ? CONTINUE : ABORT, outcome);
+    }
 
-	@Test
-	void testInvariant() throws Exception {
-		runOn("/customer.xml", true);
-	}
+    @Test
+    void testInvariant() throws Exception {
+        runOn("/customer.xml", true);
+    }
 
-	@Test
-	void testNotWellformed() throws Exception {
-		runOn("/xml/not-wellformed.xml", false);
-	}
+    @Test
+    void testNotWellformed() throws Exception {
+        runOn("/xml/not-wellformed.xml", false);
+    }
 
-	@Test
-	void removeDTD() throws Exception {
-		exc.setRequest(Request.post("/").body("""
-			<?xml  version="1.0" encoding="ISO-8859-1"?>
-			<!DOCTYPE foo [
-			     <!ELEMENT foo ANY >
-			   ]>
-			<foo/>
-			""").contentType(APPLICATION_XML).build());
+    @Test
+    void removeDTD() throws Exception {
+        exc.setRequest(Request.post("/").body("""
+                <?xml  version="1.0" encoding="ISO-8859-1"?>
+                <!DOCTYPE foo [
+                     <!ELEMENT foo ANY >
+                   ]>
+                <foo/>
+                """).contentType(APPLICATION_XML).build());
 
-		// Should pass
+        // Should pass
         assertEquals(CONTINUE, interceptor.handleRequest(exc));
 
-		// Should still contain the XML
-		assertTrue(exc.getRequest().getBodyAsStringDecoded().contains("<foo"));
+        // Should still contain the XML
+        assertTrue(exc.getRequest().getBodyAsStringDecoded().contains("<foo"));
 
-		// DTD should be removed
+        // DTD should be removed
         assertFalse(exc.getRequest().getBodyAsStringDecoded().contains("DOCTYPE"));
-	}
+    }
 }

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/xmlprotection/XMLProtectionInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/xmlprotection/XMLProtectionInterceptorTest.java
@@ -14,15 +14,15 @@
 
 package com.predic8.membrane.core.interceptor.xmlprotection;
 
+import com.predic8.membrane.core.exchange.*;
+import com.predic8.membrane.core.http.*;
+import com.predic8.membrane.core.interceptor.*;
+import com.predic8.membrane.core.util.*;
+import org.junit.jupiter.api.*;
+
+import static com.predic8.membrane.core.http.MimeType.*;
+import static com.predic8.membrane.core.interceptor.Outcome.*;
 import static org.junit.jupiter.api.Assertions.*;
-
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-
-import com.predic8.membrane.core.exchange.Exchange;
-import com.predic8.membrane.core.interceptor.Outcome;
-import com.predic8.membrane.core.util.ByteUtil;
-import com.predic8.membrane.core.util.MessageUtil;
 
 public class XMLProtectionInterceptorTest {
 	private static Exchange exc;
@@ -38,21 +38,39 @@ public class XMLProtectionInterceptorTest {
 	}
 
 	private void runOn(String resource, boolean expectSuccess) throws Exception {
-		exc.getRequest().getHeader().setContentType("application/xml");
+		exc.getRequest().getHeader().setContentType(APPLICATION_XML);
 		exc.getRequest().setBodyContent(ByteUtil.getByteArrayData(this.getClass().getResourceAsStream(resource)));
 		Outcome outcome = interceptor.handleRequest(exc);
-		assertEquals(expectSuccess ? Outcome.CONTINUE : Outcome.ABORT, outcome);
+		assertEquals(expectSuccess ? CONTINUE : ABORT, outcome);
 	}
 
 	@Test
-	public void testInvariant() throws Exception {
+	void testInvariant() throws Exception {
 		runOn("/customer.xml", true);
 	}
 
 	@Test
-	public void testNotWellformed() throws Exception {
+	void testNotWellformed() throws Exception {
 		runOn("/xml/not-wellformed.xml", false);
 	}
 
+	@Test
+	void removeDTD() throws Exception {
+		exc.setRequest(Request.post("/").body("""
+			<?xml  version="1.0" encoding="ISO-8859-1"?>
+			<!DOCTYPE foo [
+			     <!ELEMENT foo ANY >
+			   ]>
+			<foo/>
+			""").contentType(APPLICATION_XML).build());
 
+		// Should pass
+        assertEquals(CONTINUE, interceptor.handleRequest(exc));
+
+		// Should still contain the XML
+		assertTrue(exc.getRequest().getBodyAsStringDecoded().contains("<foo"));
+
+		// DTD should be removed
+        assertFalse(exc.getRequest().getBodyAsStringDecoded().contains("DOCTYPE"));
+	}
 }

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/xmlprotection/XMLProtectorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/xmlprotection/XMLProtectorTest.java
@@ -65,50 +65,41 @@ public class XMLProtectorTest {
 	}
 
 	@Test
-	public void testInvariant() throws Exception {
+	void invariant() throws Exception {
 		assertTrue(runOn("/customer.xml"));
 	}
 
 	@Test
-	public void testNotWellformed() throws Exception {
+	void NotWellformed() throws Exception {
 		assertFalse(runOn("/xml/not-wellformed.xml"));
 	}
 
 	@Test
-	public void testDTDRemoval1() throws Exception {
+	void DTDRemoval() throws Exception {
 		assertTrue(runOn("/xml/entity-expansion.lmx"));
 		assertTrue(output.length < input.length / 2);
 		assertFalse(new String(output).contains("ENTITY"));
 	}
 
 	@Test
-	public void testDTDRemoval2() throws Exception {
-		assertTrue(runOn("/xml/entity-external.xml"));
-		assertTrue(output.length < input.length * 2 / 3);
-		assertFalse(new String(output).contains("ENTITY"));
-	}
-
-	@Test
-	public void testExpandingEntities() throws Exception {
+	void expandingEntities() throws Exception {
 		assertTrue(runOn("/xml/entity-expansion.lmx", false));
 		assertTrue(output.length > input.length / 2);
 		assertTrue(new String(output).contains("ENTITY"));
 	}
 
 	@Test
-	public void testExternalEntities() throws Exception {
-		assertTrue(runOn("/xml/entity-external.xml", false));
-		assertTrue(output.length > input.length * 2 / 3);
-		assertTrue(new String(output).contains("ENTITY"));
+	void externalEntities() throws Exception {
+		assertThrows(XMLProtectionException.class, () -> runOn("/xml/entity-external.xml", false));
 	}
 
 	@Test
-	public void testLongElementName() throws Exception {
+	void longElementName() throws Exception {
 		assertFalse(runOn("/xml/long-element-name.xml"));
 	}
 
 	@Test
-	public void testManyAttributes() throws Exception {
+	void manyAttributes() throws Exception {
 		assertFalse(runOn("/xml/many-attributes.xml"));
 	}
 }

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/xmlprotection/XMLProtectorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/xmlprotection/XMLProtectorTest.java
@@ -25,8 +25,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class XMLProtectorTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(XMLProtectorTest.class);
-	private XMLProtector xmlProtector;
-	private byte[] input, output;
+    private byte[] input, output;
 
 	private boolean runOn(String resource) throws Exception {
 		return runOn(resource, true);
@@ -34,7 +33,7 @@ public class XMLProtectorTest {
 
 	private boolean runOn(String resource, boolean removeDTD) throws Exception {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		xmlProtector = new XMLProtector(new OutputStreamWriter(baos, UTF_8), removeDTD, 1000, 1000);
+        XMLProtector xmlProtector = new XMLProtector(new OutputStreamWriter(baos, UTF_8), removeDTD, 1000, 1000);
 		input = ByteUtil.getByteArrayData(this.getClass().getResourceAsStream(resource));
 
 		if (resource.endsWith("lmx")) {
@@ -89,7 +88,7 @@ public class XMLProtectorTest {
 	}
 
 	@Test
-	void externalEntities() throws Exception {
+	void externalEntities() {
 		assertThrows(XMLProtectionException.class, () -> runOn("/xml/entity-external.xml", false));
 	}
 


### PR DESCRIPTION
Before the DTD was just removed, now the request is blocked.