### PR TITLE
Guava map

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/idempotency/IdempotencyInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/idempotency/IdempotencyInterceptor.java
@@ -116,9 +116,16 @@ public class IdempotencyInterceptor extends AbstractInterceptor {
     }
 
     /**
-     * @description Time in seconds after which idempotence keys automatically expire.
+     * @description Time in seconds after which idempotency keys automatically expire.
+     * Useful to avoid memory leaks in long-running systems.
+     * Common values:
+     * <ul>
+     * <li>300 seconds = 5 minutes</li>
+     * <li>86400 seconds = 1 day</li>
+     * <li>604800 seconds = 1 week</li>
+     * <li>2592000 seconds = 1 month (30 days)</li>
+     * </ul>
      * @default 600
-     * @example 300
      */
     @MCAttribute
     public void setSeconds(int seconds) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/idempotency/IdempotencyInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/idempotency/IdempotencyInterceptor.java
@@ -48,7 +48,7 @@ public class IdempotencyInterceptor extends AbstractInterceptor {
     private String key;
     private ExchangeExpression exchangeExpression;
     private Language language = SPEL;
-    private int expirationSeconds = 3600;
+    private int expiration = 3600;
     private Cache<String, Boolean> processedKeys;
 
     @Override
@@ -57,7 +57,7 @@ public class IdempotencyInterceptor extends AbstractInterceptor {
         exchangeExpression = ExchangeExpression.newInstance(router, language, key);
         processedKeys = CacheBuilder.newBuilder()
                 .maximumSize(10000)
-                .expireAfterWrite(expirationSeconds, TimeUnit.SECONDS)
+                .expireAfterWrite(expiration, TimeUnit.SECONDS)
                 .build();
     }
 
@@ -128,8 +128,8 @@ public class IdempotencyInterceptor extends AbstractInterceptor {
      * @default 3600
      */
     @MCAttribute
-    public void setExpirationSeconds(int expirationSeconds) {
-        this.expirationSeconds = expirationSeconds;
+    public void setExpiration(int expiration) {
+        this.expiration = expiration;
     }
 
     public String getKey() {
@@ -140,7 +140,7 @@ public class IdempotencyInterceptor extends AbstractInterceptor {
         return language;
     }
 
-    public int getExpirationSeconds() {
-        return expirationSeconds;
+    public int getExpiration() {
+        return expiration;
     }
 }

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/idempotency/IdempotencyInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/idempotency/IdempotencyInterceptor.java
@@ -37,7 +37,7 @@ import static com.predic8.membrane.core.lang.ExchangeExpression.Language.SPEL;
  * @description <p>Prevents duplicate request processing based on a dynamic idempotency key.</p>
  *
  * <p>This interceptor evaluates an expression (e.g., from headers or body) to extract an idempotency key.
- * If the key has already been processed, it aborts the request with a 400 response.</p>
+ * If the key has already been processed, it aborts the request with a 409 response.</p>
  *
  * <p>Useful for handling retries from clients to avoid duplicate side effects like double payment submissions.</p>
  * @topic 3. Security and Validation
@@ -48,7 +48,7 @@ public class IdempotencyInterceptor extends AbstractInterceptor {
     private String key;
     private ExchangeExpression exchangeExpression;
     private Language language = SPEL;
-    private int seconds = 600;
+    private int expirationSeconds = 3600;
     private Cache<String, Boolean> processedKeys;
 
     @Override
@@ -57,7 +57,7 @@ public class IdempotencyInterceptor extends AbstractInterceptor {
         exchangeExpression = ExchangeExpression.newInstance(router, language, key);
         processedKeys = CacheBuilder.newBuilder()
                 .maximumSize(10000)
-                .expireAfterWrite(seconds, TimeUnit.SECONDS)
+                .expireAfterWrite(expirationSeconds, TimeUnit.SECONDS)
                 .build();
     }
 
@@ -125,11 +125,11 @@ public class IdempotencyInterceptor extends AbstractInterceptor {
      * <li>604800 seconds = 1 week</li>
      * <li>2592000 seconds = 1 month (30 days)</li>
      * </ul>
-     * @default 600
+     * @default 3600
      */
     @MCAttribute
-    public void setSeconds(int seconds) {
-        this.seconds = seconds;
+    public void setExpirationSeconds(int expirationSeconds) {
+        this.expirationSeconds = expirationSeconds;
     }
 
     public String getKey() {
@@ -140,7 +140,7 @@ public class IdempotencyInterceptor extends AbstractInterceptor {
         return language;
     }
 
-    public int getSeconds() {
-        return seconds;
+    public int getExpirationSeconds() {
+        return expirationSeconds;
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to configure the expiration time (in seconds) for idempotency keys, with a default of 3600 seconds.

- **Improvements**
  - Enhanced idempotency key handling to automatically remove old keys, improving memory usage and reliability.
  - Updated documentation to provide a clearer example for key expressions.
  - Changed HTTP response code for duplicate keys from 400 to 409.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->