### PR TITLE
add IPv6

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/util/URI.java
+++ b/core/src/main/java/com/predic8/membrane/core/util/URI.java
@@ -87,6 +87,20 @@ public class URI {
                 hostAndPort = hostAndPort.substring(posAt + 1);
             }
 
+            var posBrackets = hostAndPort.indexOf("[");
+            if (posBrackets > -1) {
+                int end = hostAndPort.indexOf("]");
+                if (end < 0) {
+                    throw new IllegalArgumentException("Invalid IPv6 bracket literal: missing ']'.");
+                }
+                String ipv6 = hostAndPort.substring(posBrackets + 1, end);
+                if (end + 1 < hostAndPort.length() && hostAndPort.charAt(end + 1) == ':') {
+                    port = Integer.parseInt(hostAndPort.substring(end + 2));
+                }
+                host = ipv6;
+                return;
+            }
+
             var pos = hostAndPort.indexOf(":");
             if (pos > -1) {
                 host = hostAndPort.substring(0, pos);
@@ -189,6 +203,7 @@ public class URI {
 
     /**
      * Fragments are client side only and should not be propagated to the backend.
+     *
      * @return
      */
     public String getPathWithQuery() {

--- a/core/src/main/java/com/predic8/membrane/core/util/URI.java
+++ b/core/src/main/java/com/predic8/membrane/core/util/URI.java
@@ -179,15 +179,21 @@ public class URI {
      * Returns {@code null} if no authority is present (e.g. "mailto:").
      */
     public String getAuthority() {
-        if (uri != null)
-            return uri.getAuthority();
-        if (host == null)
-            return null;
-        StringBuilder sb = new StringBuilder(host);
-        if (port != -1)
-            sb.append(':').append(port);
+        if (uri != null) return uri.getAuthority();
+        if (host == null) return null;
+
+        StringBuilder sb = new StringBuilder();
+        if (host.contains(":")) { // IPv6
+            sb.append('[').append(host);
+            if (port != -1) sb.append(':').append(port);
+            sb.append(']');
+        } else { // IPv4 / Domain
+            sb.append(host);
+            if (port != -1) sb.append(':').append(port);
+        }
         return sb.toString();
     }
+
 
     private String decode(String string) {
         if (string == null)

--- a/core/src/test/java/com/predic8/membrane/core/util/URITest.java
+++ b/core/src/test/java/com/predic8/membrane/core/util/URITest.java
@@ -246,4 +246,23 @@ class URITest {
 		assertEquals("/foo?q=a+b", new URIFactory().create("/foo?q=a+b").getPathWithQuery()); // '+' must remain '+'
 		assertEquals("/foo", new URIFactory().create("/foo#c%2Fd").getPathWithQuery());  // '/' in fragment is encoded
 	}
+
+    @Test
+    void ipv6Bracketed() throws URISyntaxException {
+        URI u = new URI("http://[2001:db8::1]/foo", true);
+        assertEquals("2001:db8::1", u.getHost());
+        assertEquals(-1, u.getPort());
+        assertEquals("2001:db8::1", u.getAuthority());
+        assertEquals("/foo", u.getPath());
+    }
+
+    @Test
+    void ipv6BracketedWithPort() throws URISyntaxException {
+        URI u = new URI("http://[2001:db8::1]:8080/foo", true);
+        assertEquals("2001:db8::1", u.getHost());
+        assertEquals(8080, u.getPort());
+        assertEquals("2001:db8::1:8080", u.getAuthority());
+        assertEquals("/foo", u.getPath());
+
+    }
 }

--- a/core/src/test/java/com/predic8/membrane/core/util/URITest.java
+++ b/core/src/test/java/com/predic8/membrane/core/util/URITest.java
@@ -252,7 +252,7 @@ class URITest {
         URI u = new URI("http://[2001:db8::1]/foo", true);
         assertEquals("2001:db8::1", u.getHost());
         assertEquals(-1, u.getPort());
-        assertEquals("2001:db8::1", u.getAuthority());
+        assertEquals("[2001:db8::1]", u.getAuthority());
         assertEquals("/foo", u.getPath());
     }
 
@@ -261,7 +261,7 @@ class URITest {
         URI u = new URI("http://[2001:db8::1]:8080/foo", true);
         assertEquals("2001:db8::1", u.getHost());
         assertEquals(8080, u.getPort());
-        assertEquals("2001:db8::1:8080", u.getAuthority());
+        assertEquals("[2001:db8::1:8080]", u.getAuthority());
         assertEquals("/foo", u.getPath());
 
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved URI handling to support bracketed IPv6 addresses with optional ports (e.g., http://[2001:db8::1]:8080/path).

* **Bug Fixes**
  * Correct parsing of hosts and ports when IPv6 literals are present; authority values now include brackets for IPv6 hosts.

* **Tests**
  * Added unit tests for bracketed IPv6 URIs with and without ports.

* **Documentation**
  * Minor Javadoc formatting update; no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->