### PR TITLE
if command line args were passed, use them.

### DIFF
--- a/distribution/scripts/start_router.sh
+++ b/distribution/scripts/start_router.sh
@@ -3,9 +3,7 @@
 
 CLASSPATH="$MEMBRANE_HOME/conf:$MEMBRANE_HOME/lib/*"
 
-has_c=0
-for a in "$@"; do [ "$a" = "-c" ] && { has_c=1; break; }; done
-if [ $has_c -eq 0 ]; then
+if [ $# -eq 0 ]; then
   if [ -n "${MEMBRANE_CALLER_DIR:-}" ] && [ -f "$MEMBRANE_CALLER_DIR/proxies.xml" ]; then
     set -- -c "$MEMBRANE_CALLER_DIR/proxies.xml" "$@"
   elif [ -f "$MEMBRANE_HOME/conf/proxies.xml" ]; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - The start script now injects a default proxies.xml only when launched with no arguments. If any arguments are provided, it no longer auto-adds a default config; pass your desired config explicitly via the appropriate flag. When using the default, it prefers a local proxies.xml if available, otherwise falls back to a standard installation config. Other startup behaviors remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->