### PR TITLE
Rename `setCertificateList` to `setCertificates`.

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/config/security/Trust.java
+++ b/core/src/main/java/com/predic8/membrane/core/config/security/Trust.java
@@ -53,7 +53,7 @@ public class Trust {
      * @param certificateList
      */
     @MCChildElement
-    public void setCertificateList(List<Certificate> certificateList) {
+    public void setCertificates(List<Certificate> certificateList) {
         this.certificateList = certificateList;
     }
 

--- a/core/src/main/java/com/predic8/membrane/core/kubernetes/client/KubernetesClientBuilder.java
+++ b/core/src/main/java/com/predic8/membrane/core/kubernetes/client/KubernetesClientBuilder.java
@@ -154,7 +154,7 @@ public class KubernetesClientBuilder {
             }
             if (ca != null) {
                 Trust trust = new Trust();
-                trust.setCertificateList(certList(ca));
+                trust.setCertificates(certList(ca));
                 sslParser.setTrust(trust);
             }
             StaticSSLContext sslContext = new StaticSSLContext(sslParser, null, null);

--- a/core/src/test/java/com/predic8/membrane/core/transport/ssl/SSLContextTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/transport/ssl/SSLContextTest.java
@@ -253,7 +253,7 @@ public class SSLContextTest {
 		Trust trust = new Trust();
 		Certificate cert = new Certificate();
 		cert.setContent(Resources.toString(getResource("ca/ca.pem"), UTF_8));
-		trust.setCertificateList(List.of(cert));
+		trust.setCertificates(List.of(cert));
 		sslParser.setTrust(trust);
 		StaticSSLContext ctx = new StaticSSLContext(sslParser, new ResolverMap(), "");
 		return ctx;

--- a/core/src/test/java/com/predic8/membrane/core/transport/ssl/acme/AcmeStepTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/transport/ssl/acme/AcmeStepTest.java
@@ -148,7 +148,7 @@ public class AcmeStepTest {
                 Trust trust = new Trust();
                 Certificate certificate = new Certificate();
                 certificate.setContent(sim.getCA().getCertificate());
-                trust.setCertificateList(ImmutableList.of(certificate));
+                trust.setCertificates(ImmutableList.of(certificate));
                 sslParser1.setTrust(trust);
                 e.setProperty(Exchange.SSL_CONTEXT, new StaticSSLContext(sslParser1, router.getResolverMap(), router.getConfiguration().getBaseLocation()));
                 hc.call(e);

--- a/core/src/test/java/com/predic8/membrane/integration/withoutinternet/interceptor/AcmeRenewTest.java
+++ b/core/src/test/java/com/predic8/membrane/integration/withoutinternet/interceptor/AcmeRenewTest.java
@@ -104,7 +104,7 @@ public class AcmeRenewTest {
                 Trust trust = new Trust();
                 Certificate certificate = new Certificate();
                 certificate.setContent(sim.getCA().getCertificate());
-                trust.setCertificateList(ImmutableList.of(certificate));
+                trust.setCertificates(ImmutableList.of(certificate));
                 sslParser1.setTrust(trust);
                 e.setProperty(SSL_CONTEXT, new StaticSSLContext(sslParser1, router.getResolverMap(), router.getConfiguration().getBaseLocation()));
                 hc.call(e);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed the Trust configuration API method from `setCertificateList()` to `setCertificates()` to improve naming clarity and consistency in the certificate handling interface. This is a breaking API change—any applications using the Trust configuration directly will need to update code that invokes the old method name to use the newly renamed method.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->