### PR TITLE
docs: add YAML configuration guide

### DIFF
--- a/docs/JAVADOC.md
+++ b/docs/JAVADOC.md
@@ -191,4 +191,4 @@ This project uses a structured Javadoc format to document classes, methods, and 
 > The table lists custom tags used in this project. In addition, all standard Javadoc tags (such as `@param`, `@return`,
 > and `@throws`) are fully supported according to the official Javadoc specification.
 
-See e.g. [CallInterceptor](https://www.google.com/search?q=../core/src/main/java/com/predic8/membrane/core/interceptor/flow/CallInterceptor.java) for usage.
+See e.g. [CallInterceptor](../core/src/main/java/com/predic8/membrane/core/interceptor/flow/CallInterceptor.java) for usage.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded JavaDoc guidance to explicitly map annotations to both XML and YAML configuration formats.
  * Reworked formatting, examples, and tag descriptions to be format-agnostic; added YAML-specific examples and clarified nesting, ordering, and required semantics.
  * Standardized guidance on defaults, external references, and best practices for consistent, clear documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->