### PR TITLE
Examples: Use property instead of propertiesExamples property insteadof properties

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/lang/ScriptingUtils.java
+++ b/core/src/main/java/com/predic8/membrane/core/lang/ScriptingUtils.java
@@ -84,7 +84,17 @@ public class ScriptingUtils {
         }
 
         params.put("property", exc.getProperties());
-        params.put("properties", exc.getProperties()); // properties does not work in Groovy scripts!
+
+        // properties does not work in Groovy scripts!
+        //
+        // Reason: properties is a special built-in property in Groovy. Every Groovy object has a properties property
+        // that returns a Map of all the object's properties.
+        //
+        // Decision: Keep props and property for GroovyTemplate
+        //
+        // Keep the following line for documentation, even if it is commented out!
+        // params.put("properties", exc.getProperties());
+
         params.put("props", exc.getProperties());
 
         params.put("pathParam", new PathParametersMap(exc));

--- a/distribution/examples/orchestration/call-get/proxies.xml
+++ b/distribution/examples/orchestration/call-get/proxies.xml
@@ -13,7 +13,7 @@
                 <!-- Extracts the ID of the newest product -->
                 <setProperty name="id" value="${$.products[0].id}" language="jsonpath"/>
                 <!-- Fetches the full product details using the extracted ID -->
-                <call url="https://api.predic8.de/shop/v2/products/${properties.id}"/>
+                <call url="https://api.predic8.de/shop/v2/products/${property.id}"/>
             </request>
             <return />
         </api>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a variable reference in an API call URL to ensure the correct product ID is used.

* **Documentation**
  * Added clarifying comments regarding property handling in Groovy scripts to prevent confusion with reserved keywords.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->