### PR TITLE
fixed NPE in OpenAPI validation, added test to run official JSON Schema test suite (needs to be downloaded seperately)

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/AbstractBodyValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/AbstractBodyValidator.java
@@ -43,8 +43,8 @@ public abstract class AbstractBodyValidator<T extends Message<? extends Body,?>>
         // Use the value of the OpenAPI spec for comparison, so it can not
         // be influenced from the outside.
         if ( APPLICATION_JSON_CONTENT_TYPE.match(mediaType)) {
-            if (mediaTypeObj.getSchema().get$ref() != null) {
-                ctx.schemaType(mediaTypeObj.getSchema().get$ref());
+            if (mediaTypeObj.getSchema() != null && mediaTypeObj.getSchema().get$ref() != null) {
+                ctx = ctx.schemaType(mediaTypeObj.getSchema().get$ref());
             }
             errors.add(new SchemaValidator(api, mediaTypeObj.getSchema()).validate(ctx, message.getBody()));
         } else if(isXML(mediaType)) {

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/ArrayValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/ArrayValidator.java
@@ -47,7 +47,7 @@ public class ArrayValidator implements IJSONSchemaValidator {
 
     @Override
     public ValidationErrors validate(ValidationContext ctx, Object value) {
-        ctx.schemaType("array");
+        ctx = ctx.schemaType("array");
 
         ValidationErrors errors = new ValidationErrors();
         Schema itemsSchema = schema.getItems();

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/IJSONSchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/IJSONSchemaValidator.java
@@ -18,6 +18,7 @@ package com.predic8.membrane.core.openapi.validators;
 
 interface IJSONSchemaValidator {
 
+    String NULL = "null";
     String NUMBER = "number";
     String ARRAY = "array";
     String OBJECT = "object";

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/NullValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/NullValidator.java
@@ -16,12 +16,7 @@
 
 package com.predic8.membrane.core.openapi.validators;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;
-
-import java.math.BigDecimal;
-
-import static java.lang.Double.parseDouble;
 
 public class NullValidator implements IJSONSchemaValidator {
 
@@ -37,7 +32,7 @@ public class NullValidator implements IJSONSchemaValidator {
     }
 
     /**
-     * Only check if obj can be converted to a number
+     * Check, if value is null.
      */
     @Override
     public ValidationErrors validate(ValidationContext ctx, Object value) {

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/NullValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/NullValidator.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2022 predic8 GmbH, www.predic8.com
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.predic8.membrane.core.openapi.validators;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+
+import java.math.BigDecimal;
+
+import static java.lang.Double.parseDouble;
+
+public class NullValidator implements IJSONSchemaValidator {
+
+    @Override
+    public String canValidate(Object value) {
+        if (value == null) {
+            return NULL;
+        }
+        if (value instanceof NullNode) {
+            return NULL;
+        }
+        return null;
+    }
+
+    /**
+     * Only check if obj can be converted to a number
+     */
+    @Override
+    public ValidationErrors validate(ValidationContext ctx, Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof NullNode) {
+            return null;
+        }
+        return ValidationErrors.create(ctx.schemaType(NULL), String.format("%s is not null.", value));
+    }
+}

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/NumberValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/NumberValidator.java
@@ -17,11 +17,17 @@
 package com.predic8.membrane.core.openapi.validators;
 
 import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.node.TextNode;
 
 import java.math.*;
 
 import static java.lang.Double.*;
 
+/**
+ * When numbers appear in parameters, they enter as Strings (which is OK).
+ *
+ * If numbers appear in a JSON string "123.45", this is a TextNode (which is not OK). (See JSON Schema Spec.)
+ */
 public class NumberValidator implements IJSONSchemaValidator {
 
     @Override
@@ -29,6 +35,9 @@ public class NumberValidator implements IJSONSchemaValidator {
         try {
             if (value instanceof Number) {
                 return NUMBER;
+            }
+            if (value instanceof TextNode) {
+                return null;
             }
             if (value instanceof JsonNode jn) {
                 new BigDecimal((jn).asText());
@@ -49,6 +58,9 @@ public class NumberValidator implements IJSONSchemaValidator {
     @Override
     public ValidationErrors validate(ValidationContext ctx, Object value) {
         try {
+            if (value instanceof TextNode) {
+                return ValidationErrors.create(ctx.schemaType(NUMBER), String.format("%s is not a number.", value));
+            }
             if (value instanceof JsonNode jn) {
                 // Not using double prevents from losing fractions
                 new BigDecimal(jn.asText());

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/SchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/SchemaValidator.java
@@ -107,7 +107,8 @@ public class SchemaValidator implements IJSONSchemaValidator {
     }
 
     private boolean isNullable() {
-        return (schema.getNullable() != null && schema.getNullable()) || schema.getTypes().contains("null");
+        return (schema.getNullable() != null && schema.getNullable()) || (schema.getTypes() != null && schema.getTypes().contains("null")) ||
+                (schema.getType() != null && schema.getType().equals("null"));
     }
 
     private ValidationErrors validateByType(ValidationContext ctx, Object value) {

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/SchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/SchemaValidator.java
@@ -116,7 +116,7 @@ public class SchemaValidator implements IJSONSchemaValidator {
         String type = schema.getType();
 
         if (schemaHasNoTypeAndTypes(type)) {
-            return null;
+            return validateMultipleTypes(List.of("string", "number", "integer", "boolean", "array", "object", "null"), ctx, value);
         }
 
         // type in schema has only one type
@@ -184,6 +184,7 @@ public class SchemaValidator implements IJSONSchemaValidator {
     private ValidationErrors validateSingleType(ValidationContext ctx, Object value, String type) {
         try {
             return switch (type) {
+                case NULL -> new NullValidator().validate(ctx, value);
                 case NUMBER -> new NumberValidator().validate(ctx, value);
                 case "integer" -> new IntegerValidator().validate(ctx, value);
                 case "string" -> new StringValidator(schema).validate(ctx, value);
@@ -203,6 +204,7 @@ public class SchemaValidator implements IJSONSchemaValidator {
 
     private static List<IJSONSchemaValidator> getValidatorClasses() {
         return List.of(
+                new NullValidator(),
                 new IntegerValidator(),
                 new NumberValidator(),
                 new StringValidator(null),

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/StringValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/StringValidator.java
@@ -204,6 +204,6 @@ public class StringValidator implements IJSONSchemaValidator {
     }
 
     private boolean matchRegexPattern(String v) {
-        return Pattern.compile(schema.getPattern()).matcher(v).matches();
+        return Pattern.compile(schema.getPattern()).matcher(v).find();
     }
 }

--- a/core/src/test/java/com/predic8/membrane/core/openapi/validators/IntegerTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/validators/IntegerTest.java
@@ -106,6 +106,20 @@ protected String getOpenAPIFileName() {
         assertTrue(e.getMessage().contains("maximum"));
     }
 
+    @Test
+    public void invalidMaximumWithoutTypeInBody() {
+        ValidationErrors errors = validator.validate(Request.post().path("/integer").body(new JsonBody(getNumbers("maximum-without-type",new BigDecimal(13)))));
+        assertEquals(1,errors.size());
+        ValidationError e = errors.get(0);
+        assertTrue(e.getMessage().contains("maximum"));
+    }
+
+    @Test
+    public void validMaximumWithoutTypeInBody() {
+        ValidationErrors errors = validator.validate(Request.post().path("/integer").body(new JsonBody(getNumbers("maximum-without-type",new BigDecimal(5)))));
+        assertEquals(0,errors.size());
+    }
+
     private JsonNode getNumbers(String name, BigDecimal n) {
         ObjectNode root = om.createObjectNode();
         root.put(name,n);

--- a/core/src/test/java/com/predic8/membrane/core/openapi/validators/JsonSchemaTestSuiteTests.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/validators/JsonSchemaTestSuiteTests.java
@@ -1,0 +1,132 @@
+package com.predic8.membrane.core.openapi.validators;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.predic8.membrane.core.openapi.OpenAPIValidator;
+import com.predic8.membrane.core.openapi.model.Body;
+import com.predic8.membrane.core.openapi.model.Request;
+import com.predic8.membrane.core.openapi.serviceproxy.OpenAPIRecord;
+import com.predic8.membrane.core.openapi.serviceproxy.OpenAPISpec;
+import com.predic8.membrane.core.util.URIFactory;
+import jakarta.mail.internet.ParseException;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.collect.ImmutableMap.of;
+import static com.predic8.membrane.core.openapi.util.TestUtils.om;
+import static com.predic8.membrane.core.openapi.util.TestUtils.parseOpenAPI;
+
+public class JsonSchemaTestSuiteTests {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory().disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER));
+
+    int correct, incorrect, ignored;
+
+    @Test
+    public void testJsonSchema() throws IOException, ParseException {
+        locateTests("git\\JSON-Schema-Test-Suite\\tests\\draft4");
+        System.out.println("correct = " + correct);
+        System.out.println("incorrect = " + incorrect);
+        System.out.println("ignored = " + ignored);
+    }
+
+    private void locateTests(String baseDir) throws IOException, ParseException {
+        for (File file : new File(baseDir).listFiles()) {
+            if (!file.getName().endsWith(".json"))
+                continue;
+            locateTest(file);
+        }
+    }
+
+    private void locateTest(File file) throws IOException, ParseException {
+        System.out.println("Testing file: " + file.getName());
+
+        List<?> tests = objectMapper.readValue(file, List.class);
+        for (Object t : tests) {
+            Map test = (Map) t;
+            String description = test.get("description").toString();
+            Object schema = test.get("schema");
+            List<?> testRuns = (List<?>) test.get("tests");
+
+            System.out.println("- description = " + description);
+            System.out.println("  schema = " + om.writeValueAsString(schema));
+
+            Map oa = new HashMap(of("openapi", "3.0.2", "paths", of("/test", of("post", of(
+                    "requestBody", of("content", of("application/json", of("schema", schema))),
+                    "responses", of("200", of("description", "OK")))))));
+
+            if (((Map)schema).containsKey("definitions")) {
+                oa.put("components", of("schemas", ((Map)schema).get("definitions")));
+                System.out.println("    warning: The schema contains definitions. They have been moved from #/definitions/ to #/components/schemas/ .");
+            }
+
+            String openapi = yamlMapper.writeValueAsString(oa);
+
+            openapi = openapi.replaceAll("#/definitions/", "#/components/schemas/");
+
+
+            String ignoredReason = null;
+
+            if (openapi.contains("http://"))
+                ignoredReason = "the official test code seems to start a webserver on localhost:1234, which we do not support (yet).";
+            if (description.equals("Location-independent identifier"))
+                ignoredReason = "'$ref':'#foo' is used, which we do not support.";
+            if (description.contains("empty tokens in $ref json-pointer"))
+                ignoredReason = "the name of a definition is the empty string.";
+
+            OpenAPIValidator validator = null;
+            if (ignoredReason == null)
+                validator = new OpenAPIValidator(new URIFactory(), new OpenAPIRecord(parseOpenAPI(
+                        new ByteArrayInputStream(openapi.getBytes(StandardCharsets.UTF_8))),new OpenAPISpec()));
+
+
+            for (Object tr : testRuns) {
+                Map testRun = (Map) tr;
+
+                System.out.println("  - testRun = " + om.writeValueAsString(testRun));
+
+                String description2 = testRun.get("description").toString();
+                String body = objectMapper.writeValueAsString(testRun.get("data"));
+                Boolean valid = (Boolean)testRun.get("valid");
+
+                System.out.println("    testRun.description = " + description2);
+                System.out.println("    testRun.body = " + body);
+                System.out.println("    testRun.shouldBeValid = " + valid);
+
+                if (ignoredReason != null) {
+                    ignored++;
+                    System.out.println("    Test: Ignored. (" + ignoredReason + ")");
+                    continue;
+                }
+
+                Request<Body> post = Request.post().path("/test").mediaType("application/json");
+                ValidationErrors errors = null;
+                try {
+                    errors = validator.validate(post.body(body));
+
+                    System.out.println("    validation result = " + errors);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+
+                if (errors != null && errors.isEmpty() == valid) {
+                    System.out.println("    Test: OK");
+                    correct++;
+                } else {
+                    System.out.println("    Test: NOT OK!");
+                    incorrect++;
+                }
+
+            }
+        }
+
+    }
+}

--- a/core/src/test/java/com/predic8/membrane/core/openapi/validators/JsonSchemaTestSuiteTests.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/validators/JsonSchemaTestSuiteTests.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * The test suite needs to be downloaded manually.
  */
 public class JsonSchemaTestSuiteTests {
-    private final static Logger LOG = LoggerFactory.getLogger(JsonSchemaTestSuiteTests.class);
+    private final static Logger log = LoggerFactory.getLogger(JsonSchemaTestSuiteTests.class);
     public final String TEST_SUITE_BASE_PATH = "git\\JSON-Schema-Test-Suite\\tests\\draft6";
 
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -49,9 +49,9 @@ public class JsonSchemaTestSuiteTests {
     @Test
     public void testJsonSchema() throws IOException, ParseException {
         runTestsFoundInDirectory(TEST_SUITE_BASE_PATH);
-        LOG.info("correct = {}", correct);
-        LOG.info("incorrect = {}", incorrect);
-        LOG.info("ignored = {}", ignored);
+        log.info("correct = {}", correct);
+        log.info("incorrect = {}", incorrect);
+        log.info("ignored = {}", ignored);
 
         assertEquals(0, incorrect);
     }
@@ -69,7 +69,7 @@ public class JsonSchemaTestSuiteTests {
     }
 
     private void runTestsFromFile(File file) throws IOException, ParseException {
-        LOG.info("Testing file: {}", file.getName());
+        log.info("Testing file: {}", file.getName());
 
         List<?> tests = objectMapper.readValue(file, List.class);
         for (Object t : tests) {
@@ -78,8 +78,8 @@ public class JsonSchemaTestSuiteTests {
             Object schema = test.get("schema");
             List<?> testRuns = (List<?>) test.get("tests");
 
-            LOG.info("- description = {}", description);
-            LOG.info("  schema = {}", om.writeValueAsString(schema));
+            log.info("- description = {}", description);
+            log.info("  schema = {}", om.writeValueAsString(schema));
 
             String openapi = generateOpenAPIForSchema(schema);
 
@@ -102,12 +102,12 @@ public class JsonSchemaTestSuiteTests {
 
         if (schema instanceof Map && ((Map) schema).containsKey("definitions")) {
             oa.put("components", of("schemas", ((Map) schema).get("definitions")));
-            LOG.warn("    The schema contains definitions. They have been moved from #/definitions/ to #/components/schemas/ .");
+            log.warn("    The schema contains definitions. They have been moved from #/definitions/ to #/components/schemas/ .");
         }
 
         if (schema instanceof Map && ((Map) schema).containsKey("$defs")) {
             oa.put("components", of("schemas", ((Map) schema).get("$defs")));
-            System.out.println("    warning: The schema contains definitions. They have been moved from #/$defs/ to #/components/schemas/ .");
+            log.warn("    warning: The schema contains definitions. They have been moved from #/$defs/ to #/components/schemas/ .");
         }
 
         String openapi = yamlMapper.writeValueAsString(oa);
@@ -134,19 +134,19 @@ public class JsonSchemaTestSuiteTests {
     private void runSingleTestRun(Map tr, String ignoredReason, OpenAPIValidator validator) throws JsonProcessingException, ParseException {
         Map testRun = tr;
 
-        LOG.info("  - testRun = {}", om.writeValueAsString(testRun));
+        log.info("  - testRun = {}", om.writeValueAsString(testRun));
 
         String description2 = testRun.get("description").toString();
         String body = objectMapper.writeValueAsString(testRun.get("data"));
         Boolean valid = (Boolean)testRun.get("valid");
 
-        LOG.info("    testRun.description = {}", description2);
-        LOG.info("    testRun.body = {}", body);
-        LOG.info("    testRun.shouldBeValid = {}", valid);
+        log.info("    testRun.description = {}", description2);
+        log.info("    testRun.body = {}", body);
+        log.info("    testRun.shouldBeValid = {}", valid);
 
         if (ignoredReason != null) {
             ignored++;
-            LOG.info("    Test: Ignored. ({})", ignoredReason);
+            log.info("    Test: Ignored. ({})", ignoredReason);
             return;
         }
 
@@ -155,16 +155,16 @@ public class JsonSchemaTestSuiteTests {
         try {
             errors = validator.validate(post.body(body));
 
-            LOG.info("    validation result = {}", errors);
+            log.info("    validation result = {}", errors);
         } catch (Exception e) {
             e.printStackTrace();
         }
 
         if (errors != null && errors.isEmpty() == valid) {
-            LOG.info("    Test: OK");
+            log.info("    Test: OK");
             correct++;
         } else {
-            System.out.println("    Test: NOT OK!");
+            log.warn("    Test: NOT OK!");
             incorrect++;
         }
     }

--- a/core/src/test/java/com/predic8/membrane/core/openapi/validators/JsonSchemaTestSuiteTests.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/validators/JsonSchemaTestSuiteTests.java
@@ -27,6 +27,9 @@ import static com.google.common.collect.ImmutableMap.of;
 import static com.predic8.membrane.core.openapi.util.TestUtils.om;
 import static com.predic8.membrane.core.openapi.util.TestUtils.parseOpenAPI;
 
+/**
+ * Runs the OpenAPI validator with the official tests from the JSON Schema Test Suite.
+ */
 public class JsonSchemaTestSuiteTests {
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory().disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER));
@@ -42,7 +45,11 @@ public class JsonSchemaTestSuiteTests {
     }
 
     private void locateTests(String baseDir) throws IOException, ParseException {
-        for (File file : new File(baseDir).listFiles()) {
+        File base = new File(baseDir);
+        if (!base.exists()) {
+            throw new RuntimeException("Please download the tests from https://github.com/json-schema-org/JSON-Schema-Test-Suite/ and adjust the base path here.");
+        }
+        for (File file : base.listFiles()) {
             if (!file.getName().endsWith(".json"))
                 continue;
             locateTest(file);

--- a/core/src/test/java/com/predic8/membrane/core/openapi/validators/NullTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/validators/NullTest.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright 2022 predic8 GmbH, www.predic8.com
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.predic8.membrane.core.openapi.validators;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static com.predic8.membrane.core.openapi.model.Request.post;
+import static com.predic8.membrane.core.openapi.util.JsonUtil.mapToJson;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+public class NullTest extends AbstractValidatorTest {
+
+    @Override
+    protected String getOpenAPIFileName() {
+        return "/openapi/specs/null.yml";
+    }
+
+    @Test
+    public void nullValid() {
+        ValidationErrors errors = validator.validate(post().path("/null-type").body(mapToJson(null)));
+        assertEquals(0,errors.size());
+    }
+
+    @Test
+    public void nullInvalid() {
+        ValidationErrors errors = validator.validate(post().path("/null-type").body(mapToJson("foo")));
+        assertEquals(1,errors.size());
+        assertTrue(errors.get(0).getMessage().contains("\"foo\" is of type string"));
+    }
+
+    @Test
+    public void nullOrIntegerArrayValid() {
+        List<?> l = Arrays.asList(new Object[] {null, 1});
+        ValidationErrors errors = validator.validate(post().path("/array-null-or-integer-type").body(mapToJson(l)));
+        assertEquals(0,errors.size());
+    }
+
+    @Test
+    public void nullOrIntegerArrayInvalid() {
+        List<?> l = Arrays.asList(new Object[] {null, "foo"});
+        ValidationErrors errors = validator.validate(post().path("/array-null-or-integer-type").body(mapToJson(l)));
+        assertEquals(1,errors.size());
+        assertTrue(errors.get(0).getMessage().contains("\"foo\" is of type string"));
+    }
+
+}

--- a/core/src/test/java/com/predic8/membrane/core/openapi/validators/SchemaValidatorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/validators/SchemaValidatorTest.java
@@ -86,7 +86,7 @@ public class SchemaValidatorTest {
                 Arguments.of(integerValidator, null, null),
 
                 // NumberValidator test cases
-                Arguments.of(numberValidator, new TextNode("123.45"), NUMBER),
+                Arguments.of(numberValidator, new TextNode("123.45"), null),
                 Arguments.of(numberValidator, new TextNode("notANumber"), null),
                 Arguments.of(numberValidator, "456.78", NUMBER),
                 Arguments.of(numberValidator, "invalid", null),

--- a/core/src/test/resources/openapi/specs/header-params.yml
+++ b/core/src/test/resources/openapi/specs/header-params.yml
@@ -90,7 +90,7 @@ components:
           required: true
           schema:
             type: string
-            pattern: "\\w*"
+            pattern: "^\\w*$"
   parameters:
     X-Token:
       in: header

--- a/core/src/test/resources/openapi/specs/integer.yml
+++ b/core/src/test/resources/openapi/specs/integer.yml
@@ -56,4 +56,5 @@ components:
           type: number
           exclusiveMaximum: true
           maximum: 5
-          
+        maximum-without-type:
+          maximum: 5

--- a/core/src/test/resources/openapi/specs/null.yml
+++ b/core/src/test/resources/openapi/specs/null.yml
@@ -1,0 +1,31 @@
+openapi: '3.1.0'
+info:
+  title: Null Test API
+  version: '1.0'
+servers:
+  - url: https://api.server.test/
+paths:
+  /null-type:
+    post:
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: "null"
+  /array-null-or-integer-type:
+    post:
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: "array"
+              items:
+                type:
+                  - "integer"
+                  - "null"

--- a/distribution/examples/openapi/validation/contacts-xxl-api-v1.yml
+++ b/distribution/examples/openapi/validation/contacts-xxl-api-v1.yml
@@ -65,7 +65,7 @@ components:
           format: email
         countryCode:
           type: string
-          pattern: \w{2}
+          pattern: ^\w{2}$
           minLength: 2
           maxLength: 2
         address:
@@ -86,7 +86,7 @@ components:
             - type: string
               maxLength: 7
               minLength: 7
-              pattern: \w-\d{5}
+              pattern: ^\w-\d{5}$
             - type: integer
               minimum: 00000
               maximum: 99999

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 		<javac.source>21</javac.source>
 		<javac.target>21</javac.target>
 		<jackson.version>2.19.0</jackson.version>
-		<spring.version>6.2.7</spring.version>
+		<spring.version>6.2.8</spring.version>
 		<slf4j.version>2.0.17</slf4j.version>
 		<log4j.version>2.24.3</log4j.version>
 		<junit.version>5.10.0</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -339,12 +339,12 @@
 			<dependency>
 				<groupId>io.swagger</groupId>
 				<artifactId>swagger-parser</artifactId>
-				<version>1.0.74</version>
+				<version>1.0.75</version>
 			</dependency>
 			<dependency>
 				<groupId>io.swagger.parser.v3</groupId>
 				<artifactId>swagger-parser</artifactId>
-				<version>2.1.27</version>
+				<version>2.1.30</version>
 			</dependency>
 			<dependency>
 				<groupId>net.sf.saxon</groupId>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced handling of nullable schemas by supporting explicit "null" types in validation.
  - Fixed potential null pointer exceptions during schema reference checks.
  - Updated string pattern validation to allow substring matches instead of full-string matches.
  - Refined number validation to reject numeric values represented as JSON strings.
  - Anchored header parameter regex patterns to match entire strings.
  - Anchored regex patterns in example API schemas for exact matching.

- **New Features**
  - Added explicit support for validating JSON null values with a dedicated validator.
  - Introduced a new test suite for validating JSON Schema compliance using the official JSON-Schema-Test-Suite draft6.
  - Added new OpenAPI specification and tests for validating null types and arrays containing null or integers.
  - Added validation tests for schema properties with maximum constraints lacking explicit type declarations.

- **Tests**
  - Updated number validator tests to reflect stricter validation rules for numeric strings.
  - Added comprehensive tests covering null value validation scenarios.
  - Added tests for maximum constraints without explicit types.

- **Chores**
  - Updated Swagger parser dependencies to newer versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->