### PR TITLE
add migration guide for 7.1

### DIFF
--- a/docs/MIGRATION-GUIDE.md
+++ b/docs/MIGRATION-GUIDE.md
@@ -207,3 +207,88 @@ Default naming scheme for `<serviceProxys>` has changed. This might affect exist
 ## `jwtSign`
 - `expiryTime` has been renamed to `expirySeconds`. 
 - HTTP response in case of JWT validation failure was changed to Problem JSON.
+
+# Migrate to Membrane 7.1
+
+## New Yaml Syntax
+
+### `headerFilter`
+Instead of 
+```yaml
+headerFilter:
+  rules:
+    - include:
+        pattern: "X-XSS-Protection"
+    - exclude:
+        pattern: "X-.*"
+```
+use
+```yaml
+headerFilter:
+  rules:
+    - include: "X-XSS-Protection"
+    - exclude: "X-.*"
+```
+
+### `chain`
+
+The `chainDef` no longer exists. Use `chain` to define a chain of plugins and simply reference them as all other components.
+
+instead of 
+```yaml
+components:
+  log:
+    chainDef:
+      flow:
+         - log:
+             message: "Path: ${path}"
+---
+api:
+  port: 2000
+  flow:
+    - chain:
+        ref: '#/components/log'
+```
+use 
+```yaml
+components:
+  log:
+    chain:
+      flow:
+        - log:
+            message: "Path: ${path}"
+---
+api:
+  port: 2000
+  flow:
+    - $ref: '#/components/log'
+```
+
+- `groovy` interceptor: Return string from script does not set a content type of `text/html` anymore. User has to set the content type manually.
+
+- Choose Interceptor configuration
+- Chain (ChainDef) configuration
+- OpenApi: rename `specs` to `openapi`
+- **YAML configuration in list elements**:
+  * List items can now be written in *inline form* if the list accepts exactly one concrete element type (no polymorphic candidates) and the element is not `collapsed`, not `noEnvelope`, and not string-like.
+  * Old wrapper form remains supported: `- <kind>: { ... }` (Only when schema validation is deactivated).
+
+  Old:
+     ```yaml
+      properties:
+        - property:
+            name: driverClassName
+            value: org.h2.Driver
+        - property:
+            name: url
+            value: jdbc:h2:./membranedb;AUTO_SERVER=TRUE
+  ```
+  New:
+    ```yaml
+      properties:
+        - name: driverClassName
+          value: org.h2.Driver
+        - name: url
+          value: jdbc:h2:./membranedb;AUTO_SERVER=TRUE
+  ```
+- removed `MethodOverrideInterceptor`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive migration guide for Membrane 7.1 with new YAML syntax and examples
  * Updated jwtSign configuration: `expiryTime` renamed to `expirySeconds`
  * Revised chain and headerFilter configuration patterns with new inline syntax support
  * Noted MethodOverrideInterceptor removal
  * Included before/after YAML examples for configuration migration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->