### PR TITLE
add trigger membrane api io pipeline

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -100,7 +100,7 @@ jobs:
           VERSION='${{ steps.get_version.outputs.VERSION }}'
           echo "Triggering GitLab pipeline for membrane-api.io with VERSION=${VERSION}"
 
-          curl -X POST \
+          curl -X POST --fail --timeout 10 \
             -F token="${GITLAB_TRIGGER_TOKEN}" \
             -F ref=main \
             -F "variables[MEMBRANE_VERSION]=${VERSION}" \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow now triggers the website pipeline automatically on GitLab using the generated release version.
  * Trigger includes passing the release version and enforces a short network timeout to ensure faster feedback during releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->