### PR TITLE
fix jackson-annotations version to work with jackson 2.20.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-annotations</artifactId>
-				<version>${jackson.version}</version>
+				<version>2.20</version>
 			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned a core JSON annotation library to a specific version to improve stability, compatibility, and reproducible builds.
* **Style**
  * Applied a minor formatting cleanup to configuration to align with formatting guidelines.

No user-facing changes; behavior and features remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->