### PR TITLE
switch org.graalvm.js:js dependency to type 'pom'

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -216,6 +216,7 @@
             <artifactId>js</artifactId>
             <version>24.1.2</version>
             <scope>test</scope>
+            <type>pom</type>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Maven seems to have a problem resolving the dependency (which is a `pom` only dependency, see https://repo1.maven.org/maven2/org/graalvm/js/js/24.1.2/ ) : https://github.com/membrane/api-gateway/actions/runs/13614966836/job/38056845671