### PR TITLE
Add log for mismatching content-type

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/lang/AbstractExchangeExpression.java
+++ b/core/src/main/java/com/predic8/membrane/core/lang/AbstractExchangeExpression.java
@@ -70,7 +70,7 @@ public abstract class AbstractExchangeExpression implements ExchangeExpression {
                 return resultForNoEvaluation(type);
             }
             if (!contentTypeOk.test(msg)) {
-                log.info("Content-Type not {}. Nothing to evaluate for expression: {}", contentTypeLabel, expression);
+                log.info("Content-Type is not {}. Nothing to evaluate for expression: {}", contentTypeLabel, expression);
                 return resultForNoEvaluation(type);
             }
         } catch (IOException e) {

--- a/core/src/main/java/com/predic8/membrane/core/lang/jsonpath/JsonpathExchangeExpression.java
+++ b/core/src/main/java/com/predic8/membrane/core/lang/jsonpath/JsonpathExchangeExpression.java
@@ -64,8 +64,8 @@ public class JsonpathExchangeExpression extends AbstractExchangeExpression {
     @Override
     public <T> T evaluate(Exchange exchange, Flow flow, Class<T> type) {
 
-        T check = checkContentTypeAndBody(exchange.getMessage(flow), type, Message::isJSON, "JSON", log);
-        if (check != null) return check;
+        T fallback = checkContentTypeAndBody(exchange.getMessage(flow), type, Message::isJSON, "JSON", log);
+        if (fallback != null) return fallback;
 
         try {
             return castType(exchange, flow, type);

--- a/core/src/main/java/com/predic8/membrane/core/lang/xpath/XPathExchangeExpression.java
+++ b/core/src/main/java/com/predic8/membrane/core/lang/xpath/XPathExchangeExpression.java
@@ -45,8 +45,8 @@ public class XPathExchangeExpression extends AbstractExchangeExpression {
     public <T> T evaluate(Exchange exchange, Interceptor.Flow flow, Class<T> type) {
         Message msg = exchange.getMessage(flow);
 
-        T check = checkContentTypeAndBody(exchange.getMessage(flow), type, Message::isXML, "XML", log);
-        if (check != null) return check;
+        T fallback = checkContentTypeAndBody(exchange.getMessage(flow), type, Message::isXML, "XML", log);
+        if (fallback != null) return fallback;
 
         try {
             if (Boolean.class.isAssignableFrom(type)) {


### PR DESCRIPTION
Change log level from debug to info?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * XPath/JSONPath evaluations now return sensible defaults (string, boolean, or null) for empty bodies or non-XML/non-JSON content instead of failing.

* **Refactor**
  * Pre-evaluation content-type and body checks were centralized so guards run consistently before expression evaluation.

* **Style**
  * Logging around empty or non-applicable bodies made clearer to improve traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->