### PR TITLE
Update embedding Membrane Example

### DIFF
--- a/distribution/examples/extending-membrane/embedding-java/pom.xml
+++ b/distribution/examples/extending-membrane/embedding-java/pom.xml
@@ -19,23 +19,21 @@
         </plugins>
     </build>
 
-
     <dependencies>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.5.16</version>
-        </dependency>
         <dependency>
             <groupId>org.membrane-soa</groupId>
             <artifactId>service-proxy-core</artifactId>
             <version>7.0.6-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.18.36</version>
-            <scope>provided</scope>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.25.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>2.25.3</version>
         </dependency>
     </dependencies>
 </project>

--- a/distribution/examples/extending-membrane/embedding-java/src/main/java/com/predic8/membrane/api/AddMyHeaderInterceptor.java
+++ b/distribution/examples/extending-membrane/embedding-java/src/main/java/com/predic8/membrane/api/AddMyHeaderInterceptor.java
@@ -13,24 +13,31 @@
    limitations under the License. */
 package com.predic8.membrane.api;
 
-import com.predic8.membrane.core.exchange.Exchange;
-import com.predic8.membrane.core.interceptor.AbstractInterceptor;
-import com.predic8.membrane.core.interceptor.Outcome;
-import lombok.extern.log4j.Log4j2;
-import java.lang.Override;
+import com.predic8.membrane.core.*;
+import com.predic8.membrane.core.router.*;
+import com.predic8.membrane.core.exchange.*;
+import com.predic8.membrane.core.interceptor.*;
+import org.slf4j.*;
 
 /**
  * A custom interceptor which adds the header 'X-Hello' to the HTTP request.
  *
  * @author Oliver Weiler
  */
-@Log4j2
 public class AddMyHeaderInterceptor extends AbstractInterceptor {
+
+    private static final Logger log = LoggerFactory.getLogger(AddMyHeaderInterceptor.class);
+
     @Override
     public Outcome handleRequest(Exchange exchange) {
-        log.info(exchange.getRequest().getHeader().getUserAgent());
+        // Reading an HTTP Header
+        log.info("User agent: {}",exchange.getRequest().getHeader().getUserAgent());
+
+        // Adding a HTTP Header
         exchange.getRequest().getHeader().add("X-Hello", "Hello World!");
-        log.info(exchange.getRequest());
+
+        // Logging the HTTP Request
+        log.info("Request: {}", exchange.getRequest());
         return Outcome.CONTINUE;
     }
 }

--- a/distribution/examples/extending-membrane/embedding-java/src/main/java/com/predic8/membrane/api/EmbeddingJava.java
+++ b/distribution/examples/extending-membrane/embedding-java/src/main/java/com/predic8/membrane/api/EmbeddingJava.java
@@ -13,7 +13,8 @@
    limitations under the License. */
 package com.predic8.membrane.api;
 
-import com.predic8.membrane.core.HttpRouter;
+import com.predic8.membrane.core.*;
+import com.predic8.membrane.core.router.*;
 import com.predic8.membrane.core.openapi.serviceproxy.APIProxy;
 import com.predic8.membrane.core.proxies.ServiceProxyKey;
 
@@ -42,14 +43,13 @@ public class EmbeddingJava {
 
         APIProxy api = new APIProxy();
         api.setKey(key);
-        api.setTargetHost("api.predic8.de");
-        api.setTargetPort(80);
+        api.getTarget().setUrl("https://api.predic8.de");
 
-        // Add a simple interceptor as plugin
-        api.getInterceptors().add(new AddMyHeaderInterceptor());
+        // Add a simple interceptor
+        api.getFlow().add(new AddMyHeaderInterceptor());
 
-        HttpRouter router = new HttpRouter();
+        Router router = new DefaultRouter();
         router.add(api);
-        router.init();
+        router.start();
     }
 }

--- a/distribution/examples/websockets/custom-websocket-interceptor/embedded/pom.xml
+++ b/distribution/examples/websockets/custom-websocket-interceptor/embedded/pom.xml
@@ -12,8 +12,18 @@
         <!-- https://mvnrepository.com/artifact/org.membrane-soa/membrane-service-proxy -->
         <dependency>
             <groupId>org.membrane-soa</groupId>
-            <artifactId>membrane-service-proxy</artifactId>
-            <version>5.3.6-SNAPSHOT</version>
+            <artifactId>service-proxy-core</artifactId>
+            <version>7.0.6-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.25.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>2.25.3</version>
         </dependency>
     </dependencies>
 
@@ -23,8 +33,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/distribution/examples/websockets/custom-websocket-interceptor/embedded/src/main/java/com/predic8/application/MyApplication.java
+++ b/distribution/examples/websockets/custom-websocket-interceptor/embedded/src/main/java/com/predic8/application/MyApplication.java
@@ -16,11 +16,11 @@
 
 package com.predic8.application;
 
-import com.predic8.membrane.core.HttpRouter;
 import com.predic8.membrane.core.interceptor.tunnel.WebSocketInterceptor;
 import com.predic8.membrane.core.interceptor.websocket.custom.MyWebSocketLogInterceptor;
 import com.predic8.membrane.core.proxies.ServiceProxy;
 import com.predic8.membrane.core.proxies.ServiceProxyKey;
+import com.predic8.membrane.core.*;
 
 public class MyApplication {
 
@@ -32,15 +32,15 @@ public class MyApplication {
 
         // create an enclosing WebSocket interceptor to add our own Logging interceptor to it
         WebSocketInterceptor ws = new WebSocketInterceptor();
-        ws.getInterceptors().add(new MyWebSocketLogInterceptor());
+        ws.getFlow().add(new MyWebSocketLogInterceptor());
 
         // attach the WebSocket interceptor to the service proxy
-        sp.getInterceptors().add(ws);
+        sp.getFlow().add(ws);
 
         // add the service proxy to a new router instance and start it
-        HttpRouter router = new HttpRouter();
+        Router router = new DefaultRouter();
         router.add(sp);
-        router.init();
+        router.start();
 
         System.out.println("Starting finished - Waiting for WebSocket communication");
     }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,6 +14,7 @@
 
 # 7.X
 
+- Fix maven central publish job
 - JMXExporter:
   - Tutorial
   - Documentation


### PR DESCRIPTION
…s to align with latest library versions

- Replaced `HttpRouter` with `DefaultRouter` and adjusted lifecycle methods (`start` instead of `init`).
- Updated interceptor usage to `getFlow` for improved consistency.
- Migrated dependencies to `service-proxy-core` version `7.0.6-SNAPSHOT` and switched logging to Log4j.
- Adjusted Maven plugin configurations to use Java 21.
- Added roadmap entry for Maven Central publish fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated dependencies across embedded sample projects to align with current versions
  * Increased Java compatibility to version 21 for WebSocket example
  * Refreshed logging library integrations

* **Documentation**
  * Updated roadmap with Maven publishing improvements

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->