### PR TITLE
Rename `getCertificateList` to `getCertificates` to match the setter for spring.

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/config/security/Trust.java
+++ b/core/src/main/java/com/predic8/membrane/core/config/security/Trust.java
@@ -44,7 +44,7 @@ public class Trust {
         return Objects.hash(algorithm, checkRevocation, certificateList);
     }
 
-    public List<Certificate> getCertificateList() {
+    public List<Certificate> getCertificates() {
         return certificateList;
     }
 

--- a/core/src/main/java/com/predic8/membrane/core/transport/ssl/StaticSSLContext.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/ssl/StaticSSLContext.java
@@ -126,10 +126,10 @@ public class StaticSSLContext extends SSLContext {
         KeyStore trustStore = KeyStore.getInstance(PKCS_12);
         trustStore.load(null, "".toCharArray());
 
-        for (int j = 0; j < sslParser.getTrust().getCertificateList().size(); j++)
+        for (int j = 0; j < sslParser.getTrust().getCertificates().size(); j++)
             trustStore.setCertificateEntry("inlinePemCertificate" + j,
                     PEMSupport.getInstance().parseCertificate(
-                            sslParser.getTrust().getCertificateList().get(j).get(resourceResolver, baseLocation)));
+                            sslParser.getTrust().getCertificates().get(j).get(resourceResolver, baseLocation)));
         return trustStore;
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal certificate handling API naming conventions for improved consistency and clarity across the codebase.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->