### PR TITLE
Schema pipeline

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -31,7 +31,7 @@ jobs:
           VERSION='${{ steps.get_version.outputs.VERSION }}'
           echo "Updating schema URLs in YAML files to v${VERSION}.json"
 
-          find . \( -name "*.yaml" -o -name "*.yml" \) -print0 | while IFS= read -r -d '' file; do
+          find . \( -name "apis.yaml" -o -name "apis.yml" \) -print0 | while IFS= read -r -d '' file; do
             echo "Fixing $file"
             sed -i "s|\$schema=https://www\.membrane-api\.io/v[0-9\.]\+\.json|\$schema=https://www.membrane-api.io/v${VERSION}.json|g" "$file"
           done


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build workflow now automatically standardizes $schema URLs in YAML configuration files: it applies the current version number to matched schema URLs and updates URL formatting (removing the legacy www prefix) so YAML schema references stay consistent and versioned across releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->