### PR TITLE
revert switch to virtual thread pool, as it causes tests to hang

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/transport/http/HttpTransport.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/http/HttpTransport.java
@@ -55,7 +55,9 @@ public class HttpTransport extends Transport {
 	private final Map<Integer, Map<IpPort, HttpEndpointListener>> portListenerMapping = new HashMap<>();
 	private final List<WeakReference<HttpEndpointListener>> stillRunning = new ArrayList<>();
 
-	private final ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor();
+	private final ThreadPoolExecutor executorService = new ThreadPoolExecutor(20,
+			MAX_VALUE, 60L, SECONDS,
+			new SynchronousQueue<>(), new HttpServerThreadFactory());
 
 	@Override
 	public void init(Router router) throws Exception {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the underlying thread management approach to improve scalability and performance for HTTP transport operations. End users may experience enhanced reliability under high load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->