### PR TITLE
add deprecated annot in expressionExtractor

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/apikey/extractors/ApiKeyExpressionExtractor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/apikey/extractors/ApiKeyExpressionExtractor.java
@@ -29,6 +29,7 @@ import static com.predic8.membrane.core.lang.ExchangeExpression.expression;
 import static com.predic8.membrane.core.security.ApiKeySecurityScheme.In.EXPRESSION;
 
 /**
+ * @deprecated Set the expression directly on the apiKey plugin.
  * @description Extracts an API key by evaluating an expression on the incoming request.
  * The result (a string) is treated as the API key. The expression is evaluated in the configured language
  * (default: <code>SPEL</code>) during the request flow.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deprecation notice for API key expression configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->