### PR TITLE
Detect and warn about limited IP stack at startup

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/Router.java
+++ b/core/src/main/java/com/predic8/membrane/core/Router.java
@@ -44,6 +44,7 @@ import java.util.*;
 import java.util.concurrent.*;
 
 import static com.predic8.membrane.core.Constants.*;
+import static com.predic8.membrane.core.cli.util.NetStackUtil.logIfStackLimited;
 import static com.predic8.membrane.core.util.DLPUtil.*;
 import static com.predic8.membrane.core.jmx.JmxExporter.*;
 import static java.util.concurrent.Executors.*;
@@ -339,8 +340,10 @@ public class Router implements Lifecycle, ApplicationContextAware, BeanNameAware
         }
 
         ApiInfo.logInfosAboutStartedProxies(ruleManager);
-        if (!asynchronousInitialization)
+        if (!asynchronousInitialization) {
             log.info("{} {} up and running!", PRODUCT_NAME, VERSION);
+            logIfStackLimited(log);
+        }
     }
 
     private void startJmx() {
@@ -671,6 +674,7 @@ public class Router implements Lifecycle, ApplicationContextAware, BeanNameAware
             System.exit(1);
         ApiInfo.logInfosAboutStartedProxies(ruleManager);
         log.info("{} {} up and running!", PRODUCT_NAME, VERSION);
+        logIfStackLimited(log);
         setAsynchronousInitialization(false);
     }
 }

--- a/core/src/main/java/com/predic8/membrane/core/cli/RouterCLI.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/RouterCLI.java
@@ -14,31 +14,38 @@
 
 package com.predic8.membrane.core.cli;
 
-import com.predic8.membrane.core.*;
+import com.predic8.membrane.core.HttpRouter;
+import com.predic8.membrane.core.Router;
 import com.predic8.membrane.core.config.spring.TrackingFileSystemXmlApplicationContext;
-import com.predic8.membrane.core.exceptions.*;
+import com.predic8.membrane.core.exceptions.SpringConfigurationErrorHandler;
 import com.predic8.membrane.core.kubernetes.BeanCache;
-import com.predic8.membrane.core.openapi.serviceproxy.*;
-import com.predic8.membrane.core.resolver.*;
-import org.apache.commons.cli.*;
-import org.jetbrains.annotations.*;
-import org.slf4j.*;
-import org.springframework.beans.factory.xml.*;
+import com.predic8.membrane.core.openapi.serviceproxy.APIProxy;
+import com.predic8.membrane.core.openapi.serviceproxy.OpenAPISpec;
+import com.predic8.membrane.core.resolver.ResolverMap;
+import com.predic8.membrane.core.resolver.ResourceRetrievalException;
+import org.apache.commons.cli.ParseException;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionStoreException;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
 
-import static com.predic8.membrane.core.Constants.*;
+import static com.predic8.membrane.core.Constants.MEMBRANE_HOME;
 import static com.predic8.membrane.core.cli.util.JwkGenerator.generateJWK;
 import static com.predic8.membrane.core.cli.util.JwkGenerator.privateJWKtoPublic;
 import static com.predic8.membrane.core.cli.util.YamlLoader.sendYamlToBeanCache;
-import static com.predic8.membrane.core.config.spring.TrackingFileSystemXmlApplicationContext.*;
-import static com.predic8.membrane.core.openapi.serviceproxy.OpenAPISpec.YesNoOpenAPIOption.*;
+import static com.predic8.membrane.core.config.spring.TrackingFileSystemXmlApplicationContext.InvalidConfigurationException;
+import static com.predic8.membrane.core.config.spring.TrackingFileSystemXmlApplicationContext.handleXmlBeanDefinitionStoreException;
+import static com.predic8.membrane.core.openapi.serviceproxy.OpenAPISpec.YesNoOpenAPIOption.YES;
 import static com.predic8.membrane.core.openapi.util.OpenAPIUtil.isOpenAPIMisplacedError;
