### PR TITLE
Fixing Socket Exception

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/transport/http/ConnectionManager.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/http/ConnectionManager.java
@@ -123,7 +123,7 @@ public class ConnectionManager {
 				int i = l.size() - 1;
 				while(i >= 0) {
 					OldConnection c = l.get(i);
-					if (c.deathTime > now) {
+					if (c.deathTime > now && !c.connection.isClosed()) {
 						l.remove(i);
 						return c.connection;
 					}


### PR DESCRIPTION
Hello,

We have experienced 502 - Bad Gateway errors on predic8 api-gateway. While I was searching for the root cause of SocketExceptions and HTTP 502 responses, I came to conclusion of this:

The api-gateway is reusing an old connection but it is not aware if this connection still exists. We found out this behaviour from TCP captures. Before the SocketException occurs, we have proofs that the entity behind the api gateway sends a RST package. First attempt after this RST package, the api gateway throws a SocketException. Because it is not aware that the connection is ended. After investigating TCP captures and the code, I found out the ConnectionManager does not check if the connection still valid before returning an existing connection. It just checks if the deathTime is reached. 

I believe adding this single line will fix this issue. Unfortunately we do not have the environment to manually reproduce the issue. The issue somewhat happens to be between some time with the deathTime and the actual time of the connection is closed.