### PR TITLE
fixed accepting massively parallel incoming requests, added test

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/transport/http/HttpTransport.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/http/HttpTransport.java
@@ -22,6 +22,7 @@ import com.predic8.membrane.core.transport.*;
 import com.predic8.membrane.core.transport.ssl.*;
 import com.predic8.membrane.core.util.*;
 import org.slf4j.*;
+import org.springframework.core.task.VirtualThreadTaskExecutor;
 
 import javax.annotation.*;
 import java.io.*;
@@ -55,9 +56,7 @@ public class HttpTransport extends Transport {
 	private final Map<Integer, Map<IpPort, HttpEndpointListener>> portListenerMapping = new HashMap<>();
 	private final List<WeakReference<HttpEndpointListener>> stillRunning = new ArrayList<>();
 
-	private final ThreadPoolExecutor executorService = new ThreadPoolExecutor(20,
-			MAX_VALUE, 60L, SECONDS,
-			new SynchronousQueue<>(), new HttpServerThreadFactory());
+	private final ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor();
 
 	@Override
 	public void init(Router router) throws Exception {
@@ -209,34 +208,6 @@ public class HttpTransport extends Transport {
 	        sb.append(ip.toShortString()).append(", ");
 	    }
 		return sb.replace(sb.length() - 2, sb.length(), "]").toString();
-	}
-
-	public int getCoreThreadPoolSize() {
-		return executorService.getCorePoolSize();
-	}
-
-	/**
-	 * @description <p>Membrane uses a thread pool to allocate threads to incomming clients connections. The core thread pool size is the minimum number of threads that are created in advance to serve client requests.</p>
-	 * @default 20
-	 * @example 5
-	 */
-	@MCAttribute
-	public void setCoreThreadPoolSize(int corePoolSize) {
-		executorService.setCorePoolSize(corePoolSize);
-	}
-
-	public int getMaxThreadPoolSize() {
-		return executorService.getMaximumPoolSize();
-	}
-
-	/**
-	 * @description Maximum number of threads to handle incoming connections. (Membrane uses 1 thread per incoming connection.)
-	 * @default <i>no limit</i>
-	 * @example 300
-	 */
-	@MCAttribute
-	public void setMaxThreadPoolSize(int value) {
-		executorService.setMaximumPoolSize(value);
 	}
 
 	public ExecutorService getExecutorService() {

--- a/core/src/test/java/com/predic8/membrane/core/transport/http/MassivelyParallelTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/transport/http/MassivelyParallelTest.java
@@ -1,0 +1,126 @@
+package com.predic8.membrane.core.transport.http;
+
+import com.predic8.membrane.core.HttpRouter;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.http.Response;
+import com.predic8.membrane.core.interceptor.AbstractInterceptor;
+import com.predic8.membrane.core.interceptor.Outcome;
+import com.predic8.membrane.core.proxies.ServiceProxy;
+import com.predic8.membrane.core.proxies.ServiceProxyKey;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Consumer;
+
+import static com.predic8.membrane.core.RuleManager.RuleDefinitionSource.MANUAL;
+import static com.predic8.membrane.core.http.Request.get;
+import static com.predic8.membrane.core.interceptor.Outcome.RETURN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests 500 parallel incoming requests (most probably via ~500 parallel TCP connections). Each request uses a unique
+ * path.
+ *
+ * The requests wait for 700ms on the server (reducing the probability that connections are reused during the test) and
+ * are responded to with 200 OK and their request.uri as body. Back on the client, the response body is asserted to be
+ * the request path.
+ *
+ * The test first starts with a ramp up of 20 parallel requests, waits for them to complete, and then proceeds to the
+ * main task of 500.
+ */
+public class MassivelyParallelTest {
+
+    static HttpClient client;
+    static HttpRouter server;
+
+    @BeforeAll
+    public static void init() {
+        client = new HttpClient();
+
+        server = new HttpRouter();
+        server.getTransport().setConcurrentConnectionLimitPerIp(1000);
+        server.getTransport().setBacklog(1000);
+        server.getTransport().setSocketTimeout(10000);
+        server.setHotDeploy(false);
+        server.getRuleManager().addProxy(createServiceProxy(), MANUAL);
+        server.start();
+    }
+
+    private static ServiceProxy createServiceProxy() {
+        ServiceProxy sp = new ServiceProxy(new ServiceProxyKey(3067), null, 99999);
+
+        sp.getInterceptors().add(new AbstractInterceptor() {
+            @Override
+            public Outcome handleRequest(Exchange exc) {
+                try {
+                    Thread.sleep(700);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                exc.setResponse(Response.ok().body(exc.getRequest().getUri()).build());
+                return RETURN;
+            }
+        });
+        return sp;
+    }
+
+
+    @AfterAll
+    public static void shutdown() {
+        server.stop();
+        client.close();
+    }
+
+    @Test
+    public void run() throws Exception {
+        System.out.println("test: begin.");
+        Set<String> paths = new HashSet<>();
+        // ramp up
+        runInParallel((cdl) -> parallelTestWorker(cdl, paths), 20);
+        // go
+        runInParallel((cdl) -> parallelTestWorker(cdl, paths), 500);
+        synchronized (paths) {
+            assertEquals(520, paths.size());
+        }
+        System.out.println("test: end.");
+    }
+
+    private void runInParallel(Consumer<CountDownLatch> job, int threadCount) {
+        List<Thread> threadList = new ArrayList<>();
+        CountDownLatch cdl = new CountDownLatch(threadCount);
+        for (int i = 0; i < threadCount; i++) {
+            threadList.add(new Thread(() -> job.accept(cdl)));
+        }
+        threadList.forEach(Thread::start);
+        threadList.forEach(thread -> {
+            try {
+                thread.join();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        });
+    }
+
+    private void parallelTestWorker(CountDownLatch cdl, Set<String> paths) {
+        try {
+            cdl.countDown();
+            cdl.await();
+
+            String uuid = UUID.randomUUID().toString();
+            var exchange = client.call(get("http://localhost:3067/api/" + uuid).buildExchange());
+
+            var body = exchange.getResponse().getBodyAsStringDecoded();
+            assertTrue(body.startsWith("/api/"));
+            synchronized (paths) {
+                paths.add(body);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+}


### PR DESCRIPTION
fixed accepting massively parallel incoming requests, added test. This removes the transport/@coreThreadPoolSize and transport/@maxThreadPoolSize attributes.