### PR TITLE
add missing start scripts to JwtVerificationExample

### DIFF
--- a/distribution/examples/security/jwt/verification/membrane.cmd
+++ b/distribution/examples/security/jwt/verification/membrane.cmd
@@ -1,0 +1,24 @@
+@echo off
+setlocal EnableExtensions
+
+set "SCRIPT_DIR=%~dp0"
+if "%SCRIPT_DIR:~-1%"=="\" set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
+
+set "dir=%SCRIPT_DIR%"
+
+:search_up
+if exist "%dir%\LICENSE.txt" if exist "%dir%\scripts\run-membrane.cmd" goto found
+for %%A in ("%dir%\..") do set "next=%%~fA"
+if /I "%next%"=="%dir%" goto notfound
+set "dir=%next%"
+goto search_up
+
+:found
+set "MEMBRANE_HOME=%dir%"
+set "MEMBRANE_CALLER_DIR=%SCRIPT_DIR%"
+call "%MEMBRANE_HOME%\scripts\run-membrane.cmd" %*
+exit /b %ERRORLEVEL%
+
+:notfound
+>&2 echo Could not locate Membrane root. Ensure directory structure is correct.
+exit /b 1

--- a/distribution/examples/security/jwt/verification/membrane.sh
+++ b/distribution/examples/security/jwt/verification/membrane.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Default: ./proxies.xml (next to this script); fallback -> $MEMBRANE_HOME/conf/proxies.xml
+# JAVA_OPTS: relative -D paths are auto-resolved against $MEMBRANE_HOME (absolute/URI unchanged).
+# Examples:
+#   export JAVA_OPTS='-Dlog4j.configurationFile=examples/logging/access/log4j2_access.xml'
+#   export JAVA_OPTS='-Dlog4j.configurationFile=/abs/path/log4j2.xml'
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+
+dir="$SCRIPT_DIR"
+while [ "$dir" != "/" ]; do
+  if [ -f "$dir/LICENSE.txt" ] && [ -f "$dir/scripts/run-membrane.sh" ]; then
+    export MEMBRANE_HOME="$dir"
+    export MEMBRANE_CALLER_DIR="$SCRIPT_DIR"
+    exec sh "$dir/scripts/run-membrane.sh" "$@"
+  fi
+  dir=$(dirname "$dir")
+done
+
+echo "Could not locate Membrane root. Ensure directory structure is correct." >&2
+exit 1

--- a/distribution/src/test/java/com/predic8/membrane/examples/withoutinternet/JwtVerificationExampleTest.java
+++ b/distribution/src/test/java/com/predic8/membrane/examples/withoutinternet/JwtVerificationExampleTest.java
@@ -14,15 +14,10 @@
 
 package com.predic8.membrane.examples.withoutinternet;
 
-import com.predic8.membrane.core.http.Header;
 import com.predic8.membrane.examples.util.AbstractSampleMembraneStartStopTestcase;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import static io.restassured.RestAssured.given;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JwtVerificationExampleTest extends AbstractSampleMembraneStartStopTestcase {
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows and Unix/Linux launch scripts for JWT verification examples that automatically detect the Membrane installation root and execute with argument passthrough.

* **Tests**
  * Removed unused imports from test code.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->