### PR TITLE
expose default session lifetime via SpEL

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/lang/spel/functions/BuiltInFunctions.java
+++ b/core/src/main/java/com/predic8/membrane/core/lang/spel/functions/BuiltInFunctions.java
@@ -65,6 +65,16 @@ public class BuiltInFunctions {
         }
     }
 
+    public static long getDefaultSessionLifetime(String beanName, SpELExchangeEvaluationContext ctx) {
+        try {
+            return ((AbstractInterceptorWithSession) requireNonNull(ctx.getExchange().getHandler().getTransport().getRouter().getBeanFactory()).getBean(beanName))
+                    .getSessionManager().getExpiresAfterSeconds();
+        } catch (Exception e) {
+            log.info("Failed to resolve bean with name '{}'", beanName);
+            return -1;
+        }
+    }
+
     public static boolean isBearerAuthorization(SpELExchangeEvaluationContext ctx) {
         return ctx.getExchange().getRequest().getHeader().contains(AUTHORIZATION)
                 && ctx.getExchange().getRequest().getHeader().getFirstValue(AUTHORIZATION).startsWith("Bearer");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new expression function to retrieve the default session lifetime (in seconds) for session-enabled components. This enables dynamic routing, policies, and configuration that react to session expiry values in your expressions.
  * If the referenced component cannot be resolved, a warning is logged and the function returns -1, allowing safe fallbacks in configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->