### PR TITLE
Enhance JavaLicenseInfoTest to automatically prepend missing license

### DIFF
--- a/core/src/test/java/com/predic8/membrane/core/interceptor/idempotency/IdempotencyInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/idempotency/IdempotencyInterceptorTest.java
@@ -1,3 +1,17 @@
+/* Copyright 2025 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
 package com.predic8.membrane.core.interceptor.idempotency;
 
 import com.predic8.membrane.core.exchange.Exchange;

--- a/distribution/src/test/java/com/predic8/membrane/examples/withinternet/test/orchestration/ForLoopExampleTest.java
+++ b/distribution/src/test/java/com/predic8/membrane/examples/withinternet/test/orchestration/ForLoopExampleTest.java
@@ -1,3 +1,17 @@
+/* Copyright 2025 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
 package com.predic8.membrane.examples.withinternet.test.orchestration;
 
 import com.predic8.membrane.examples.util.AbstractSampleMembraneStartStopTestcase;

--- a/distribution/src/test/java/com/predic8/membrane/examples/withoutinternet/env/JavaLicenseInfoTest.java
+++ b/distribution/src/test/java/com/predic8/membrane/examples/withoutinternet/env/JavaLicenseInfoTest.java
@@ -11,6 +11,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License. */
+
 package com.predic8.membrane.examples.withoutinternet.env;
 
 import org.junit.jupiter.api.*;
@@ -37,10 +38,40 @@ public class JavaLicenseInfoTest {
 		var files = findJavaFiles(new File("..").getCanonicalFile()).stream()
 				.filter(file -> !containsLicense(file))
 				.toList();
+
+		for (File file : files) {
+			prependLicense(file);
+		}
+
 		if (!files.isEmpty()) {
-			String s = getFailureMessage(files);
-			System.out.println(s);
-			fail(s);
+			System.out.printf("NOTE: Added license headers to %d file(s):%n", files.size());
+			files.forEach(file -> System.out.println("  " + file.getAbsolutePath()));
+		}
+	}
+
+
+	private static void prependLicense(File file) {
+		String license = """
+			/* Copyright 2025 predic8 GmbH, www.predic8.com
+			
+			   Licensed under the Apache License, Version 2.0 (the "License");
+			   you may not use this file except in compliance with the License.
+			   You may obtain a copy of the License at
+			
+			   http://www.apache.org/licenses/LICENSE-2.0
+			
+			   Unless required by applicable law or agreed to in writing, software
+			   distributed under the License is distributed on an "AS IS" BASIS,
+			   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+			   See the License for the specific language governing permissions and
+			   limitations under the License. */
+			""";
+
+		try {
+			String content = readFileToString(file, UTF_8);
+			writeStringToFile(file, license + "\n" + content, UTF_8);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not prepend license to " + file, e);
 		}
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added standard Apache License 2.0 headers to multiple test files.
  - Updated license-checking test to automatically add missing license headers to Java files instead of failing the test, with a summary of updated files printed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->