### PR TITLE
update sed command to correctly replace the CLASSPATH path in start_r…

### DIFF
--- a/membrane.spec
+++ b/membrane.spec
@@ -138,7 +138,7 @@ exit 0
 %{__rm} -f %{buildroot}%{homedir}/build-install-wrapper.xml
 
 # TODO use %{confdir} macro here, does not get replaced currently
-if [ -e %{buildroot}%{homedir}/scripts/start_router.sh ] ; then sed -i 's#CLASSPATH="$MEMBRANE_HOME/conf"#CLASSPATH="/etc/membrane"#' %{buildroot}%{homedir}/scripts/start_router.sh ; fi
+if [ -e %{buildroot}%{homedir}/scripts/start_router.sh ] ; then sed -i 's#CLASSPATH="$MEMBRANE_HOME/conf#CLASSPATH="/etc/membrane#' %{buildroot}%{homedir}/scripts/start_router.sh ; fi
 sed -i 's#CLASSPATH="$MEMBRANE_HOME/conf"#CLASSPATH="/etc/membrane"#' %{buildroot}%{homedir}/membrane.sh
 sed -i 's#CLASSPATH="$membrane_home/conf:#CLASSPATH="/etc/membrane:#' %{buildroot}%{homedir}/membrane.sh
 


### PR DESCRIPTION
…outer.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected an install-time replacement pattern to reliably set CLASSPATH to /etc/membrane, preventing misconfiguration due to quoting issues and ensuring consistent configuration after installation. No runtime behavior changes; other installation steps remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->