### PR TITLE
store the B2C flow info in the OAuth2 state and attach it to the request token

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/authorizationservice/AuthorizationService.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/authorizationservice/AuthorizationService.java
@@ -40,6 +40,7 @@ import org.jose4j.lang.JoseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import java.io.IOException;
 import java.io.InputStream;
@@ -111,7 +112,11 @@ public abstract class AuthorizationService {
 
     public abstract String getSubject();
 
-    public abstract String getTokenEndpoint();
+    /**
+     * Note that this method does not honor the B2C flows. Use {@link #getTokenEndpoint(FlowContext)} instead.
+     * @return The Token Endpoint URL.
+     */
+    protected abstract String getTokenEndpoint();
 
     public abstract String getRevocationEndpoint();
 
@@ -223,10 +228,10 @@ public abstract class AuthorizationService {
         return JWSSigner;
     }
 
-    public Request.Builder applyAuth(Request.Builder requestBuilder, String body) {
+    public Request.Builder applyAuth(Request.Builder requestBuilder, String body, FlowContext flowContext) {
 
         if (isUseJWTForClientAuth()) {
-            body += "&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer" + "&client_assertion=" + createClientToken();
+            body += "&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer" + "&client_assertion=" + createClientToken(flowContext);
         }
 
         String clientSecret = getClientSecret();
@@ -237,11 +242,10 @@ public abstract class AuthorizationService {
     }
 
 
-
-    public String getTokenEndpoint(Session session) {
+    public String getTokenEndpoint(@Nullable FlowContext flowContext) {
         String tokenEndpoint = getTokenEndpoint();
-        if (session.get("defaultFlow") != null) {
-            tokenEndpoint = tokenEndpoint.replaceAll(session.get("defaultFlow"), session.get("triggerFlow"));
+        if (flowContext != null) {
+            tokenEndpoint = tokenEndpoint.replaceAll(flowContext.defaultFlow, flowContext.triggerFlow);
         }
         return tokenEndpoint;
     }
@@ -265,10 +269,10 @@ public abstract class AuthorizationService {
         }
     }
 
-    private String createClientToken() {
+    private String createClientToken(FlowContext flowContext) {
         try {
             String jwtSub = this.getClientId();
-            String jwtAud = this.getTokenEndpoint();
+            String jwtAud = this.getTokenEndpoint(flowContext);
 
             // see https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-certificate-credentials
             JwtClaims jwtClaims = new JwtClaims();
@@ -298,23 +302,24 @@ public abstract class AuthorizationService {
     }
 
     public OAuth2TokenResponseBody refreshTokenRequest(Session session, String wantedScope, String refreshToken) throws Exception {
+        FlowContext fc = FlowContext.fromSession(session);
         return parseTokenResponse(checkTokenResponse(doRequest(applyAuth(
-                new Request.Builder().post(getTokenEndpoint(session))
+                new Request.Builder().post(getTokenEndpoint(fc))
                         .contentType(APPLICATION_X_WWW_FORM_URLENCODED)
                         .header(ACCEPT, APPLICATION_JSON)
                         .header(USER_AGENT, USERAGENT),
-                refreshTokenBodyBuilder(refreshToken).scope(wantedScope).build())
+                refreshTokenBodyBuilder(refreshToken).scope(wantedScope).build(), fc)
                 .buildExchange())));
     }
 
-    public OAuth2TokenResponseBody codeTokenRequest(String redirectUri, String code, String verifier) throws Exception {
+    public OAuth2TokenResponseBody codeTokenRequest(String redirectUri, String code, String verifier, FlowContext flowContext) throws Exception {
         return parseTokenResponse(checkTokenResponse(doRequest(applyAuth(
                 new Request.Builder()
-                        .post(getTokenEndpoint())
+                        .post(getTokenEndpoint(flowContext))
                         .contentType(APPLICATION_X_WWW_FORM_URLENCODED)
                         .header(ACCEPT, APPLICATION_JSON)
                         .header(USER_AGENT, USERAGENT),
-                authorizationCodeBodyBuilder(code, verifier).redirectUri(redirectUri).build()).buildExchange())));
+                authorizationCodeBodyBuilder(code, verifier).redirectUri(redirectUri).build(), flowContext).buildExchange())));
     }
 
     private OAuth2TokenResponseBody parseTokenResponse(Response response) throws IOException {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/authorizationservice/FlowContext.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/authorizationservice/FlowContext.java
@@ -1,0 +1,102 @@
+package com.predic8.membrane.core.interceptor.oauth2.authorizationservice;
+
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.interceptor.session.Session;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.predic8.membrane.core.interceptor.oauth2.OAuth2Util.urlencode;
+import static com.predic8.membrane.core.interceptor.oauth2client.rf.StateManager.getValueFromState;
+
+/**
+ * This is a parametrization of the B2C Token endpoint.
+ *
+ * This object can be null. If not null, <code>defaultFlow</code> will be replaced by <code>triggerFlow</code> in the
+ * Token Endpoint URL.
+ *
+ * If set, the FlowContext represents the information, that a non-default B2C flow should be used.
+ *
+ * The FlowContext is passed
+ * <ul>
+ *     <li><b>on the current Exchange</b> or <b>as a method parameter</b> to carry the information within a Java caller
+ *     context</li>
+ *     <li><b>in the OAuth2 state parameter</b> to carry the information during a (re)login process. (Note that the
+ *     session and oauth2 state might temporarily disagree, especially when an OAuth2 flow is executed in parallel or
+ *     temporarily paused due to user interaction)</li>
+ *     <li><b>via a session entry</b> to carry the information which flow the current refresh token belongs to.</li>
+ * </ul>
+ *
+ */
+public class FlowContext {
+
+    private static final Logger log = LoggerFactory.getLogger(FlowContext.class);
+
+    public final String defaultFlow;
+    public final String triggerFlow;
+
+    private FlowContext(String defaultFlow, String triggerFlow) {
+        this.defaultFlow = defaultFlow;
+        this.triggerFlow = triggerFlow;
+    }
+
+    public static FlowContext fromExchange(Exchange exc) {
+        FlowContext fc = exc.getPropertyOrNull("flowContext", FlowContext.class);
+        log.debug("FlowContext from exchange = {}", fc);
+        return fc;
+    }
+
+    public static FlowContext fromSession(Session session) {
+        String fcd = session.get("flowContextDefault");
+        String fct = session.get("flowContextTrigger");
+        if (fcd == null) {
+            log.debug("FlowContext from session = null");
+            return null;
+        }
+        FlowContext fc = new FlowContext(fcd, fct);
+        log.debug("FlowContext from session = {}", fc);
+        return fc;
+    }
+
+    public static void applyToSession(FlowContext flowContext, Session session) {
+        log.debug("FlowContext to session = {}", flowContext);
+        if (flowContext == null) {
+            session.remove("flowContextDefault", "flowContextTrigger");
+            return;
+        }
+        session.put("flowContextDefault", flowContext.defaultFlow);
+        session.put("flowContextTrigger", flowContext.triggerFlow);
+    }
+
+    public static @NotNull String toUrlParam(FlowContext fc) {
+        log.debug("FlowContext to URL = {}", fc);
+        return fc != null ? "%26fcd%3D" + urlencode(fc.defaultFlow) + "%26fct%3D" + urlencode(fc.triggerFlow) : "";
+    }
+
+    public static FlowContext fromUrlParam(String params) {
+        var fcD = getValueFromState(params, "fcd");
+        var fcT = getValueFromState(params, "fct");
+        if (fcD != null) {
+            FlowContext flowContext = new FlowContext(fcD, fcT);
+            log.debug("FlowContext from URL = {}", flowContext);
+            return flowContext;
+        } else {
+            log.debug("FlowContext from URL = null");
+            return null;
+        }
+    }
+
+    public static FlowContext fromConfig(String defaultFlow, String triggerFlow) {
+        FlowContext fc = new FlowContext(defaultFlow, triggerFlow);
+        log.debug("FlowContext from config = {}", fc);
+        return fc;
+    }
+
+    @Override
+    public String toString() {
+        return "FlowContext{" +
+                "defaultFlow='" + defaultFlow + '\'' +
+                ", triggerFlow='" + triggerFlow + '\'' +
+                '}';
+    }
+}

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2client/rf/OAuth2CallbackRequestHandler.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2client/rf/OAuth2CallbackRequestHandler.java
@@ -29,6 +29,7 @@ import java.security.*;
 
 import static com.predic8.membrane.core.http.Response.badRequest;
 import static com.predic8.membrane.core.interceptor.oauth2.OAuth2AnswerParameters.createFrom;
+import static com.predic8.membrane.core.interceptor.oauth2.authorizationservice.FlowContext.applyToSession;
 import static com.predic8.membrane.core.interceptor.oauth2client.rf.StateManager.*;
 import static com.predic8.membrane.core.interceptor.oauth2client.temp.OAuth2Constants.*;
 
@@ -103,7 +104,7 @@ public class OAuth2CallbackRequestHandler {
 
             OAuth2TokenResponseBody tokenResponse = auth.codeTokenRequest(
                     publicUrlManager.getPublicURLAndReregister(exc) + callbackPath, params.getCode(),
-                    PKCEVerifier.getVerifier(stateFromUri, session));
+                    PKCEVerifier.getVerifier(stateFromUri, session), stateFromUri.getFlowContext());
 
             if (tokenResponse.getAccessToken() == null) {
                 if (!onlyRefreshToken)
@@ -121,6 +122,7 @@ public class OAuth2CallbackRequestHandler {
                     sessionAuthorizer.retrieveUserInfo(tokenResponse, createFrom(tokenResponse), session);
                 }
             }
+            applyToSession(stateFromUri.getFlowContext(), session);
 
             continueOriginalExchange(exc, originalRequest, session);
 

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2client/rf/StateManager.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2client/rf/StateManager.java
@@ -14,8 +14,7 @@
 package com.predic8.membrane.core.interceptor.oauth2client.rf;
 
 import com.predic8.membrane.core.exchange.Exchange;
-import com.predic8.membrane.core.http.Response;
-import com.predic8.membrane.core.interceptor.oauth2.OAuth2Util;
+import com.predic8.membrane.core.interceptor.oauth2.authorizationservice.FlowContext;
 import com.predic8.membrane.core.interceptor.session.Session;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -28,6 +27,9 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.predic8.membrane.core.http.Response.badRequest;
+import static com.predic8.membrane.core.interceptor.oauth2.OAuth2Util.urlencode;
+import static com.predic8.membrane.core.interceptor.oauth2.authorizationservice.FlowContext.fromUrlParam;
+import static com.predic8.membrane.core.interceptor.oauth2.authorizationservice.FlowContext.toUrlParam;
 import static com.predic8.membrane.core.interceptor.oauth2client.rf.OAuth2CallbackRequestHandler.*;
 import static com.predic8.membrane.core.interceptor.session.SessionManager.SESSION_VALUE_SEPARATOR;
 import static com.predic8.membrane.core.util.URLParamUtil.DuplicateKeyOrInvalidFormStrategy.ERROR;
@@ -43,23 +45,27 @@ public class StateManager {
 
     private final String securityToken;
     private final String verifierId;
+    private final FlowContext flowContext;
 
-    public StateManager(PKCEVerifier pkceVerifier) {
+    public StateManager(PKCEVerifier pkceVerifier, FlowContext flowContext) {
         securityToken = generateNewState();
         verifierId = pkceVerifier.getId();
+        this.flowContext = flowContext;
     }
 
     public StateManager(String stateFromUri) {
         securityToken = getValueFromState(stateFromUri, "security_token");
         verifierId = getValueFromState(stateFromUri, "verifierId");
+        flowContext = fromUrlParam(stateFromUri);
     }
+
 
     @NotNull
     public static String generateNewState() {
         return new BigInteger(130, sr).toString(32);
     }
 
-    private static String getValueFromState(String state, String key) {
+    public static String getValueFromState(String state, String key) {
         if (state == null)
             throw new RuntimeException("State is null, No "+key+".");
 
@@ -114,8 +120,8 @@ public class StateManager {
     }
 
     public String buildStateParameter(Exchange exchange) {
-        return "&state=security_token%3D" + securityToken + "%26url%3D" + OAuth2Util.urlencode(exchange.getRequestURI())
-                + "%26verifierId%3D" + verifierId;
+        return "&state=security_token%3D" + securityToken + "%26url%3D" + urlencode(exchange.getRequestURI())
+                + "%26verifierId%3D" + verifierId + toUrlParam(flowContext);
     }
 
     public void saveToSession(Session session) {
@@ -133,11 +139,17 @@ public class StateManager {
         return Optional.ofNullable(verifierId);
     }
 
+    public FlowContext getFlowContext() {
+        return flowContext;
+    }
+
     @Override
     public String toString() {
         return "StateManager{" +
                 "securityToken='" + securityToken + '\'' +
                 ", verifierId='" + verifierId + '\'' +
+                ", flowContext=" + flowContext +
                 '}';
     }
+
 }

--- a/core/src/main/java/com/predic8/membrane/core/transport/http/HttpClient.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/http/HttpClient.java
@@ -49,6 +49,8 @@ public class HttpClient implements AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(HttpClient.class.getName());
 
+    private static final int TRACE_BODY_MAX_LEN = getTraceBodyMaximumLength();
+
     @GuardedBy("HttpClient.class")
     private static SSLProvider defaultSSLProvider;
 
@@ -657,17 +659,20 @@ public class HttpClient implements AutoCloseable {
     }
 
     private void appendBody(StringBuilder sb, String body) {
-        final int MAX_LEN = 1024;          // 1KB
         if (body == null || body.isEmpty()) {
             sb.append("[no body]\n");
             return;
         }
-        if (body.length() > MAX_LEN) {
-            sb.append(body, 0, MAX_LEN)
+        if (body.length() > TRACE_BODY_MAX_LEN) {
+            sb.append(body, 0, TRACE_BODY_MAX_LEN)
                     .append("\n...[body truncated]...\n");
         } else {
             sb.append(body).append('\n');
         }
+    }
+
+    private static int getTraceBodyMaximumLength() {
+        return Integer.parseInt(System.getProperty("membrane.core.http.traceBodyMaximumLength", "10240"));
     }
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for OAuth2 B2C flows with customizable flow context, enabling dynamic token endpoint handling.
  * Added a configurable limit for HTTP body trace logging.

* **Bug Fixes**
  * Improved refresh token tracking and validation for B2C OAuth2 flows in the mock authorization server.
  * Ensured proper URL encoding of parameters in OAuth2 redirects.

* **Tests**
  * Enhanced and expanded test coverage for B2C OAuth2 flows, including new scenarios for refresh token usage and flow switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->