### PR TITLE
Stop exchange store from capturing admin API

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/ExchangeStoreInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/ExchangeStoreInterceptor.java
@@ -17,6 +17,7 @@ package com.predic8.membrane.core.interceptor;
 import com.predic8.membrane.annot.*;
 import com.predic8.membrane.core.exchange.*;
 import com.predic8.membrane.core.exchangestore.*;
+import com.predic8.membrane.core.interceptor.adminApi.AdminApiInterceptor;
 import com.predic8.membrane.core.interceptor.administration.*;
 import com.predic8.membrane.core.proxies.*;
 import org.springframework.beans.*;
@@ -134,6 +135,9 @@ public class ExchangeStoreInterceptor extends AbstractInterceptor implements App
 
 			for (Interceptor i : r.getInterceptors()) {
 				if (i instanceof AdminConsoleInterceptor) {
+					serviceProxiesContainingAdminConsole.add((AbstractServiceProxy)r);
+				}
+				if (i instanceof AdminApiInterceptor) {
 					serviceProxiesContainingAdminConsole.add((AbstractServiceProxy)r);
 				}
 			}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of service proxies containing administrative console features, ensuring both admin console and admin API interceptors are recognized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->