### PR TITLE
fix example http request

### DIFF
--- a/distribution/examples/security/oauth2/api/rest.http
+++ b/distribution/examples/security/oauth2/api/rest.http
@@ -2,7 +2,7 @@
 POST http://localhost:7007/oauth2/token
 Content-Type: application/x-www-form-urlencoded
 
-grant_type=password &username=john&password=password&client_id=abc&client_secret=def
+grant_type=password&username=john&password=password&client_id=abc&client_secret=def
 
 # Execute the POST request above. You should be a response like that:
 #


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the OAuth2 token example to use a single-line URL-encoded POST body, consolidating parameters for clearer, more consistent request formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->