### PR TITLE
Added type JWT to JWS header in JwtSignInterceptor

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/jwt/JwtSignInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/jwt/JwtSignInterceptor.java
@@ -81,6 +81,7 @@ public class JwtSignInterceptor extends AbstractInterceptor {
     private Outcome handleInternal(Exchange exc, Flow flow) {
         try {
             JsonWebSignature jws = new JsonWebSignature();
+            jws.setHeader("typ", "JWT");
             jws.setPayload(prepareJwtPayload(exc.getMessage(flow)));
             jws.setKey(rsaJsonWebKey.getRsaPrivateKey());
             jws.setAlgorithmHeaderValue(RSA_USING_SHA256);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that JWT tokens now explicitly include the "typ" (type) header set to "JWT" for improved compatibility with JWT consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->