### PR TITLE
removed commons-discovery dependency

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - id: install-secret-key
@@ -30,11 +30,13 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
         run: |
+          mvn clean && 
+          mvn -pl distribution cyclonedx:makeAggregateBom &&
           mvn \
             --no-transfer-progress \
             --batch-mode \
-            -Possrh \
+            -Pcentral \
             -DskipTests \
-            -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} \
-            clean deploy
+            deploy

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -75,7 +75,7 @@ jobs:
             --no-transfer-progress \
             --batch-mode \
             -DskipTests \
-            -Possrh \
+            -Pcentral \
             -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} \
             clean verify
       - name: Ensure release files exist

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -80,16 +80,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>commons-discovery</groupId>
-            <artifactId>commons-discovery</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
             <version>1.14.0</version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -247,6 +247,7 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- We explicitly use an old commons-httpclient version here, only for testing features which were removed in later versions. -->
         <dependency>
             <groupId>commons-httpclient</groupId>
             <artifactId>commons-httpclient</artifactId>
@@ -286,6 +287,7 @@
             <artifactId>spotbugs-annotations</artifactId>
             <version>4.9.3</version>
         </dependency>
+        <!-- fallback parser for documents based on older Swagger standards -->
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-parser</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -112,7 +112,7 @@
 				<artifactId>cyclonedx-maven-plugin</artifactId>
 				<executions>
 					<execution>
-						<phase>package</phase>
+						<phase>prepare-package</phase>
 						<goals>
 							<goal>makeAggregateBom</goal>
 						</goals>

--- a/docs/JAVADOC.md
+++ b/docs/JAVADOC.md
@@ -67,6 +67,8 @@ api:
         println('Here')
 ```
 
+Therefore, while most of the project still uses XML as its configuration language, everything can be expressed in YAML.
+
 ## Annotations used
 * `@MCElement(name="foo")` means that you can write `<foo>` somewhere in the configuration where it fits.
 

--- a/pom.xml
+++ b/pom.xml
@@ -358,16 +358,6 @@
 		</dependencies>
 	</dependencyManagement>
 
-
-	<repositories>
-		<repository>
-			<id>com.springsource.repository.bundles.external</id>
-			<name>SpringSource Enterprise Bundle Repository - External Bundle Releases</name>
-			<url>https://repository.springsource.com/maven/bundles/external</url>
-		</repository>
-	</repositories>
-
-
 	<build>
 		<plugins>
 			<plugin>
@@ -632,7 +622,7 @@
 
 	<profiles>
 		<profile>
-			<id>ossrh</id>
+			<id>central</id>
 			<build>
 				<plugins>
 					<plugin>
@@ -649,29 +639,19 @@
 							</execution>
 						</executions>
 					</plugin>
-					<plugin>
-						<groupId>org.sonatype.plugins</groupId>
-						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<version>1.7.0</version>
-						<extensions>true</extensions>
-						<configuration>
-							<serverId>ossrh</serverId>
-							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-							<autoReleaseAfterClose>true</autoReleaseAfterClose>
-						</configuration>
-					</plugin>
-				</plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                        </configuration>
+                    </plugin>
+                </plugins>
 			</build>
-			<distributionManagement>
-				<repository>
-					<id>ossrh</id>
-					<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-				</repository>
-				<snapshotRepository>
-					<id>ossrh</id>
-					<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-				</snapshotRepository>
-			</distributionManagement>
 		</profile>
 	</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -129,11 +129,6 @@
 				<version>2.13.0</version>
 			</dependency>
 			<dependency>
-				<groupId>commons-discovery</groupId>
-				<artifactId>commons-discovery</artifactId>
-				<version>0.5</version>
-			</dependency>
-			<dependency>
 				<groupId>commons-fileupload</groupId>
 				<artifactId>commons-fileupload</artifactId>
 				<version>1.6.0</version>

--- a/starter/pom.xml
+++ b/starter/pom.xml
@@ -7,6 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>starter</artifactId>
+    <name>Membrane API Gateway Starter</name>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed an outdated discovery library and external repository; replaced a parser dependency and added a test-scoped legacy HTTP client for tests.
  * Switched publishing/config to use the central repository, updated CI publish workflow and added pre-deploy BOM generation.
  * Adjusted build lifecycle to generate SBOM earlier and added project metadata name for the starter.

* **Documentation**
  * Clarified that YAML can fully express configuration alongside XML.

* **Impact**
  * Leaner dependencies, streamlined publishing, and earlier SBOM generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->