-import static com.predic8.membrane.core.util.ExceptionUtil.*;
-import static com.predic8.membrane.core.util.OSUtil.*;
-import static com.predic8.membrane.core.util.URIUtil.*;
-import static java.lang.Integer.*;
+import static com.predic8.membrane.core.util.ExceptionUtil.concatMessageAndCauseMessages;
+import static com.predic8.membrane.core.util.OSUtil.fixBackslashes;
+import static com.predic8.membrane.core.util.URIUtil.pathFromFileURI;
+import static java.lang.Integer.parseInt;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getMessage;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMessage;
 

--- a/core/src/main/java/com/predic8/membrane/core/cli/util/NetStackUtil.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/util/NetStackUtil.java
@@ -1,0 +1,83 @@
+package com.predic8.membrane.core.cli.util;
+
+import org.slf4j.Logger;
+
+import java.net.*;
+import java.util.Enumeration;
+
+import static com.predic8.membrane.core.cli.util.NetStackUtil.IpStack.*;
+import static com.predic8.membrane.core.cli.util.NetStackUtil.IpStack.NONE;
+
+public final class NetStackUtil {
+
+    public enum IpStack {
+        NONE,
+        IPV4_ONLY,
+        IPV6_ONLY,
+        IPV6_LINK_LOCAL_ONLY,
+        DUAL_STACK
+    }
+
+    public static void logIfStackLimited(Logger log) {
+        try {
+            switch (detectIpStack()) {
+                case IPV4_ONLY ->
+                        log.warn("Only IPv4 available. No global IPv6 addresses detected.");
+                case IPV6_ONLY ->
+                        log.warn("Only IPv6 available. No IPv4 addresses detected.");
+                case IPV6_LINK_LOCAL_ONLY ->
+                        log.warn("Only IPv6 link-local addresses detected. IPv6 not globally usable.");
+                case NONE ->
+                        log.warn("No valid IP stack detected.");
+                default -> { /* DUAL_STACK → no log */ }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to detect IP stack.", e);
+        }
+    }
+
+    private static IpStack detectIpStack() throws SocketException {
+        boolean hasIPv4 = false;
+        boolean hasIPv6Global = false;
+        boolean hasIPv6LinkLocal = false;
+
+        Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+
+        while (interfaces.hasMoreElements()) {
+            NetworkInterface ni = interfaces.nextElement();
+            if (!ni.isUp() || ni.isLoopback() || ni.isVirtual()) {
+                continue;
+            }
+
+            for (InterfaceAddress ia : ni.getInterfaceAddresses()) {
+                InetAddress addr = ia.getAddress();
+                switch (addr) {
+                    case null -> {
+                        continue;
+                    }
+                    case Inet4Address ignored -> hasIPv4 = true;
+                    case Inet6Address ignored -> {
+                        if (addr.isLinkLocalAddress()) {
+                            hasIPv6LinkLocal = true;
+                        } else {
+                            hasIPv6Global = true;
+                        }
+                    }
+                    default -> {
+                    }
+                }
+
+                if (hasIPv4 && hasIPv6Global) {
+                    return DUAL_STACK;
+                }
+            }
+        }
+
+        if (hasIPv4) return IPV4_ONLY;
+        if (hasIPv6Global) return IPV6_ONLY;
+        if (hasIPv6LinkLocal) return IPV6_LINK_LOCAL_ONLY;
+        return NONE;
+    }
+
+}
+


### PR DESCRIPTION
Add NetStackUtil to detect IPv4/IPv6/dual-stack/link-local/none network configurations and log warnings when the stack is limited. Invoke logIfStackLimited(...) during Router startup to inform users about potential networking limitations. Adjust RouterCLI imports to accommodate the new utility and related refactorings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added network stack diagnostics during startup to identify limited IPv4/IPv6 configurations and alert users to potential connectivity constraints.

* **Bug Fixes**
  * Improved configuration error messages with more specific exception handling in CLI initialization.

* **Chores**
  * Reorganized imports for improved code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->