### PR TITLE
Use 302 in all OAuth2/OpenID-Connect redirects

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/http/Response.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/Response.java
@@ -235,10 +235,18 @@ public class Response extends Message {
 		return newInstance().status(100);
 	}
 
+	public static ResponseBuilder redirect(String uri) {
+		return redirect(uri, false);
+	}
+
 	public static ResponseBuilder redirect(String uri, boolean permanent) {
+		return redirect(uri, permanent ? 301 : 307);
+	}
+
+	public static ResponseBuilder redirect(String uri, int code) {
 		String escaped = StringEscapeUtils.escapeXml11(uri);
 		return ResponseBuilder.newInstance().
-				status(permanent ? 301 : 307, permanent ? "Moved Permanently" : "Temporary Redirect").
+				status(code).
 				header(LOCATION, uri).
 				contentType(TEXT_HTML_UTF8).
 				body(HttpUtil.unescapedHtmlMessage("Moved.", "This page has moved to <a href=\""+escaped+"\">"+escaped+"</a>."));

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/flows/CodeFlow.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/flows/CodeFlow.java
@@ -61,12 +61,12 @@ public class CodeFlow extends OAuth2Flow{
             redirectUrl = s.getUserAttributes().get("redirect_uri");
         }
 
-        exc.setResponse(Response.
-                redirect(redirectUrl + "?code=" + code + stateQuery(state),false).
-                dontCache().
-                body("").
-                build());
-        
+        exc.setResponse(Response
+                .redirect(redirectUrl + "?code=" + code + stateQuery(state),302)
+                .dontCache()
+                .body("")
+                .build());
+
         return Outcome.RETURN;
     }
 }

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/flows/TokenFlow.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/flows/TokenFlow.java
@@ -55,10 +55,10 @@ public class TokenFlow extends OAuth2Flow {
         }
 
         exc.setResponse(Response.
-                redirect(redirectUrl + "?access_token=" + token + stateQuery(state) + "&token_type=" + tokenType + "&scope=" + scope,false).
-                dontCache().
-                body("").
-                build());
+                redirect(redirectUrl + "?access_token=" + token + stateQuery(state) + "&token_type=" + tokenType + "&scope=" + scope,302)
+                .dontCache()
+                .body("")
+                .build());
 
         return Outcome.RETURN;
     }

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/processors/EmptyEndpointProcessor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/processors/EmptyEndpointProcessor.java
@@ -138,9 +138,10 @@ public class EmptyEndpointProcessor extends EndpointProcessor {
 
 
     private Outcome redirectToConsentPage(Exchange exc) {
-        exc.setResponse(Response.redirect(
-                (exc.getRequestURI().endsWith("/") ? exc.getRequestURI().substring(0,exc.getRequestURI().length()-1) : exc.getRequestURI())
-                        + "/login/consent",false).dontCache().bodyEmpty().build());
+        String redirectURI = (
+                exc.getRequestURI().endsWith("/") ? exc.getRequestURI().substring(0, exc.getRequestURI().length() - 1) : exc.getRequestURI()
+        ) + "/login/consent";
+        exc.setResponse(Response.redirect(redirectURI,302).dontCache().bodyEmpty().build());
         return Outcome.RETURN;
     }
 

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/request/AuthWithSessionRequest.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/request/AuthWithSessionRequest.java
@@ -46,7 +46,7 @@ public class AuthWithSessionRequest extends ParameterizedRequest {
         synchronized (session) {
             session.getUserAttributes().put(ParamNames.STATE, getState());
         }
-        return Response.redirect(authServer.getBasePath() + "/?" + getState(), false).build();
+        return Response.redirect(authServer.getBasePath() + "/?" + getState(), 302).build();
     }
 
     private Response doOpenIDPrompt() throws IOException {
@@ -69,6 +69,6 @@ public class AuthWithSessionRequest extends ParameterizedRequest {
     }
 
     private static Response redirectToOAuth2AuthEndpoint(Exchange exc) {
-        return Response.redirect(exc.getRequestURI(), false).dontCache().bodyEmpty().build();
+        return Response.redirect(exc.getRequestURI(), 302).dontCache().bodyEmpty().build();
     }
 }

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/request/AuthWithoutSessionRequest.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/request/AuthWithoutSessionRequest.java
@@ -40,7 +40,7 @@ public class AuthWithoutSessionRequest extends ParameterizedRequest {
             return OAuth2Util.createParameterizedJsonErrorResponse("error", "invalid_request");
 
         if(getResponseType() == null || getScope() == null)
-            return createParameterizedFormUrlencodedRedirect(exc, getState(), getRedirectUri() + "?error=invalid_request");
+            return createParameterizedFormUrlencodedRedirect(exc, getState(), getRedirectUri(), "invalid_request");
         return new NoResponse();
     }
 
@@ -57,20 +57,20 @@ public class AuthWithoutSessionRequest extends ParameterizedRequest {
             return OAuth2Util.createParameterizedJsonErrorResponse("error", "invalid_request");
 
         if (promptEqualsNone())
-            return createParameterizedFormUrlencodedRedirect(exc, getState(), client.getCallbackUrl() + "?error=login_required");
+            return createParameterizedFormUrlencodedRedirect(exc, getState(), client.getCallbackUrl(), "login_required");
 
 
         if (!authServer.getSupportedAuthorizationGrants().contains(getResponseType()))
-            return createParameterizedFormUrlencodedRedirect(exc, getState(), client.getCallbackUrl() + "?error=unsupported_response_type");
+            return createParameterizedFormUrlencodedRedirect(exc, getState(), client.getCallbackUrl(), "unsupported_response_type");
 
         String validScopes = verifyScopes(getScope());
 
         if (validScopes.isEmpty())
-            return createParameterizedFormUrlencodedRedirect(exc, getState(), client.getCallbackUrl() + "?error=invalid_scope");
+            return createParameterizedFormUrlencodedRedirect(exc, getState(), client.getCallbackUrl(), "invalid_scope");
 
         if(OAuth2Util.isOpenIdScope(validScopes)) {
             if (!isCodeRequest())
-                return createParameterizedFormUrlencodedRedirect(exc, getState(), client.getCallbackUrl() + "?error=invalid_request");
+                return createParameterizedFormUrlencodedRedirect(exc, getState(), client.getCallbackUrl(), "invalid_request");
 
             //Parses the claims parameter into a json object. Claim values are always ignored and set to "null" as it is optional to react to those values
             addValidClaimsToParams();
@@ -137,11 +137,11 @@ public class AuthWithoutSessionRequest extends ParameterizedRequest {
     }
 
     protected Response redirectToLogin() throws MalformedURLException, UnsupportedEncodingException {
-        Response resp = Response.
-                redirect(authServer.getBasePath() + authServer.getPath(),false).
-                dontCache().
-                body("").
-                build();
+        Response resp = Response
+                .redirect(authServer.getBasePath() + authServer.getPath(),302)
+                .dontCache()
+                .body("")
+                .build();
         return resp;
     }
 

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/request/ParameterizedRequest.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/request/ParameterizedRequest.java
@@ -80,10 +80,16 @@ public abstract class ParameterizedRequest {
         params.entrySet().removeIf(e -> e.getValue().isEmpty());
     }
 
-    protected Response createParameterizedFormUrlencodedRedirect(Exchange exc, String state, String url) {
+    protected Response createParameterizedFormUrlencodedRedirect(Exchange exc, String state, String url, String error) {
+        url = url + "?error=" + error;
         if (state != null)
             url += "&state=" + state;
-        return Response.redirect(url,false).header(Header.CONTENT_TYPE, "application/x-www-form-urlencoded").bodyEmpty().dontCache().build();
+        return Response
+                .redirect(url,302)
+                .header(Header.CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .bodyEmpty()
+                .dontCache()
+                .build();
     }
 
     protected Response buildWwwAuthenticateErrorResponse(Response.ResponseBuilder builder, String errorValue) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2client/OAuth2Resource2Interceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2client/OAuth2Resource2Interceptor.java
@@ -114,7 +114,7 @@ public class OAuth2Resource2Interceptor extends AbstractInterceptorWithSession {
         Session session = getSessionManager().getSession(exc);
 
         if (isLogoutBackRequest(exc)) {
-            exc.setResponse(Response.redirect(afterLogoutUrl, false).status(303).build());
+            exc.setResponse(Response.redirect(afterLogoutUrl, 303).build());
 
             logOutSession(exc);
 
@@ -130,9 +130,9 @@ public class OAuth2Resource2Interceptor extends AbstractInterceptorWithSession {
                 OAuth2AnswerParameters ap = session.getOAuth2AnswerParameters();
                 if (ap != null && ap.getIdToken() != null)
                     uri += "&id_token_hint=" + ap.getIdToken();
-                exc.setResponse(Response.redirect(uri, false).status(303).build());
+                exc.setResponse(Response.redirect(uri, 303).build());
             } else {
-                exc.setResponse(Response.redirect(afterLogoutUrl, false).status(303).build());
+                exc.setResponse(Response.redirect(afterLogoutUrl, 303).build());
             }
 
             logOutSession(exc);
@@ -285,7 +285,10 @@ public class OAuth2Resource2Interceptor extends AbstractInterceptorWithSession {
                         new LoginParameter(e.getKey(), e.getValue())
                 ).toList();
 
-        exc.setResponse(Response.redirect(auth.getLoginURL(state, publicUrlManager.getPublicURLAndReregister(exc) + callbackPath, exc.getRequestURI()) + LoginParameter.copyLoginParameters(exc, combinedLoginParameters), false).build());
+        Response redirectResponse = Response
+                .redirect(auth.getLoginURL(state, publicUrlManager.getPublicURLAndReregister(exc) + callbackPath, exc.getRequestURI()) + LoginParameter.copyLoginParameters(exc, combinedLoginParameters), 302)
+                .build();
+        exc.setResponse(redirectResponse);
 
         readBodyFromStreamIntoMemory(exc);
 

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2client/rf/OAuth2CallbackRequestHandler.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2client/rf/OAuth2CallbackRequestHandler.java
@@ -123,14 +123,14 @@ public class OAuth2CallbackRequestHandler {
 
     private static void continueOriginalExchange(Exchange exc, AbstractExchangeSnapshot originalRequest, Session session) throws Exception {
         if (originalRequest.getRequest().getMethod().equals("GET")) {
-            exc.setResponse(Response.redirect(originalRequest.getOriginalRequestUri(), false).build());
+            exc.setResponse(Response.redirect(originalRequest.getOriginalRequestUri(), 302).build());
         } else {
             String oa2redirect = new BigInteger(130, new SecureRandom()).toString(32);
 
             session.put(OAuthUtils.oa2redictKeyNameInSession(oa2redirect), new ObjectMapper().writeValueAsString(originalRequest));
 
             String delimiter = originalRequest.getOriginalRequestUri().contains("?") ? "&" : "?";
-            exc.setResponse(Response.redirect(originalRequest.getOriginalRequestUri() + delimiter + OA2REDIRECT + "=" + oa2redirect, false).build());
+            exc.setResponse(Response.redirect(originalRequest.getOriginalRequestUri() + delimiter + OA2REDIRECT + "=" + oa2redirect, 302).build());
         }
     }
 }

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2server/LoginDialog2.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2server/LoginDialog2.java
@@ -138,7 +138,7 @@ public class LoginDialog2 {
             case "/logout" -> {
                 if (s != null)
                     s.clear();
-                exc.setResponse(Response.redirect(path, false).body("").build());
+                exc.setResponse(Response.redirect(path, 302).body("").build());
             }
             case "/consent" -> {
                 if (exc.getRequest().getMethod().equals("POST"))
@@ -346,13 +346,12 @@ public class LoginDialog2 {
     }
 
     public Outcome redirectToLogin(Exchange exc) throws UnsupportedEncodingException {
-        exc.setResponse(Response.
-                redirect(path + "?target=" + URLEncoder.encode(exc.getOriginalRequestUri(), UTF_8), false).
-                dontCache().
-                body("").
-                build());
+        exc.setResponse(Response
+                .redirect(path + "?target=" + URLEncoder.encode(exc.getOriginalRequestUri(), UTF_8), 302)
+                .dontCache()
+                .body("")
+                .build());
         return RETURN;
     }
 
 }
-

--- a/core/src/main/java/com/predic8/membrane/core/util/HttpUtil.java
+++ b/core/src/main/java/com/predic8/membrane/core/util/HttpUtil.java
@@ -194,6 +194,7 @@ public class HttpUtil {
 			case 206 -> "Partial Content";
 			case 301 -> "Moved Permanently";
 			case 302 -> "Found";
+			case 303 -> "See Other";
 			case 304 -> "Not Modified";
 			case 307 -> "Temporary Redirect";
 			case 308 -> "Permanent Redirect";

--- a/core/src/test/java/com/predic8/membrane/core/http/ResponseTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/http/ResponseTest.java
@@ -239,10 +239,10 @@ public class ResponseTest {
             of(notModified("ABC"), 304 , "Not Modified", false),
             of(serviceUnavailable("ABC"), 503 , "Service Unavailable", true),
             of(badGateway("ABC"), 502, "Bad Gateway", true),
-            of(unauthorized("ABC"),401 , "Unauthorized", true),
+            of(unauthorized("ABC"), 401 , "Unauthorized", true),
             of(gatewayTimeout("ABC"), 504, "Gateway Timeout", true),
-            of(redirect("ABC", false), 307, "Temporary Redirect", true),
-            of(redirect("ABC", true), 301, "Moved Permanently", true),
+            of(redirect("ABC", 307), 307, "Temporary Redirect", true),
+            of(redirect("ABC", 301), 301, "Moved Permanently", true),
             of(statusCode(999), 999, "", false)
         );
     }
@@ -262,7 +262,7 @@ public class ResponseTest {
                 <html><head><title>200 Ok.</title></head><body><h1>200 Ok.</h1><p>The Message <b>is</b> this!</p></body></html>""",
                 response.getBodyAsStringDecoded());
     }
-    
+
     @Test
     void redirectWithout300Test() {
         Response res = Response.redirectWithout300("http://localhost:2000/login","New <b>address</b>!").build();

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/AuthWithSessionRequestTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/AuthWithSessionRequestTest.java
@@ -43,6 +43,6 @@ public class AuthWithSessionRequestTest extends RequestParameterizedTest {
     }
 
     private static RequestTestData testPromptEqualsLogin() {
-        return new RequestTestData("testPromptEqualsLogin",addValueToRequestUri("prompt=login"),307,getBool(true),responseContainsValueInLocationHeader("/oauth2/auth"));
+        return new RequestTestData("testPromptEqualsLogin",addValueToRequestUri("prompt=login"),302,getBool(true),responseContainsValueInLocationHeader("/oauth2/auth"));
     }
 }

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/AuthWithoutSessionOpenidRequestTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/AuthWithoutSessionOpenidRequestTest.java
@@ -34,11 +34,11 @@ public class AuthWithoutSessionOpenidRequestTest extends RequestParameterizedTes
     }
 
     private static RequestTestData testHasClaimsButIsNotOpenid() {
-        return new RequestTestData("testHasClaimsButIsNotOpenid", replaceValueFromRequestUri("scope=openid","scope=profile"),307, getBool(true), sessionHasNoClaimsParam());
+        return new RequestTestData("testHasClaimsButIsNotOpenid", replaceValueFromRequestUri("scope=openid","scope=profile"),302, getBool(true), sessionHasNoClaimsParam());
     }
 
     private static RequestTestData testOpenidScopeButIsTokenResponseType() {
-        return new RequestTestData("testOpenidScopeButIsTokenResponseType",replaceValueFromRequestUri("response_type=code","response_type=token"),307,getBool(true),responseContainsValueInLocationHeader("error=invalid_request"));
+        return new RequestTestData("testOpenidScopeButIsTokenResponseType",replaceValueFromRequestUri("response_type=code","response_type=token"),302,getBool(true),responseContainsValueInLocationHeader("error=invalid_request"));
     }
 
     private static Supplier<Object> sessionHasNoClaimsParam() {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/AuthWithoutSessionRequestTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/AuthWithoutSessionRequestTest.java
@@ -41,15 +41,15 @@ public class AuthWithoutSessionRequestTest extends RequestParameterizedTest{
     }
 
     private static RequestTestData testPromptIsNone() {
-        return new RequestTestData("testPromptIsNone",addValueToRequestUri("prompt=none"),307,getBool(true),responseContainsValueInLocationHeader("error=login_required"));
+        return new RequestTestData("testPromptIsNone",addValueToRequestUri("prompt=none"),302,getBool(true),responseContainsValueInLocationHeader("error=login_required"));
     }
 
     private static RequestTestData testEmptyScopeList() {
-        return new RequestTestData("testEmptyScopeList",replaceValueFromRequestUri("scope=profile","scope=123456789"),307,getBool(true),responseContainsValueInLocationHeader("error=invalid_scope"));
+        return new RequestTestData("testEmptyScopeList",replaceValueFromRequestUri("scope=profile","scope=123456789"),302,getBool(true),responseContainsValueInLocationHeader("error=invalid_scope"));
     }
 
     private static RequestTestData testUnsupportedResponseType() {
-        return new RequestTestData("testUnsupportedResponseType",replaceValueFromRequestUri("response_type=code","response_type=code123456789"),307,getBool(true),responseContainsValueInLocationHeader("error=unsupported_response_type"));
+        return new RequestTestData("testUnsupportedResponseType",replaceValueFromRequestUri("response_type=code","response_type=code123456789"),302,getBool(true),responseContainsValueInLocationHeader("error=unsupported_response_type"));
     }
 
     private static RequestTestData testRedirectUriNotEqauls() {
@@ -61,7 +61,7 @@ public class AuthWithoutSessionRequestTest extends RequestParameterizedTest{
     }
 
     private static RequestTestData testResponseTypeMissing() {
-        return new RequestTestData("testResponseTypeMissing",removeValueFromRequestUri("&response_type=code"),307,getBool(true),responseContainsValueInLocationHeader("error=invalid_request"));
+        return new RequestTestData("testResponseTypeMissing",removeValueFromRequestUri("&response_type=code"),302,getBool(true),responseContainsValueInLocationHeader("error=invalid_request"));
     }
 
     private static RequestTestData testRedirectUriMissing() {
@@ -77,6 +77,6 @@ public class AuthWithoutSessionRequestTest extends RequestParameterizedTest{
     }
 
     private static RequestTestData testScopeMissing() {
-        return new RequestTestData("testScopeMissing",removeValueFromRequestUri("&scope=profile"),307,getBool(true),responseContainsValueInLocationHeader("error=invalid_request"));
+        return new RequestTestData("testScopeMissing",removeValueFromRequestUri("&scope=profile"),302,getBool(true),responseContainsValueInLocationHeader("error=invalid_request"));
     }
 }

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/EmptyEndpointOpenidTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/EmptyEndpointOpenidTest.java
@@ -37,7 +37,7 @@ public class EmptyEndpointOpenidTest extends RequestParameterizedTest{
     }
 
     private static RequestTestData testIdTokenTokenResponse() {
-        return new RequestTestData ("testIdTokenTokenResponse", modifySessionToIdTokenTokenResponseType(),307,getBool(true),responseContainsValueInLocationHeader("id_token="));
+        return new RequestTestData ("testIdTokenTokenResponse", modifySessionToIdTokenTokenResponseType(),302,getBool(true),responseContainsValueInLocationHeader("id_token="));
     }
 
     private static RequestTestData testConsentNotGiven() {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/EmptyEndpointTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/EmptyEndpointTest.java
@@ -40,11 +40,11 @@ public class EmptyEndpointTest extends RequestParameterizedTest{
     }
 
     private static RequestTestData testTokenResponse() {
-        return new RequestTestData("testTokenResponse", modifySessionToTokenResponseType(),307,getBool(true),responseContainsValueInLocationHeader("token="));
+        return new RequestTestData("testTokenResponse", modifySessionToTokenResponseType(),302,getBool(true),responseContainsValueInLocationHeader("token="));
     }
 
     private static RequestTestData testCodeResponse() {
-        return new RequestTestData("testCodeResponse", modifySessionToCodeResponseType(),307,getBool(true),responseContainsValueInLocationHeader("code="));
+        return new RequestTestData("testCodeResponse", modifySessionToCodeResponseType(),302,getBool(true),responseContainsValueInLocationHeader("code="));
     }
 
     private static Callable<Object> modifySessionToCodeResponseType() {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/OAuth2AuthorizationServerInterceptorNormalTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/OAuth2AuthorizationServerInterceptorNormalTest.java
@@ -71,11 +71,11 @@ public class OAuth2AuthorizationServerInterceptorNormalTest extends OAuth2Author
     }
 
     private static Object[] testGoodGrantedAuthCode() {
-        return new Object[]{"testGoodGrantedAuthCode", runUntilGoodAuthRequest(), getMockEmptyEndpointRequest(), 307, getCodeFromResponse()};
+        return new Object[]{"testGoodGrantedAuthCode", runUntilGoodAuthRequest(), getMockEmptyEndpointRequest(), 302, getCodeFromResponse()};
     }
 
     private static Object[] testGoodAuthRequest() {
-        return new Object[]{"testGoodAuthRequest", noPreprocessing(), getMockAuthRequestExchange(),307, loginAsJohn()};
+        return new Object[]{"testGoodAuthRequest", noPreprocessing(), getMockAuthRequestExchange(),302, loginAsJohn()};
     }
 
     private static Object[] testBadRequest() {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/OAuth2AuthorizationServerInterceptorOpenidTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/OAuth2AuthorizationServerInterceptorOpenidTest.java
@@ -52,11 +52,11 @@ public class OAuth2AuthorizationServerInterceptorOpenidTest extends OAuth2Author
     }
 
     private static Object[] testGoodGrantedAuthCode() {
-        return new Object[]{"testGoodGrantedAuthCode", runUntilGoodAuthOpenidRequest(), getMockEmptyEndpointRequest(), 307, getCodeFromResponse()};
+        return new Object[]{"testGoodGrantedAuthCode", runUntilGoodAuthOpenidRequest(), getMockEmptyEndpointRequest(), 302, getCodeFromResponse()};
     }
 
     private static Object[] testGoodAuthRequest() {
-        return new Object[]{"testGoodAuthRequest", noPreprocessing(), getMockAuthOpenidRequestExchange(),307, loginAsJohnOpenid()};
+        return new Object[]{"testGoodAuthRequest", noPreprocessing(), getMockAuthOpenidRequestExchange(),302, loginAsJohnOpenid()};
     }
 
     private static ExceptionThrowingConsumer<Exchange> loginAsJohnOpenid() {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/OAuth2ResourceRpIniLogoutTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/OAuth2ResourceRpIniLogoutTest.java
@@ -230,7 +230,7 @@ public class OAuth2ResourceRpIniLogoutTest {
                     assertEquals(8, claims.getClaimsMap().size());
                     String uri = params.get("post_logout_redirect_uri");
                     assertNotNull(uri);
-                    exc.setResponse(Response.redirect(uri, false).status(303).build());
+                    exc.setResponse(Response.redirect(uri, 303).build());
                     isLoggedOutAtOP.set(true);
                 }
 

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/b2c/MockAuthorizationServer.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/b2c/MockAuthorizationServer.java
@@ -133,16 +133,16 @@ public class MockAuthorizationServer {
                         return Response.internalServerError().body("signin aborted").build();
                     }
                     if (returnOAuth2ErrorFromSignIn.get()) {
-                        return Response.redirect(tc.getClientAddress() + "/oauth2callback?error=DEMO-123&error_description=This+is+a+demo+error.&state=" + params.get("state"), false).build();
+                        return Response.redirect(tc.getClientAddress() + "/oauth2callback?error=DEMO-123&error_description=This+is+a+demo+error.&state=" + params.get("state"), 302).build();
                     } else {
                         onLogin.run();
-                        return Response.redirect(tc.getClientAddress() + "/oauth2callback?code=1234&state=" + params.get("state"), false).build();
+                        return Response.redirect(tc.getClientAddress() + "/oauth2callback?code=1234&state=" + params.get("state"), 302).build();
                     }
                 } else if (requestURI.contains("/token")) {
                     return handleTokenRequest(flowId, exc);
                 } else if (requestURI.contains("/logout")) {
                     onLogout.run();
-                    return Response.redirect( params.get("post_logout_redirect_uri"), false).build();
+                    return Response.redirect( params.get("post_logout_redirect_uri"), 302).build();
                 } else {
                     return Response.notFound().build();
                 }

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/b2c/OAuth2ResourceB2CTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/b2c/OAuth2ResourceB2CTest.java
@@ -391,7 +391,7 @@ public abstract class OAuth2ResourceB2CTest {
     @Test
     public void requireAuthRedirects() throws Exception {
         var excCallResource = browser.applyWithoutRedirect(get(tc.getClientAddress() + "/api/"));
-        assertEquals(307, excCallResource.getResponse().getStatusCode());
+        assertEquals(302, excCallResource.getResponse().getStatusCode());
         assertTrue(excCallResource.getResponse().getHeader().getFirstValue(Header.LOCATION).contains(
                 ":"+mockAuthorizationServer.getServerPort()+"/"));
         assertFalse(didLogIn.get());

--- a/distribution/src/test/java/com/predic8/membrane/examples/withoutinternet/oauth2/OAuth2Membrane2ExampleTest.java
+++ b/distribution/src/test/java/com/predic8/membrane/examples/withoutinternet/oauth2/OAuth2Membrane2ExampleTest.java
@@ -24,6 +24,7 @@ import org.hamcrest.*;
 import org.junit.jupiter.api.*;
 
 import java.io.*;
+import java.net.URI;
 
 import static io.restassured.RestAssured.*;
 
@@ -67,7 +68,7 @@ public class OAuth2Membrane2ExampleTest extends DistributionExtractingTestcase {
 
     @Test
     void loginPage() {
-        OAuth2AuthFlowClient OAuth2 = new OAuth2AuthFlowClient("http://localhost:8000");
+        OAuth2AuthFlowClient OAuth2 = new OAuth2AuthFlowClient(URI.create("http://localhost:8000"), URI.create("http://localhost:2000"));
         // Step 1: Initial request to the client
         Response clientResponse = OAuth2.step1originalRequestGET("/");
         // Step 2: Send to authentication at OAuth2 server

--- a/test/src/main/java/com/predic8/membrane/test/OAuth2AuthFlowClient.java
+++ b/test/src/main/java/com/predic8/membrane/test/OAuth2AuthFlowClient.java
@@ -54,8 +54,8 @@ public class OAuth2AuthFlowClient {
                 .when()
                     .get(clientBaseUrl.resolve(url).toString())
                 .then()
-                    .statusCode(307)
-                    .header(LOCATION, MatchesPattern.matchesPattern(authServerBaseUrl + ".*"))
+                    .statusCode(302)
+                    .header(LOCATION, MatchesPattern.matchesPattern(authServerBaseUrl.toString() + ".*"))
                     .extract().response();
         doUserAgentCookieHandling(memCookies, response.getDetailedCookies());
         return response;
@@ -70,8 +70,8 @@ public class OAuth2AuthFlowClient {
                 .when()
                     .post(clientBaseUrl.resolve(url).toString())
                 .then()
-                    .statusCode(307)
-                    .header(LOCATION, MatchesPattern.matchesPattern(authServerBaseUrl + ".*"))
+                    .statusCode(302)
+                    .header(LOCATION, MatchesPattern.matchesPattern(authServerBaseUrl.toString() + ".*"))
                     .extract().response();
         doUserAgentCookieHandling(memCookies, response.getDetailedCookies());
         return response;
@@ -86,7 +86,7 @@ public class OAuth2AuthFlowClient {
                 .when()
                     .get(response.getHeader(LOCATION))
                 .then()
-                    .statusCode(307)
+                    .statusCode(302)
                     .header(LOCATION, MatchesPattern.matchesPattern("/login.*"))
                     .extract().response();
         doUserAgentCookieHandling(cookies, formRedirect.getDetailedCookies());
@@ -129,7 +129,7 @@ public class OAuth2AuthFlowClient {
             .when()
                 .get(authServerBaseUrl.toString())
             .then()
-                .statusCode(307)
+                .statusCode(302)
                 .header(LOCATION, MatchesPattern.matchesPattern("/login/consent.*"))
                 .extract().response();
         doUserAgentCookieHandling(cookies, response.getDetailedCookies());
@@ -171,7 +171,7 @@ public class OAuth2AuthFlowClient {
             .when()
                 .post(authServerBaseUrl.toString())
             .then()
-                .statusCode(307)
+                .statusCode(302)
                 .header(LOCATION, MatchesPattern.matchesPattern(clientBaseUrl.toString() + ".*"))
                 .extract().response();
         doUserAgentCookieHandling(cookies, response.getDetailedCookies());
@@ -186,7 +186,7 @@ public class OAuth2AuthFlowClient {
             .post(location)
         .then()
             .log().ifValidationFails(LogDetail.ALL)
-            .statusCode(307)
+            .statusCode(302)
             .extract().response();
 
         doUserAgentCookieHandling(memCookies, response.getDetailedCookies());


### PR DESCRIPTION
Using HTTP 307 is expressly forbidden as it can result in leaking credentials. While https://openid.net/specs/openid-connect-core-1_0.html#HTTP307Redirects recommends using HTTP303, the examples on the same page use HTTP 302, which is essentially a drop-in replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Simplified creation of HTTP redirect responses with explicit status code support.
- **Bug Fixes**
    - Standardized HTTP redirect status codes across OAuth2 flows and related endpoints, now explicitly using 302 (Found) or 303 (See Other) where appropriate.
    - Improved error redirect handling for OAuth2 requests by separating URI and error parameters.
    - Enhanced cookie handling in test browser mocks to detect duplicate cookie keys.
- **Refactor**
    - Refactored test and utility code to use URI constants and explicit URI resolution for improved maintainability.
    - Updated method signatures and chaining for clarity and consistency in response construction.
- **Tests**
    - Adjusted test cases to expect correct HTTP redirect status codes.
    - Improved test reliability by using parameterized URIs and enhanced cookie validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->