### PR TITLE
Add parameterized tests for HttpUtil.getPathAndQueryString

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/util/HttpUtil.java
+++ b/core/src/main/java/com/predic8/membrane/core/util/HttpUtil.java
@@ -148,10 +148,21 @@ public class HttpUtil {
 		return header;
 	}
 
+	/**
+	 * If there is no path like api.predic8.de it will return /
+	 *
+	 * @param dest URL e.g. http://predic8.de/foo?name=bar
+	 * @return Path and query string without protocol and host e.g. /foo?name=bar
+	 * @throws MalformedURLException
+	 */
 	public static String getPathAndQueryString(String dest) throws MalformedURLException {
 		URL url = new URL(dest);
-
 		String uri = url.getPath();
+
+		if(url.getPath().isEmpty()) {
+			uri = "/";
+		}
+
 		if (url.getQuery() != null) {
 			return uri + "?" + url.getQuery();
 		}

--- a/core/src/test/java/com/predic8/membrane/core/util/HttpUtilTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/util/HttpUtilTest.java
@@ -16,6 +16,8 @@ package com.predic8.membrane.core.util;
 
 import com.predic8.membrane.core.http.Request;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.io.*;
 import java.net.*;
@@ -109,5 +111,21 @@ public class HttpUtilTest {
 
 	private static int getPort(String uri) throws MalformedURLException, URISyntaxException {
 		return HttpUtil.getPort(new URI(uri).toURL());
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"'http://localhost', '/'",
+			"'http://localhost/', '/'",
+			"'http://localhost?', '/?'",
+			"'http://localhost?foo=bar', '/?foo=bar'",
+			"'http://localhost:2000', '/'",
+			"'http://localhost:2000/', '/'",
+			"'http://localhost:2000?', '/?'",
+			"'http://localhost:2000?foor=bar', '/?foor=bar'",
+			"'http://localhost:2000/foor?bar', '/foor?bar'"
+	})
+	public void testGetPathAndQueryString(String url, String expected) throws MalformedURLException {
+		assertEquals(expected, HttpUtil.getPathAndQueryString(url));
 	}
 }


### PR DESCRIPTION
Implement parameterized tests in HttpUtilTest to verify the behavior of the getPathAndQueryString method with various URL formats. Update the method in HttpUtil to return "/" for empty paths, ensuring consistent handling of URLs without paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced URL processing to always return a valid output when the URL lacks a path, ensuring consistent behavior.
- **Tests**
  - Expanded test coverage with parameterized tests to verify correct URL handling across a range of input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->