### PR TITLE
Fixed encoding for `state` in the `OAuth2Server`

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -217,7 +217,7 @@
         <dependency>
             <groupId>org.graalvm.sdk</groupId>
             <artifactId>graal-sdk</artifactId>
-            <version>24.2.0</version>
+            <version>24.1.2</version>
             <scope>provided</scope>
         </dependency>
 

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/flows/OAuth2Flow.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/flows/OAuth2Flow.java
@@ -18,6 +18,11 @@ import com.predic8.membrane.core.interceptor.Outcome;
 import com.predic8.membrane.core.interceptor.authentication.session.SessionManager;
 import com.predic8.membrane.core.interceptor.oauth2.OAuth2AuthorizationServerInterceptor;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 public abstract class OAuth2Flow {
     protected final OAuth2AuthorizationServerInterceptor authServer;
     protected final Exchange exc;
@@ -33,6 +38,6 @@ public abstract class OAuth2Flow {
     public abstract Outcome getResponse() throws Exception;
 
     protected String stateQuery(String state) {
-        return state == null ? "" : "&state=" + state;
+        return state == null ? "" : "&state=" + URLEncoder.encode(state, UTF_8);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of the OAuth2 `state` parameter by ensuring it is properly URL-encoded, preventing issues with special characters during authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->