### PR TITLE
Add SetCookiesInterceptor

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/lang/SetCookiesInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/lang/SetCookiesInterceptor.java
@@ -1,0 +1,165 @@
+package com.predic8.membrane.core.interceptor.lang;
+
+import com.predic8.membrane.annot.MCAttribute;
+import com.predic8.membrane.annot.MCChildElement;
+import com.predic8.membrane.annot.MCElement;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.interceptor.AbstractInterceptor;
+import com.predic8.membrane.core.interceptor.Outcome;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
+
+/**
+ * Interceptor that adds one or more Set-Cookie headers on the response.
+ */
+@MCElement(name="setCookies")
+public class SetCookiesInterceptor extends AbstractInterceptor {
+
+    @Override
+    public Outcome handleResponse(Exchange exc) {
+        for (CookieDef def : cookies) {
+            exc.getResponse().getHeader().add("Set-Cookie", def.buildHeader());
+        }
+        return CONTINUE;
+    }
+
+    /**
+     * Holder for a single cookie's attributes.
+     */
+    private final List<CookieDef> cookies = new ArrayList<>();
+
+    /**
+     * Register one <cookie> child element.
+     */
+    @MCChildElement(order = 1)
+    public void addCookieDef(CookieDef def) {
+        cookies.add(def);
+    }
+
+    public List<CookieDef> getCookies() {
+        return cookies;
+    }
+
+    @SuppressWarnings("unused")
+    @MCElement(name="cookie")
+    public static class CookieDef {
+        private String domain;
+        private String path = "/";
+        private String expires; // RFC1123 date format
+        private int maxAge = -1;
+        private boolean secure = false;
+        private boolean httpOnly = false;
+        private SameSite sameSite = SameSite.LAX;
+
+        private String name;
+        private String value;
+
+        public enum SameSite {LAX, STRICT, NONE}
+
+        public String getName() {
+            return name;
+        }
+
+        @MCAttribute
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @MCAttribute
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        @MCAttribute
+        public void setPath(String path) {
+            this.path = path;
+        }
+
+        public String getDomain() {
+            return domain;
+        }
+
+        @MCAttribute
+        public void setDomain(String domain) {
+            this.domain = domain;
+        }
+
+        public int getMaxAge() {
+            return maxAge;
+        }
+
+        @MCAttribute
+        public void setMaxAge(int maxAge) {
+            this.maxAge = maxAge;
+        }
+
+        public String getExpires() {
+            return expires;
+        }
+
+        @MCAttribute
+        public void setExpires(String expires) {
+            this.expires = expires;
+        }
+
+        public boolean isSecure() {
+            return secure;
+        }
+
+        @MCAttribute
+        public void setSecure(boolean secure) {
+            this.secure = secure;
+        }
+
+        public boolean isHttpOnly() {
+            return httpOnly;
+        }
+
+        @MCAttribute
+        public void setHttpOnly(boolean httpOnly) {
+            this.httpOnly = httpOnly;
+        }
+
+        public SameSite getSameSite() {
+            return sameSite;
+        }
+
+        @MCAttribute
+        public void setSameSite(SameSite sameSite) {
+            this.sameSite = sameSite;
+        }
+
+        @Override
+        public String toString() {
+            return buildHeader();
+        }
+
+        /**
+         * Build the Set-Cookie header string with proper attributes.
+         */
+        public String buildHeader() {
+            StringBuilder sb = new StringBuilder();
+            sb.append(name).append("=").append(value);
+            sb.append("; Path=").append(path);
+            if (domain != null) sb.append("; Domain=").append(domain);
+            if (maxAge >= 0) sb.append("; Max-Age=").append(maxAge);
+            if (expires != null) sb.append("; Expires=").append(expires);
+            if (httpOnly) sb.append("; HttpOnly");
+            if (secure) sb.append("; Secure");
+            if (sameSite != null) sb.append("; SameSite=").append(sameSite.name());
+            return sb.toString();
+        }
+    }
+
+}

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/lang/SetCookiesInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/lang/SetCookiesInterceptorTest.java
@@ -1,0 +1,66 @@
+package com.predic8.membrane.core.interceptor.lang;
+
+import com.predic8.membrane.core.interceptor.lang.SetCookiesInterceptor.CookieDef;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZonedDateTime;
+
+import static com.predic8.membrane.core.interceptor.lang.SetCookiesInterceptor.CookieDef.SameSite.NONE;
+import static com.predic8.membrane.core.interceptor.lang.SetCookiesInterceptor.CookieDef.SameSite.STRICT;
+import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SetCookiesInterceptorTest {
+
+    @Test
+    void buildHeader_withDefaults() {
+        CookieDef cd = new CookieDef();
+        cd.setName("sessionId");
+        cd.setValue("abc123");
+        String header = cd.buildHeader();
+        assertTrue(header.contains("sessionId=abc123"));
+        assertTrue(header.contains("Path=/"));
+        assertTrue(header.contains("SameSite=LAX"));
+        assertFalse(header.contains("Domain="));
+        assertFalse(header.contains("Max-Age="));
+        assertFalse(header.contains("Expires="));
+        assertFalse(header.contains("HttpOnly"));
+        assertFalse(header.contains("Secure"));
+    }
+
+    @Test
+    void buildHeader_allAttributes() {
+        CookieDef cd = new CookieDef();
+        cd.setName("user");
+        cd.setValue("john");
+        cd.setDomain("example.com");
+        cd.setPath("/app");
+        cd.setMaxAge(3600);
+        String expires = ZonedDateTime.now().plusDays(1).format(RFC_1123_DATE_TIME);
+        cd.setExpires(expires);
+        cd.setHttpOnly(true);
+        cd.setSecure(true);
+        cd.setSameSite(STRICT);
+
+        String header = cd.buildHeader();
+        assertTrue(header.startsWith("user=john;"));
+        assertTrue(header.contains("Domain=example.com"));
+        assertTrue(header.contains("Path=/app"));
+        assertTrue(header.contains("Max-Age=3600"));
+        assertTrue(header.contains("Expires=" + expires));
+        assertTrue(header.contains("HttpOnly"));
+        assertTrue(header.contains("Secure"));
+        assertTrue(header.contains("SameSite=STRICT"));
+    }
+
+    @Test
+    void buildHeader_sameSiteNone() {
+        CookieDef cd = new CookieDef();
+        cd.setName("pref");
+        cd.setValue("yes");
+        cd.setSameSite(NONE);
+        assertTrue(cd.buildHeader().contains("SameSite=NONE"));
+    }
+
+}


### PR DESCRIPTION
- Implement SetCookiesInterceptor with support for multiple cookie definitions
- Define CookieDef class with attributes: name, value, domain, path, maxAge, expires, secure, httpOnly, and SameSite
- Support building standard Set-Cookie header strings with all attributes
- Add unit tests for header building with default and full attribute sets, including SameSite variations