### PR TITLE
fixed java doc

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/lang/SetCookiesInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/lang/SetCookiesInterceptor.java
@@ -41,7 +41,7 @@ public class SetCookiesInterceptor extends AbstractInterceptor {
     }
 
     /**
-     * @description Registers the list of <cookie> child elements.
+     * @description Registers the list of &lt;cookie&gt; child elements.
      * @param cookies list of CookieDef parsed from XML
      */
     @MCChildElement(order = 1)

--- a/docs/JAVADOC.md
+++ b/docs/JAVADOC.md
@@ -2,12 +2,13 @@
 
 This project uses a structured Javadoc format to document classes, methods, and fields:
 
-| Tag            | Applies To       | Purpose / Content                                              |
-|----------------|------------------|----------------------------------------------------------------|
-| `@description` | Classes, Methods | Description of the element.                                    |
-| `@default`     | Methods          | Default value if not explicitly configured.                    |
-| `@example`     | Methods          | Example value or usage snippet.                                |
-| `@topic`       | Classes          | Assigns a topic/category to group related classes in the docs. |
+| Tag            | Applies To       | Purpose / Content                                                                                                                                                                                                                                                                          | Content                                            |
+|----------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------|
+| `@description` | Classes, Methods | Description of the element. (Longer text for classes, shorter for methods. The name of the @MCElement annotation (for classes) and the name of the method (for methods) is obvious: "setHttpClientConfiguration" does NOT need to be documented with "sets the HTTP Client Configuration". | XML snippet (especially: well-formed)              |
+| `@default`     | Methods          | Default value. This often duplicates the Java Field initializer or effective result of the init() method.                                                                                                                                                                                  | String                                             |
+| `@example`     | Methods          | Example value or usage snippet.                                                                                                                                                                                                                                                            | String or XML Snippet                              |
+| `@topic`       | Classes          | Assigns a topic/category to group related classes in the docs. The topics (e.g. "1. Proxies and Flow") are numbered. The title ("Proxies and Flow") should be consistently assigned to the number ("1.") across all files.                                                                 | Number, followed by a dot and a string (the title) |
+
 
 > **Note:**
 > The table lists custom tags used in this project. In addition, all standard Javadoc tags (such as `@param`, `@return`,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting and detail in the Javadoc documentation table, adding a new column and clarifying tag usage with examples and guidance.
  * Corrected XML tag formatting in a Javadoc comment to ensure proper display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->