### PR TITLE
Validate enum uppercase

### DIFF
--- a/annot/src/main/java/com/predic8/membrane/annot/SpringConfigurationXSDGeneratingAnnotationProcessor.java
+++ b/annot/src/main/java/com/predic8/membrane/annot/SpringConfigurationXSDGeneratingAnnotationProcessor.java
@@ -535,7 +535,8 @@ public class SpringConfigurationXSDGeneratingAnnotationProcessor extends Abstrac
             if (enclosed.getKind() == ElementKind.ENUM_CONSTANT) {
                 String name = enclosed.getSimpleName().toString();
                 if (!name.equals(name.toUpperCase(Locale.ROOT))) {
-                    throw new IllegalArgumentException("write error message later!");
+                    throw new IllegalArgumentException("Enum constant '" + name + "' in " + enumType.getQualifiedName() +
+                            " must be uppercase. Found: " + name + ", expected: " + name.toUpperCase(Locale.ROOT));
                 }
             }
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Stricter validation for enum-based configuration properties: enum constants must be uppercase. Misconfigurations now fail fast with clear error messages, helping catch issues early during configuration and build-time processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->