### PR TITLE
Fixing #2233 by renewing Session time also in SessionFinder access. 

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/SessionFinder.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/SessionFinder.java
@@ -62,19 +62,31 @@ public class SessionFinder {
 
     public SessionManager.Session getSessionForCode(String code) {
         synchronized (authCodesToSession) {
-            return authCodesToSession.get(code);
+            Session session = authCodesToSession.get(code);
+            if (session != null) {
+                session.touch();
+            }
+            return session;
         }
     }
 
     public SessionManager.Session getSessionForToken(String token) {
         synchronized (tokensToSession) {
-            return tokensToSession.get(token);
+            Session session = tokensToSession.get(token);
+            if (session != null) {
+                session.touch();
+            }
+            return session;
         }
     }
 
     public SessionManager.Session getSessionForRefreshToken(String refreshToken) {
         synchronized (refreshTokensToSession) {
-            return refreshTokensToSession.get(refreshToken);
+            Session session = refreshTokensToSession.get(refreshToken);
+            if (session != null) {
+                session.touch();
+            }
+            return session;
         }
     }
 

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/request/tokenrequest/RefreshTokenFlow.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/request/tokenrequest/RefreshTokenFlow.java
@@ -89,6 +89,10 @@ public class RefreshTokenFlow extends TokenRequest {
         refreshToken = authServer.getRefreshTokenGenerator().getToken(getUsername(), getClientId(), getClientSecret(), additionalClaims);
 
         SessionManager.Session session = authServer.getSessionFinder().getSessionForRefreshToken(getRefreshToken());
+        if(session == null) {
+            // client sends unknown refresh token
+            return OAuth2Util.createParameterizedJsonErrorResponse(exc, jsonGen,"error", "invalid_request");
+        }
         synchronized(session) {
             session.getUserAttributes().put(ACCESS_TOKEN, token);
         }


### PR DESCRIPTION
Renewing Session time also in SessionFinder access and adding explicit exception into RefreshFlow for invalid tokens instead of NPE.
Now RefreshFlow can renew the Session to prevent log off after initial Session time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Session access timestamps are now consistently updated when authentication codes, tokens, and refresh tokens are retrieved, improving the accuracy of session tracking and activity monitoring.
  * Invalid or unknown refresh token requests now return descriptive error responses, providing better feedback for authentication failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->