### PR TITLE
Docker Image add ANSI colors in log

### DIFF
--- a/distribution/docker/log4j2.xml
+++ b/distribution/docker/log4j2.xml
@@ -2,13 +2,18 @@
 <Configuration>
     <Appenders>
         <Console name="STDOUT" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ABSOLUTE} %5p %tid %tn %c{1}:%L %X - %m%n" />
+           <!--
+           To turn off the colors in the log, set the environment variable:
+           export MEMBRANE_DISABLE_TERM_COLORS=true
+
+           Accepted values (case-insensitive): true, false
+           -->
+            <PatternLayout charset="UTF-8"
+                           disableAnsi="${sys:membrane.disable.term.colors:-false}"
+                           pattern="%d{ABSOLUTE} %highlight{%5p}{ERROR=red, WARN=yellow, INFO=cyan} %tid %tn %c{1}:%L %X - %m%n"/>
         </Console>
     </Appenders>
     <Loggers>
-<!--        <Logger name="com.predic8.membrane.core.openapi" level="debug">-->
-<!--            <AppenderRef ref="STDOUT" />-->
-<!--        </Logger>-->
         <Root level="info">
             <AppenderRef ref="STDOUT" />
         </Root>

--- a/distribution/router/conf/log4j2.xml
+++ b/distribution/router/conf/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration>
     <Appenders>
         <Console name="STDOUT" target="SYSTEM_OUT">
-            <!--
+           <!--
            To turn off the colors in the log, set the environment variable:
            export MEMBRANE_DISABLE_TERM_COLORS=true
 


### PR DESCRIPTION
… variable

- Introduced `MEMBRANE_DISABLE_TERM_COLORS` environment variable to disable ANSI colors in log output.
- Updated `log4j2.xml` configurations to support the new option and ensure UTF-8 charset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added colored log output for improved readability with distinct colors for different log levels (ERROR, WARN, INFO).
  * Added support for disabling terminal colors via environment variable configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->