### PR TITLE
Address Thread-Safety issues in Test Setup for OAuth2 tests

### DIFF
--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/BrowserMock.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/BrowserMock.java
@@ -37,7 +37,6 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static java.net.URLEncoder.encode;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -46,11 +45,11 @@ import static org.apache.commons.text.StringEscapeUtils.unescapeXml;
 
 public class BrowserMock implements Function<Exchange, Exchange> {
 
-    public static final Pattern INPUT_PATTERN = Pattern.compile("<input type=\"hidden\" name=\"([-a-zA-Z0-9&;_]*)\" value=\"([-a-zA-Z ._=0-9&/;]*)\"/>");
+    public static final Pattern INPUT_PATTERN = Pattern.compile("<input type=\"hidden\" name=\"([-a-zA-Z0-9&;_]*)\" value=\"([-a-zA-Z ._~=0-9&/;]*)\"/>");
     public static final Pattern FORM_PATTERN = Pattern.compile("<form method=\"post\" action=\"([a-z:/0-9]*)\"");
     final Logger LOG = LoggerFactory.getLogger(BrowserMock.class);
     final Map<String, Map<String, String>> cookie = new HashMap<>();
-    final Function<Exchange, Exchange> cookieHandlingHttpClient = exc -> cookeManager(httpClient(), exc);
+    final Function<Exchange, Exchange> cookieHandlingHttpClient = exc -> cookieManager(httpClient(), exc);
     final Function<Exchange, Exchange> cookieHandlingRedirectingHttpClient = outerExc -> handleFormPost(innerExc -> handleRedirect(cookieHandlingHttpClient, innerExc, new ArrayList<>()), outerExc);
 
     /**
@@ -145,17 +144,22 @@ public class BrowserMock implements Function<Exchange, Exchange> {
      * @return the Exchange resulting from applying the consumer function
      */
 
-    private @NotNull Exchange cookeManager(Function<Exchange, Exchange> consumer, final Exchange exc) {
+    private @NotNull Exchange cookieManager(Function<Exchange, Exchange> consumer, final Exchange exc) {
         String domain = getDomain(exc);
-        Map<String, String> cookies = cookie.get(domain);
-        addCookiesToExchange(exc, cookies);
+        Map<String, String> cookies;
+        synchronized (cookie) {
+            cookies = cookie.get(domain);
+            addCookiesToExchange(exc, cookies);
+        }
         var result = consumer.apply(exc);
 
         List<HeaderField> setCookieInstructions = result.getResponse().getHeader().getValues(new HeaderName("Set-Cookie"));
         checkSameForCookieKeyUsedMultipleTimes(setCookieInstructions);
 
-        for (HeaderField setCookieField : setCookieInstructions) {
-            cookies = manipulateCookies(setCookieField, domain, cookies);
+        synchronized (cookie) {
+            for (HeaderField setCookieField : setCookieInstructions) {
+                cookies = manipulateCookies(setCookieField, domain, cookies);
+            }
         }
 
         return result;
@@ -380,10 +384,14 @@ public class BrowserMock implements Function<Exchange, Exchange> {
     }
 
     public void clearCookies() {
-        cookie.clear();
+        synchronized (cookie) {
+            cookie.clear();
+        }
     }
 
     public int getCookieCount() {
-        return cookie.values().stream().map(Map::size).reduce(0, Integer::sum);
+        synchronized (cookie) {
+            return cookie.values().stream().map(Map::size).reduce(0, Integer::sum);
+        }
     }
 }

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/JwtSMOAuth2R2Test.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/JwtSMOAuth2R2Test.java
@@ -112,11 +112,13 @@ public class JwtSMOAuth2R2Test extends OAuth2ResourceTest {
     }
 
     private int countCookies() {
-        return browser.cookie.values().stream()
-                .map(Map::keySet)
-                .flatMap(Collection::stream)
-                .map(jwt -> (hasValidClaims(jwt)) ? 1 : 0)
-                .reduce(0, Integer::sum);
+        synchronized (browser.cookie) {
+            return browser.cookie.values().stream()
+                    .map(Map::keySet)
+                    .flatMap(Collection::stream)
+                    .map(jwt -> (hasValidClaims(jwt)) ? 1 : 0)
+                    .reduce(0, Integer::sum);
+        }
     }
 
     private boolean hasValidClaims(String jwt) {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/OAuth2ResourceTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/OAuth2ResourceTest.java
@@ -95,6 +95,7 @@ public abstract class OAuth2ResourceTest {
     @Test
     public void getOriginalRequest() throws Exception {
         var response = browser.apply(get(getClientAddress() + "/init")).getResponse();
+        assertEquals(200, response.getStatusCode());
         var body = om.readValue(response.getBodyAsStream(), new TypeReference<Map<String, String>>() {});
         assertEquals("/init", body.get("path"));
         assertEquals("", body.get("body"));
@@ -104,6 +105,7 @@ public abstract class OAuth2ResourceTest {
     @Test
     public void postOriginalRequest() throws Exception {
         var response = browser.apply(post(getClientAddress() + "/init").body("demobody")).getResponse();
+        assertEquals(200, response.getStatusCode());
         var body = om.readValue(response.getBodyAsStream(), new TypeReference<Map<String, String>>() {});
         assertEquals("/init", body.get("path"));
         assertEquals("demobody", body.get("body"));

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/OAuth2ResourceTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/OAuth2ResourceTest.java
@@ -114,6 +114,7 @@ public abstract class OAuth2ResourceTest {
     @Test
     public void testUseRefreshTokenOnTokenExpiration() throws Exception {
         var response = browser.apply(get(getClientAddress() + "/init")).getResponse();
+        assertEquals(200, response.getStatusCode());
         var body = om.readValue(response.getBodyAsStream(), new TypeReference<Map<String, String>>() {});
         assertEquals("/init", body.get("path"));
 
@@ -222,18 +223,21 @@ public abstract class OAuth2ResourceTest {
         browser.apply(get(getClientAddress() + "/init"));
 
         var isLoggedInResponse = browser.apply(get(getClientAddress() + "/is-logged-in")).getResponse();
+        assertEquals(200, isLoggedInResponse.getStatusCode());
         assertTrue(isLoggedInResponse.getBodyAsStringDecoded().contains("true"));
 
         // call to /logout uses cookieHandlingHttpClient: *NOT* following the redirect (which would auto-login again)
         browser.applyWithoutRedirect(get(getClientAddress() + "/logout"));
 
         var secondIsLoggedInResponse = browser.apply(get(getClientAddress() + "/is-logged-in")).getResponse();
+        assertEquals(200, secondIsLoggedInResponse.getStatusCode());
         assertTrue(secondIsLoggedInResponse.getBodyAsStringDecoded().contains("false"));
     }
 
     @Test
     public void loginParams() throws Exception {
         var response = browser.applyWithoutRedirect(get(getClientAddress() + "/init?login_hint=def&illegal=true")).getResponse();
+        assertEquals(302, response.getStatusCode());
 
         var params = extractQueryParameters(response.getHeader().getFirstValue("Location"));
 


### PR DESCRIPTION
resolves #1878 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved thread safety for cookie handling in browser-related tests to prevent concurrent modification issues.
  - Fixed typos in method and variable names related to cookie management.

- **Tests**
  - Enhanced test reliability by adding assertions to verify HTTP response status codes before further validation in OAuth2 resource tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->