### PR TITLE
Restrict JAVA_OPTS path normalization to log4j.configurationFile in start_router.sh

### DIFF
--- a/distribution/scripts/start_router.sh
+++ b/distribution/scripts/start_router.sh
@@ -13,11 +13,14 @@ normalize_java_opts() {
       -D*=*)
         key=${tok%%=*}
         val=${tok#*=}
-        case "$val" in
-          /*|~/*|[A-Za-z]:/*|\\\\*|file:*|*://*) : ;;
-          *) val="$MEMBRANE_HOME/$val" ;;
-        esac
-        tok="$key=$val"
+        # Only normalize when the key is log4j.configurationFile
+        if [ "$key" = "-Dlog4j.configurationFile" ]; then
+          case "$val" in
+            /*|~/*|[A-Za-z]:/*|\\\\*|file:*|*://*) : ;;
+            *) val="$MEMBRANE_HOME/$val" ;;
+          esac
+          tok="$key=$val"
+        fi
         ;;
     esac
     NEW_OPTS="$NEW_OPTS $tok"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Java options processing during startup to limit automatic path normalization to log4j configuration files only. Other Java properties are now left unchanged, allowing proper handling of custom application settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->