### PR TITLE
Fixing CVE-2024-57699 for json-smart by updating it explicitly.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -178,6 +178,11 @@
             <version>2.9.0</version>
         </dependency>
         <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>2.5.2</version>
+        </dependency>
+        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>4.12.0</version>


### PR DESCRIPTION
Fixing CVE by updating transitive dependency explicitly for issue #1725.