### PR TITLE
Improve Error Messages Related To Session Data

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2client/rf/OAuth2CallbackRequestHandler.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2client/rf/OAuth2CallbackRequestHandler.java
@@ -34,6 +34,9 @@ import static com.predic8.membrane.core.interceptor.oauth2client.temp.OAuth2Cons
 
 public class OAuth2CallbackRequestHandler {
     private static final Logger log = LoggerFactory.getLogger(OAuth2CallbackRequestHandler.class);
+    public static final String MEMBRANE_MISSING_SESSION = "Missing session.";
+    public static final String MEMBRANE_CSRF_TOKEN_MISSING_IN_SESSION = "CSRF token missing in session.";
+    public static final String MEMBRANE_CSRF_TOKEN_MISMATCH = "CSRF token mismatch.";
 
     private URIFactory uriFactory;
     private AuthorizationService auth;
@@ -78,18 +81,18 @@ public class OAuth2CallbackRequestHandler {
                 if (session.isNew()) {
                     throw new OAuth2Exception(
                             "MEMBRANE_MISSING_SESSION",
-                            "Missing session.",
-                            Response.badRequest().body("Missing session.").build());
+                            MEMBRANE_MISSING_SESSION,
+                            Response.badRequest().body(MEMBRANE_MISSING_SESSION).build());
                 } else if (!session.get().containsKey(ParamNames.STATE)) {
                     throw new OAuth2Exception(
                             "MEMBRANE_CSRF_TOKEN_MISSING_IN_SESSION",
-                            "CSRF token missing in session.",
-                            Response.badRequest().body("CSRF token missing in session.").build());
+                            MEMBRANE_CSRF_TOKEN_MISSING_IN_SESSION,
+                            Response.badRequest().body(MEMBRANE_CSRF_TOKEN_MISSING_IN_SESSION).build());
                 }else {
                     throw new OAuth2Exception(
                             "MEMBRANE_CSRF_TOKEN_MISMATCH",
-                            "CSRF token mismatch.",
-                            Response.badRequest().body("CSRF token mismatch.").build());
+                            MEMBRANE_CSRF_TOKEN_MISMATCH,
+                            Response.badRequest().body(MEMBRANE_CSRF_TOKEN_MISMATCH).build());
                 }
             }
 

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2client/rf/OAuth2CallbackRequestHandler.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2client/rf/OAuth2CallbackRequestHandler.java
@@ -75,7 +75,22 @@ public class OAuth2CallbackRequestHandler {
             String stateFromUri = getSecurityTokenFromState(params.getState());
 
             if (!csrfTokenMatches(session, stateFromUri)) {
-                throw new RuntimeException("CSRF token mismatch.");
+                if (session.isNew()) {
+                    throw new OAuth2Exception(
+                            "MEMBRANE_MISSING_SESSION",
+                            "Missing session.",
+                            Response.badRequest().body("Missing session.").build());
+                } else if (!session.get().containsKey(ParamNames.STATE)) {
+                    throw new OAuth2Exception(
+                            "MEMBRANE_CSRF_TOKEN_MISSING_IN_SESSION",
+                            "CSRF token missing in session.",
+                            Response.badRequest().body("CSRF token missing in session.").build());
+                }else {
+                    throw new OAuth2Exception(
+                            "MEMBRANE_CSRF_TOKEN_MISMATCH",
+                            "CSRF token mismatch.",
+                            Response.badRequest().body("CSRF token mismatch.").build());
+                }
             }
 
             // state in session can be "merged" -> save the selected state in session overwriting the possibly merged value

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/session/InMemorySessionManager.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/session/InMemorySessionManager.java
@@ -46,11 +46,11 @@ public class InMemorySessionManager extends SessionManager {
 
     @Override
     protected Map<String, Object> cookieValueToAttributes(String cookie) {
-        log.info("inMemorySessionManager getting cookie: {}", cookie);
+        log.info("Getting cookie: {}", cookie);
         try {
             synchronized (sessions) {
                 Map<String, Object> result = sessions.get(cookie.split("=true")[0], () -> new Session(usernameKeyName, new HashMap<>())).get();
-                result.forEach((key, value) -> log.info("cookieValueToAttributes {} : {}", key, value));
+                result.forEach((key, value) -> log.info("* {} : {}", key, value));
                 return result;
             }
         } catch (ExecutionException e) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/session/InMemorySessionManager.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/session/InMemorySessionManager.java
@@ -19,6 +19,8 @@ import com.predic8.membrane.annot.*;
 import com.predic8.membrane.core.*;
 import com.predic8.membrane.core.exchange.*;
 import com.predic8.membrane.core.http.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.*;
 import java.util.*;
@@ -27,6 +29,8 @@ import java.util.stream.*;
 
 @MCElement(name = "inMemorySessionManager2")
 public class InMemorySessionManager extends SessionManager {
+
+    private static final Logger log = LoggerFactory.getLogger(InMemorySessionManager.class);
 
     final static String ID_NAME = "_in_memory_session_id";
     Cache<String, Session> sessions;
@@ -42,9 +46,12 @@ public class InMemorySessionManager extends SessionManager {
 
     @Override
     protected Map<String, Object> cookieValueToAttributes(String cookie) {
+        log.info("inMemorySessionManager getting cookie: {}", cookie);
         try {
             synchronized (sessions) {
-                return sessions.get(cookie.split("=true")[0], () -> new Session(usernameKeyName, new HashMap<>())).get();
+                Map<String, Object> result = sessions.get(cookie.split("=true")[0], () -> new Session(usernameKeyName, new HashMap<>())).get();
+                result.forEach((key, value) -> log.info("inMemorySessionManager {} : {}", key, value));
+                return result;
             }
         } catch (ExecutionException e) {
             throw new RuntimeException(e);

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/session/InMemorySessionManager.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/session/InMemorySessionManager.java
@@ -46,12 +46,9 @@ public class InMemorySessionManager extends SessionManager {
 
     @Override
     protected Map<String, Object> cookieValueToAttributes(String cookie) {
-        log.info("Getting cookie: {}", cookie);
         try {
             synchronized (sessions) {
-                Map<String, Object> result = sessions.get(cookie.split("=true")[0], () -> new Session(usernameKeyName, new HashMap<>())).get();
-                result.forEach((key, value) -> log.info("* {} : {}", key, value));
-                return result;
+                return sessions.get(cookie.split("=true")[0], () -> new Session(usernameKeyName, new HashMap<>())).get();
             }
         } catch (ExecutionException e) {
             throw new RuntimeException(e);
@@ -76,11 +73,7 @@ public class InMemorySessionManager extends SessionManager {
     }
 
     private void addSessionToCache(Session[] session) {
-        log.info("storing Session");
-        Arrays.stream(session).forEach(s -> {
-//            s.content.forEach((key, value) -> log.info("* {} : {}", key, value));
-            sessions.put(s.get(ID_NAME), s);
-        });
+        Arrays.stream(session).forEach(s -> sessions.put(s.get(ID_NAME), s));
     }
 
     private void createSessionIdsForNewSessions(Session[] session) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/session/InMemorySessionManager.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/session/InMemorySessionManager.java
@@ -50,7 +50,7 @@ public class InMemorySessionManager extends SessionManager {
         try {
             synchronized (sessions) {
                 Map<String, Object> result = sessions.get(cookie.split("=true")[0], () -> new Session(usernameKeyName, new HashMap<>())).get();
-                result.forEach((key, value) -> log.info("inMemorySessionManager {} : {}", key, value));
+                result.forEach((key, value) -> log.info("cookieValueToAttributes {} : {}", key, value));
                 return result;
             }
         } catch (ExecutionException e) {
@@ -76,7 +76,11 @@ public class InMemorySessionManager extends SessionManager {
     }
 
     private void addSessionToCache(Session[] session) {
-        Arrays.stream(session).forEach(s -> sessions.put(s.get(ID_NAME), s));
+        log.info("addSessionToCache");
+        Arrays.stream(session).forEach(s -> {
+            s.content.forEach((key, value) -> log.info(" {} : {}", key, value));
+            sessions.put(s.get(ID_NAME), s);
+        });
     }
 
     private void createSessionIdsForNewSessions(Session[] session) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/session/InMemorySessionManager.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/session/InMemorySessionManager.java
@@ -78,7 +78,7 @@ public class InMemorySessionManager extends SessionManager {
     private void addSessionToCache(Session[] session) {
         log.info("storing Session");
         Arrays.stream(session).forEach(s -> {
-            s.content.forEach((key, value) -> log.info("* {} : {}", key, value));
+//            s.content.forEach((key, value) -> log.info("* {} : {}", key, value));
             sessions.put(s.get(ID_NAME), s);
         });
     }

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/session/InMemorySessionManager.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/session/InMemorySessionManager.java
@@ -76,9 +76,9 @@ public class InMemorySessionManager extends SessionManager {
     }
 
     private void addSessionToCache(Session[] session) {
-        log.info("addSessionToCache");
+        log.info("storing Session");
         Arrays.stream(session).forEach(s -> {
-            s.content.forEach((key, value) -> log.info(" {} : {}", key, value));
+            s.content.forEach((key, value) -> log.info("* {} : {}", key, value));
             sessions.put(s.get(ID_NAME), s);
         });
     }

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/session/Session.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/session/Session.java
@@ -25,6 +25,7 @@ import static com.predic8.membrane.core.interceptor.oauth2client.temp.OAuth2Cons
 
 public class Session {
 
+    @JsonIgnore  // we don't want this utility method to show up in JSON representations
     public boolean isNew() {
         if (isDirty)
             return false;

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/session/Session.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/session/Session.java
@@ -25,6 +25,16 @@ import static com.predic8.membrane.core.interceptor.oauth2client.temp.OAuth2Cons
 
 public class Session {
 
+    public boolean isNew() {
+        if (isDirty)
+            return false;
+        if (content.size() != 1)
+            return false;
+        if (!content.containsKey(INTERNAL_PREFIX + AUTHORIZATION_LEVEL))
+            return false;
+        return AuthorizationLevel.ANONYMOUS.name().equals(content.get(INTERNAL_PREFIX + AUTHORIZATION_LEVEL));
+    }
+
     public enum AuthorizationLevel{
         ANONYMOUS,
         VERIFIED

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/session/SessionManager.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/session/SessionManager.java
@@ -243,7 +243,7 @@ public abstract class SessionManager {
             log.warn("Cookie is larger than 4093 bytes, this will not work some browsers.");
         String setCookieValue = currentSessionCookieValue
                 + ";" + String.join(";", createCookieAttributes(exc));
-        log.info("Setting session cookie for {}: {}", currentSessionCookieValue, setCookieValue);
+        log.info("Setting session cookie: {}", setCookieValue);
         exc.getResponse().getHeader().add(Header.SET_COOKIE, setCookieValue);
     }
 
@@ -361,7 +361,9 @@ public abstract class SessionManager {
 
 
     protected Stream<String> getCookies(Exchange exc) {
-        return exc.getRequest().getHeader().getValues(new HeaderName(COOKIE)).stream().map(s -> s.getValue().split(";")).flatMap(Arrays::stream).map(String::trim).peek(cookie -> log.info("getCookie: {}", cookie));
+        var caller = StackWalker.getInstance().walk(s -> s.skip(1).map(StackWalker.StackFrame::getMethodName).limit(2).collect(Collectors.joining(";")));
+        log.info("getCookies from {}", caller);
+        return exc.getRequest().getHeader().getValues(new HeaderName(COOKIE)).stream().map(s -> s.getValue().split(";")).flatMap(Arrays::stream).map(String::trim).peek(cookie -> log.info("getCookies: {}", cookie));
     }
 
     public void removeSession(Exchange exc) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/session/SessionManager.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/session/SessionManager.java
@@ -144,6 +144,8 @@ public abstract class SessionManager {
     private void handleSetCookieHeaderForResponse(Exchange exc, Session session) throws Exception {
         log.info("\n\n-------\nhandleSetCookieHeaderForResponse from {}", getCallingMethod(4));
         log.info("RequestURI {}", exc.getRequestURI());
+        log.info("* Request Headers: {}", exc.getRequest().getHeader());
+        log.info("* Response Headers: {}", exc.getResponse().getHeader());
         session.getContent().forEach((key, value) -> log.info("* Session {}: {}", key, value));
         Optional<Object> originalCookieValueAtBeginning = Optional.ofNullable(exc.getProperty(SESSION_COOKIE_ORIGINAL));
 

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/session/SessionManager.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/session/SessionManager.java
@@ -169,6 +169,7 @@ public abstract class SessionManager {
         Optional<HeaderField> setCookie = getAllRelevantSetCookieHeaders(exc).filter(e -> e.getValue().contains(currentSessionCookieValue)).findFirst();
         if(setCookie.isPresent())
             synchronized (cookieExpireCache) {
+                log.info("Caching session cookie for {}: {}", currentSessionCookieValue, setCookie.get().getValue());
                 cookieExpireCache.put(currentSessionCookieValue, setCookie.get().getValue());
             }
     }
@@ -189,7 +190,8 @@ public abstract class SessionManager {
         return Arrays.stream(exc.getResponse().getHeader().getAllHeaderFields())
                 .filter(hf -> hf.getHeaderName().toString().contains(Header.SET_COOKIE))
                 .filter(hf -> hf.getValue().contains("=true"))
-                .filter(hf -> isValidCookieForThisSessionManager(Arrays.stream(hf.getValue().split(";")).filter(s -> s.contains("=true")).findFirst().get()));
+                .filter(hf -> isValidCookieForThisSessionManager(Arrays.stream(hf.getValue().split(";")).filter(s -> s.contains("=true")).findFirst().get()))
+                .peek(hf -> log.info("Found set-cookie header: {}: {}", hf.getHeaderName(), hf.getValue()));
     }
 
     private void removeRefreshIfNoChangeInExpireTime(Exchange exc, Map<String, List<String>> setCookieHeaders) {
@@ -213,6 +215,7 @@ public abstract class SessionManager {
                 .filter(e -> e.getValue().size() > 1)
                 .filter(e -> e.getValue().stream().filter(s -> s.contains(VALUE_TO_EXPIRE_SESSION_IN_BROWSER)).count() == 1)
                 .forEach(e -> {
+                    log.info("Removing redundant expire cookie for {}: {}", e.getKey(), e.getValue());
                     setCookieHeaders.get(e.getKey()).remove(e.getValue());
                     exc.getResponse().getHeader().remove(getAllRelevantSetCookieHeaders(exc)
                             .filter(hf -> hf.getValue().contains(VALUE_TO_EXPIRE_SESSION_IN_BROWSER))
@@ -232,6 +235,7 @@ public abstract class SessionManager {
             log.warn("Cookie is larger than 4093 bytes, this will not work some browsers.");
         String setCookieValue = currentSessionCookieValue
                 + ";" + String.join(";", createCookieAttributes(exc));
+        log.info("Setting session cookie for {}: {}", currentSessionCookieValue, setCookieValue);
         exc.getResponse().getHeader()
                 .add(Header.SET_COOKIE, setCookieValue);
     }
@@ -259,17 +263,22 @@ public abstract class SessionManager {
     private List<String> expireCookies(Exchange exc, List<String> invalidCookies) {
         return invalidCookies
                 .stream()
+                .peek(cookie -> log.info("Expiring cookie {}", cookie))
                 .map(cookie -> cookie + ";" + String.join(";", createInvalidationAttributes(exc)))
                 .collect(Collectors.toList());
     }
 
     protected Session getSessionInternal(Exchange exc) {
         exc.setProperty(SESSION_COOKIE_ORIGINAL,null);
-        if (getCookieHeader(exc) == null)
+        if (getCookieHeader(exc) == null) {
+            log.info("No session cookie found for {}, returning new Session", usernameKeyName);
             return new Session(usernameKeyName, new HashMap<>());
+        }
 
         Map<String, Map<String, Object>> validCookiesAsListOfMaps = convertValidCookiesToAttributes(exc);
         Session session = new Session(usernameKeyName, mergeCookies(new ArrayList<>(validCookiesAsListOfMaps.values())));
+        log.info("Session created: {}", session);
+        session.content.forEach((key, value) -> log.info(" {}: {}", key, value));
 
         if(validCookiesAsListOfMaps.size() == 1)
             exc.setProperty(SESSION_COOKIE_ORIGINAL,validCookiesAsListOfMaps.keySet().iterator().next());
@@ -297,6 +306,7 @@ public abstract class SessionManager {
 
     // TODO Side effect!
     private Session getSessionFromManager(Exchange exc) {
+        log.info("Getting session from manager");
         exc.setProperty(SESSION, getSessionInternal(exc));
         return getSessionFromExchange(exc).get();
     }
@@ -318,6 +328,7 @@ public abstract class SessionManager {
                 sameSite != null ? "SameSite="+sameSite : null
         )
                 .filter(Objects::nonNull)
+                .peek(cookie -> log.info("Cookie created: {}", cookie))
                 .collect(Collectors.toList());
     }
 
@@ -338,12 +349,13 @@ public abstract class SessionManager {
                 sameSite != null ? "SameSite="+sameSite : null
         )
                 .filter(Objects::nonNull)
+                .peek(attr -> log.info("Invalidation attribute: {}", attr))
                 .collect(Collectors.toList());
     }
 
 
     protected Stream<String> getCookies(Exchange exc) {
-        return exc.getRequest().getHeader().getValues(new HeaderName(COOKIE)).stream().map(s -> s.getValue().split(";")).flatMap(Arrays::stream).map(String::trim);
+        return exc.getRequest().getHeader().getValues(new HeaderName(COOKIE)).stream().map(s -> s.getValue().split(";")).flatMap(Arrays::stream).map(String::trim).peek(cookie -> log.info("getCookie: {}", cookie));
     }
 
     public void removeSession(Exchange exc) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/session/SessionManager.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/session/SessionManager.java
@@ -193,6 +193,8 @@ public abstract class SessionManager {
     }
 
     private Stream<HeaderField> getAllRelevantSetCookieHeaders(Exchange exc) {
+        var caller = StackWalker.getInstance().walk(s -> s.skip(1).map(StackWalker.StackFrame::getMethodName).limit(1).toList()).getFirst();
+        log.info("getAllRelevantSetCookieHeaders from {}", caller);
         return Arrays.stream(exc.getResponse().getHeader().getAllHeaderFields())
                 .filter(hf -> hf.getHeaderName().toString().contains(Header.SET_COOKIE))
                 .filter(hf -> hf.getValue().contains("=true"))
@@ -282,7 +284,6 @@ public abstract class SessionManager {
 
         Map<String, Map<String, Object>> validCookiesAsListOfMaps = convertValidCookiesToAttributes(exc);
         Session session = new Session(usernameKeyName, mergeCookies(new ArrayList<>(validCookiesAsListOfMaps.values())));
-        log.info("Session created: {}", session.getUsernameKeyName());
         session.content.forEach((key, value) -> log.info(" {}: {}", key, value));
 
         if(validCookiesAsListOfMaps.size() == 1)

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/session/SessionManager.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/session/SessionManager.java
@@ -143,6 +143,8 @@ public abstract class SessionManager {
 
 
     private void handleSetCookieHeaderForResponse(Exchange exc, Session session) throws Exception {
+        log.info("RequestURI {}", exc.getRequestURI());
+        log.info("Session {}", session.getUsernameKeyName());
         Optional<Object> originalCookieValueAtBeginning = Optional.ofNullable(exc.getProperty(SESSION_COOKIE_ORIGINAL));
 
         if (originalCookieValueAtBeginning.isEmpty() && !session.isDirty)

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/session/SessionManager.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/session/SessionManager.java
@@ -142,7 +142,7 @@ public abstract class SessionManager {
     }
 
     private void handleSetCookieHeaderForResponse(Exchange exc, Session session) throws Exception {
-        log.info("handleSetCookieHeaderForResponse from {}", getCallingMethod(2));
+        log.info("\n\n-------\nhandleSetCookieHeaderForResponse from {}", getCallingMethod(4));
         log.info("RequestURI {}", exc.getRequestURI());
         session.getContent().forEach((key, value) -> log.info("* Session {}: {}", key, value));
         Optional<Object> originalCookieValueAtBeginning = Optional.ofNullable(exc.getProperty(SESSION_COOKIE_ORIGINAL));
@@ -177,7 +177,7 @@ public abstract class SessionManager {
         Optional<HeaderField> setCookie = getAllRelevantSetCookieHeaders(exc).filter(e -> e.getValue().contains(currentSessionCookieValue)).findFirst();
         if(setCookie.isPresent())
             synchronized (cookieExpireCache) {
-                log.info("Caching session cookie for: {}", setCookie.get().getValue());
+                log.info("Caching session cookie: {}", setCookie.get().getValue());
                 cookieExpireCache.put(currentSessionCookieValue, setCookie.get().getValue());
             }
     }
@@ -195,12 +195,12 @@ public abstract class SessionManager {
     }
 
     private Stream<HeaderField> getAllRelevantSetCookieHeaders(Exchange exc) {
-        log.info("getAllRelevantSetCookieHeaders from {}", getCallingMethod(1));
+//        log.info("getAllRelevantSetCookieHeaders from {}", getCallingMethod(1));
         return Arrays.stream(exc.getResponse().getHeader().getAllHeaderFields())
                 .filter(hf -> hf.getHeaderName().toString().contains(Header.SET_COOKIE))
                 .filter(hf -> hf.getValue().contains("=true"))
-                .filter(hf -> isValidCookieForThisSessionManager(Arrays.stream(hf.getValue().split(";")).filter(s -> s.contains("=true")).findFirst().get()))
-                .peek(hf -> log.info("Found {} header: {}", hf.getHeaderName(), hf.getValue()));
+                .filter(hf -> isValidCookieForThisSessionManager(Arrays.stream(hf.getValue().split(";")).filter(s -> s.contains("=true")).findFirst().get()));
+//                .peek(hf -> log.info("Found {} header: {}", hf.getHeaderName(), hf.getValue()));
     }
 
     private void removeRefreshIfNoChangeInExpireTime(Exchange exc, Map<String, List<String>> setCookieHeaders) {
@@ -335,7 +335,7 @@ public abstract class SessionManager {
                 sameSite != null ? "SameSite="+sameSite : null
         )
                 .filter(Objects::nonNull)
-                .peek(cookie -> log.info("Cookie created: {}", cookie))
+//                .peek(cookie -> log.info("Cookie created: {}", cookie))
                 .collect(Collectors.toList());
     }
 

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/session/SessionManager.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/session/SessionManager.java
@@ -144,9 +144,9 @@ public abstract class SessionManager {
     private void handleSetCookieHeaderForResponse(Exchange exc, Session session) throws Exception {
         log.info("\n\n-------\nhandleSetCookieHeaderForResponse from {}", getCallingMethod(4));
         log.info("RequestURI {}", exc.getRequestURI());
-        log.info("* Request Headers: {}", exc.getRequest().getHeader());
-        log.info("* Response Headers: {}", exc.getResponse().getHeader());
-        session.getContent().forEach((key, value) -> log.info("* Session {}: {}", key, value));
+        log.info("* Request Headers: \n{}", exc.getRequest().getHeader());
+        log.info("* Response Headers: \n{}", exc.getResponse().getHeader());
+//        session.getContent().forEach((key, value) -> log.info("* Session {}: {}", key, value));
         Optional<Object> originalCookieValueAtBeginning = Optional.ofNullable(exc.getProperty(SESSION_COOKIE_ORIGINAL));
 
         if (originalCookieValueAtBeginning.isEmpty() && !session.isDirty)

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/session/SessionManager.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/session/SessionManager.java
@@ -212,7 +212,6 @@ public abstract class SessionManager {
                 .filter(e -> e.getValue().size() > 1)
                 .filter(e -> e.getValue().stream().filter(s -> s.contains(VALUE_TO_EXPIRE_SESSION_IN_BROWSER)).count() == 1)
                 .forEach(e -> {
-                    log.info("Removing redundant expire cookie for {}: {}", e.getKey(), e.getValue());
                     setCookieHeaders.get(e.getKey()).remove(e.getValue());  // TODO does this actually do anything?
                     exc.getResponse().getHeader().remove(getAllRelevantSetCookieHeaders(exc)
                             .filter(hf -> hf.getValue().contains(VALUE_TO_EXPIRE_SESSION_IN_BROWSER))
@@ -265,7 +264,6 @@ public abstract class SessionManager {
     protected Session getSessionInternal(Exchange exc) {
         exc.setProperty(SESSION_COOKIE_ORIGINAL,null);
         if (getCookieHeader(exc) == null) {
-            log.info("No session cookie found for {}, returning new Session", usernameKeyName);
             return new Session(usernameKeyName, new HashMap<>());
         }
 

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/OAuth2RedirectTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/OAuth2RedirectTest.java
@@ -25,7 +25,9 @@ import com.predic8.membrane.core.interceptor.templating.*;
 import com.predic8.membrane.core.proxies.*;
 import com.predic8.membrane.core.transport.http.*;
 import com.predic8.membrane.test.*;
+import io.restassured.filter.log.LogDetail;
 import io.restassured.response.*;
+import org.hamcrest.Matchers;
 import org.jetbrains.annotations.*;
 import org.junit.jupiter.api.*;
 
@@ -35,6 +37,8 @@ import java.util.*;
 import java.util.concurrent.atomic.*;
 
 import static com.predic8.membrane.core.lang.ExchangeExpression.Language.*;
+import static com.predic8.membrane.test.TestUtil.getPathFromResource;
+import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.*;
 
 public abstract class OAuth2RedirectTest {
@@ -61,6 +65,19 @@ public abstract class OAuth2RedirectTest {
         authorizationServerRouter.shutdown();
         oauth2ResourceRouter.shutdown();
         backendRouter.shutdown();
+    }
+
+    @Test
+    void invalidState() {
+        given()
+            .redirects().follow(false)
+            //.cookies(memCookies) TODO: create clone of this test with existing session
+        .when()
+            .get("http://localhost:2000/oauth2callback?code=b2296nh0navopaj5iq5slu7dje&state=security_token=miv38g9f80v7fiau029ctfel2o&url=/a?b=c&d=%C3%A4")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL)
+            .statusCode(400)
+            .body(Matchers.is("Missing session."));
     }
 
     @Test

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/OAuth2ResourceTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/OAuth2ResourceTest.java
@@ -42,6 +42,7 @@ import java.util.stream.IntStream;
 import static com.predic8.membrane.core.http.MimeType.*;
 import static com.predic8.membrane.core.http.Request.get;
 import static com.predic8.membrane.core.http.Request.post;
+import static com.predic8.membrane.core.interceptor.oauth2client.rf.OAuth2CallbackRequestHandler.MEMBRANE_MISSING_SESSION;
 import static org.junit.jupiter.api.Assertions.*;
 
 public abstract class OAuth2ResourceTest {
@@ -183,7 +184,7 @@ public abstract class OAuth2ResourceTest {
 
         var response = browser.apply(get("http://localhost:" + serverPort + ref.get())).getResponse();
         assertEquals(400, response.getStatusCode());
-        assertTrue(response.getBodyAsStringDecoded().contains("CSRF"));
+        assertTrue(response.getBodyAsStringDecoded().contains(MEMBRANE_MISSING_SESSION));
     }
 
     @Test

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/b2c/OAuth2ResourceB2CTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/b2c/OAuth2ResourceB2CTest.java
@@ -34,6 +34,7 @@ import java.util.function.Consumer;
 
 import static com.predic8.membrane.core.http.Header.*;
 import static com.predic8.membrane.core.http.Request.get;
+import static com.predic8.membrane.core.interceptor.oauth2client.rf.OAuth2CallbackRequestHandler.MEMBRANE_MISSING_SESSION;
 import static com.predic8.membrane.core.util.URLParamUtil.DuplicateKeyOrInvalidFormStrategy.ERROR;
 import static com.predic8.membrane.core.util.URLParamUtil.parseQueryString;
 import static org.junit.jupiter.api.Assertions.*;
@@ -167,7 +168,8 @@ public abstract class OAuth2ResourceB2CTest {
 
         assertEquals(400, excCallResource.getResponse().getStatusCode());
 
-        assertTrue(excCallResource.getResponse().getBodyAsStringDecoded().contains("CSRF"));
+        String response = excCallResource.getResponse().getBodyAsStringDecoded();
+        assertTrue(response.contains(MEMBRANE_MISSING_SESSION));
     }
 
     @Test


### PR DESCRIPTION
The "CSRF token mismatch" error was previously thrown in situations when it was misleading, e.g. no session was found or the session did not contain any CSRF token.