### PR TITLE
uppercase enum values in ClientAuthorization

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/authorizationservice/AuthorizationService.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/authorizationservice/AuthorizationService.java
@@ -33,7 +33,6 @@ import com.predic8.membrane.core.transport.ssl.PEMSupport;
 import com.predic8.membrane.core.transport.ssl.SSLContext;
 import com.predic8.membrane.core.transport.ssl.StaticSSLContext;
 import jakarta.mail.internet.ParseException;
-import org.apache.commons.codec.binary.Base64;
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.MalformedClaimException;
 import org.jose4j.jwt.NumericDate;
@@ -45,7 +44,6 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URLEncoder;
 import java.util.List;
 import java.util.UUID;
 
@@ -56,8 +54,6 @@ import static com.predic8.membrane.core.http.MimeType.APPLICATION_X_WWW_FORM_URL
 import static com.predic8.membrane.core.interceptor.oauth2.OAuth2TokenBody.authorizationCodeBodyBuilder;
 import static com.predic8.membrane.core.interceptor.oauth2.OAuth2TokenBody.refreshTokenBodyBuilder;
 import static com.predic8.membrane.core.interceptor.oauth2client.rf.JsonUtils.isJson;
-import static java.net.URLEncoder.encode;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.codec.binary.Base64.encodeBase64;
 
 public abstract class AuthorizationService {
@@ -79,7 +75,7 @@ public abstract class AuthorizationService {
     private SSLContext sslContext;
     private boolean useJWTForClientAuth;
     private final LogHelper logHelper = new LogHelper();
-    private ClientAuthorization clientAuthorization = ClientAuthorization.client_secret_basic;
+    private ClientAuthorization clientAuthorization = ClientAuthorization.CLIENT_SECRET_BASIC;
 
     protected boolean supportsDynamicRegistration = false;
 
@@ -259,7 +255,7 @@ public abstract class AuthorizationService {
         if (clientSecret == null) {
             return requestBuilder.body(body.clientId(getClientId()).build());
         }
-        if (clientAuthorization == ClientAuthorization.client_secret_basic) {
+        if (clientAuthorization == ClientAuthorization.CLIENT_SECRET_BASIC) {
             return requestBuilder.header(AUTHORIZATION, "Basic " + new String(encodeBase64((getClientId() + ":" + clientSecret).getBytes()))).body(body.build());
         }
         return requestBuilder.body(body.clientId(getClientId()).clientSecret(clientSecret).build());

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/authorizationservice/ClientAuthorization.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/authorizationservice/ClientAuthorization.java
@@ -20,6 +20,6 @@ package com.predic8.membrane.core.interceptor.oauth2.authorizationservice;
  * Core 1.0 chapter 9</a>.
  */
 public enum ClientAuthorization {
-    client_secret_basic,
-    client_secret_post
-}
+    CLIENT_SECRET_BASIC,
+    CLIENT_SECRET_POST
+    }

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/b2c/B2CMembrane.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/b2c/B2CMembrane.java
@@ -159,7 +159,7 @@ public class B2CMembrane {
         auth.setClientSecret(tc.clientSecret);
         auth.setScope("openid profile offline_access");
         auth.setSubject("sub");
-        auth.setClientAuthorization(ClientAuthorization.client_secret_post);
+        auth.setClientAuthorization(ClientAuthorization.CLIENT_SECRET_POST);
         return auth;
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized naming for OAuth2 client authorization methods to uppercase for consistency across the app and logs. No functional behavior changes expected.
- Tests
  - Updated tests to align with the standardized authorization method names.

Note: If you reference these authorization methods in custom integrations or scripts, ensure names use uppercase to match the new convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->