### PR TITLE
Add warning for default JWK usage in JwtSignInterceptor

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/jwt/JwtSignInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/jwt/JwtSignInterceptor.java
@@ -27,6 +27,8 @@ import org.jose4j.lang.*;
 import org.slf4j.*;
 
 import java.io.*;
+import java.util.Map;
+import java.util.Objects;
 
 import static com.predic8.membrane.core.exceptions.ProblemDetails.*;
 import static com.predic8.membrane.core.interceptor.Interceptor.Flow.*;
@@ -38,6 +40,7 @@ import static org.jose4j.jws.AlgorithmIdentifiers.*;
 public class JwtSignInterceptor extends AbstractInterceptor {
 
     private static final Logger log = LoggerFactory.getLogger(JwtSignInterceptor.class);
+    public static final String DEFAULT_PKEY = "wP1ITsKxAWOO03eywdOj73T5Po1OFXZlFgzf1CJaf8D3piuxS0C5JSHTKTO354_r9cg2WyQ3nEqJ6YScV3-NfW8xXbiyMr5Xokzn7YpuB9dtby0veEn4w7JHChH5lV2fwrjH2iL6IIOLrND9D_Dxoc3mmLMaie0mTW9-UHGOunk";
 
     private JwtSessionManager.Jwk jwk;
     private RsaJsonWebKey rsaJsonWebKey;
@@ -49,7 +52,14 @@ public class JwtSignInterceptor extends AbstractInterceptor {
     public void init() {
         super.init();
         try {
-            rsaJsonWebKey = new RsaJsonWebKey(JsonUtil.parseJson(jwk.get(router.getResolverMap(), router.getBaseLocation())));
+            Map<String, Object> params = JsonUtil.parseJson(jwk.get(router.getResolverMap(), router.getBaseLocation()));
+            if (Objects.equals(params.get("p"), DEFAULT_PKEY)) {
+                log.warn("""
+                    \n------------------------------------ DEFAULT JWK IN USE! ------------------------------------
+                            This key is for demonstration purposes only and UNSAFE for production use.          \s
+                    ---------------------------------------------------------------------------------------------""");
+            }
+            rsaJsonWebKey = new RsaJsonWebKey(params);
         } catch (JoseException e) {
             throw new ConfigurationException("Cannot create RSA JSON Web Key",e);
         } catch (IOException e) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/jwt/JwtSignInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/jwt/JwtSignInterceptor.java
@@ -40,7 +40,7 @@ import static org.jose4j.jws.AlgorithmIdentifiers.*;
 public class JwtSignInterceptor extends AbstractInterceptor {
 
     private static final Logger log = LoggerFactory.getLogger(JwtSignInterceptor.class);
-    public static final String DEFAULT_PKEY = "wP1ITsKxAWOO03eywdOj73T5Po1OFXZlFgzf1CJaf8D3piuxS0C5JSHTKTO354_r9cg2WyQ3nEqJ6YScV3-NfW8xXbiyMr5Xokzn7YpuB9dtby0veEn4w7JHChH5lV2fwrjH2iL6IIOLrND9D_Dxoc3mmLMaie0mTW9-UHGOunk";
+    private static final String DEFAULT_PKEY = "wP1ITsKxAWOO03eywdOj73T5Po1OFXZlFgzf1CJaf8D3piuxS0C5JSHTKTO354_r9cg2WyQ3nEqJ6YScV3-NfW8xXbiyMr5Xokzn7YpuB9dtby0veEn4w7JHChH5lV2fwrjH2iL6IIOLrND9D_Dxoc3mmLMaie0mTW9-UHGOunk";
 
     private JwtSessionManager.Jwk jwk;
     private RsaJsonWebKey rsaJsonWebKey;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved security key handling by adding an extra layer of verification. The system now logs a warning if an unsafe default key configuration is detected, helping prevent potential misconfigurations in production environments.
  - Introduced a predefined key value to enhance the handling of JSON Web Keys (JWK).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->