### PR TITLE
Fix port 443 --> 8443 example tests

### DIFF
--- a/distribution/src/test/java/com/predic8/membrane/examples/withoutinternet/ssl/SSLServerApiWithTlsPemExampleTest.java
+++ b/distribution/src/test/java/com/predic8/membrane/examples/withoutinternet/ssl/SSLServerApiWithTlsPemExampleTest.java
@@ -29,11 +29,9 @@ public class SSLServerApiWithTlsPemExampleTest extends DistributionExtractingTes
 
     @Test
     void test() throws Exception {
-        replaceInFile2("proxies.xml", "443", "3023");
-
         try(Process2 ignored = startServiceProxyScript(); HttpAssertions ha = new HttpAssertions()) {
-            ha.trustAnyHTTPSServer(3023);
-            assertContains("success", ha.getAndAssert200("https://localhost:3023"));
+            ha.trustAnyHTTPSServer(8443);
+            assertContains("success", ha.getAndAssert200("https://localhost:8443"));
         }
     }
 

--- a/distribution/src/test/java/com/predic8/membrane/examples/withoutinternet/ssl/SSLServerApiWithTlsPkcs12ExampleTest.java
+++ b/distribution/src/test/java/com/predic8/membrane/examples/withoutinternet/ssl/SSLServerApiWithTlsPkcs12ExampleTest.java
@@ -30,11 +30,9 @@ public class SSLServerApiWithTlsPkcs12ExampleTest extends DistributionExtracting
 
 	@Test
 	void test() throws Exception {
-		replaceInFile2("proxies.xml", "443", "3023");
-
 		try(Process2 ignored = startServiceProxyScript(); HttpAssertions ha = new HttpAssertions()) {
-			ha.trustAnyHTTPSServer(3023);
-			assertContains("success", ha.getAndAssert200("https://localhost:3023/axis2/services/BLZService?wsdl"));
+			ha.trustAnyHTTPSServer(8443);
+			assertContains("success", ha.getAndAssert200("https://localhost:8443/axis2/services/BLZService?wsdl"));
 		}
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated SSL/TLS example tests to use standard HTTPS port 8443 instead of 3023.
  * Simplified test configuration by removing unnecessary dynamic port replacement logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->