### PR TITLE
REST2SOAPInterceptor Response XSLT Empty

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/rest/REST2SOAPInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/rest/REST2SOAPInterceptor.java
@@ -196,7 +196,7 @@ public class REST2SOAPInterceptor extends SOAPRESTHelper {
     public Outcome handleResponseInternal(Exchange exc) throws Exception {
         Mapping mapping = getRESTURL(exc);
         log.debug("restURL: {}",mapping);
-        if (getRESTURL(exc) == null)
+       if (mapping == null || mapping.getResponseXSLT().isEmpty())
             return CONTINUE;
 
         if (log.isDebugEnabled())


### PR DESCRIPTION
On response Flow if mapping.responseXSLT is empty  return directly CONTINUE. There is not way to avoid an XSL trasformation on response flow for an exchange which the mapping regex has been correctly evaluated on request flow.