### PR TITLE
Ensure unread bodies in request and response are discarded before reassigning.

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/exchange/AbstractExchange.java
+++ b/core/src/main/java/com/predic8/membrane/core/exchange/AbstractExchange.java
@@ -109,7 +109,7 @@ public abstract class AbstractExchange {
 
 	public void setRequest(Request request) {
 
-		if (this.request != null) request.discardBody(); // prevent old bodies to remain unread
+		if (this.request != null) this.request.discardBody(); // Drain the previous message body to avoid unread bytes on keep-alive connections.
 
 		this.request = request;
 		if (this.request != null) {
@@ -127,7 +127,7 @@ public abstract class AbstractExchange {
 
 	public void setResponse(Response res) {
 
-		if (response != null) response.discardBody(); // prevent old bodies to remain unread
+		if (response != null) response.discardBody(); // Drain the previous message body to avoid unread bytes on keep-alive connections.
 
 		response = res;
 		if (response != null) {

--- a/core/src/test/java/com/predic8/membrane/core/exchange/AbstractExchangeTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/exchange/AbstractExchangeTest.java
@@ -1,0 +1,59 @@
+package com.predic8.membrane.core.exchange;
+
+import com.predic8.membrane.core.http.Body;
+import com.predic8.membrane.core.http.Message;
+import com.predic8.membrane.core.http.Request;
+import com.predic8.membrane.core.http.Response;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AbstractExchangeTest {
+
+    private static Body body(String s) {
+        return new Body(new ByteArrayInputStream(s.getBytes()), s.getBytes().length);
+    }
+
+    private static <M extends Message> void assertOldBodyDrainedOnReplace(Function<Body, M> msgFactory, BiConsumer<Exchange, M> setter) {
+        Exchange exc = new Exchange(null);
+
+        Body oldBody = body("old");
+        M m1 = msgFactory.apply(oldBody);
+        setter.accept(exc, m1);
+
+        assertFalse(oldBody.isRead());
+
+        Body newBody = body("new");
+        M m2 = msgFactory.apply(newBody);
+        setter.accept(exc, m2);
+
+        assertTrue(oldBody.isRead(), "old body must be read/drained when message is replaced");
+    }
+
+    @Test
+    void setResponse_readsOldBodyOnReplace() {
+        assertOldBodyDrainedOnReplace(
+                b -> {
+                    Response r = Response.ok().build();
+                    r.setBody(b);
+                    return r;
+                },
+                Exchange::setResponse
+        );
+    }
+
+    @Test
+    void setRequest_readsOldBodyOnReplace() {
+        assertOldBodyDrainedOnReplace(
+                b -> new Request() {{setBody(b);}},
+                Exchange::setRequest
+        );
+    }
+
+
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when replacing requests or responses so unread message bodies are drained, preventing leftover bytes on persistent connections and improving stability.
* **Tests**
  * Added unit tests that verify old message bodies are properly drained when requests or responses are replaced.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->