### PR TITLE
Add `-it` flag to Docker container creation in tutorial scripts

### DIFF
--- a/distribution/tutorials/advanced/run-docker.sh
+++ b/distribution/tutorials/advanced/run-docker.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
-cid="$(docker create -p 2000-2010:2000-2010 predic8/membrane:7.0 "$@")"
+cid="$(docker create -it -p 2000-2010:2000-2010 predic8/membrane:7.0 "$@")"
 
 cleanup() {
   docker rm -f "$cid" >/dev/null 2>&1 || true

--- a/distribution/tutorials/getting-started/run-docker.sh
+++ b/distribution/tutorials/getting-started/run-docker.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
-cid="$(docker create -p 2000-2010:2000-2010 predic8/membrane:7.0 "$@")"
+cid="$(docker create -it -p 2000-2010:2000-2010 predic8/membrane:7.0 "$@")"
 
 cleanup() {
   docker rm -f "$cid" >/dev/null 2>&1 || true

--- a/distribution/tutorials/json/run-docker.sh
+++ b/distribution/tutorials/json/run-docker.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
-cid="$(docker create -p 2000-2010:2000-2010 predic8/membrane:7.0 "$@")"
+cid="$(docker create -it -p 2000-2010:2000-2010 predic8/membrane:7.0 "$@")"
 
 cleanup() {
   docker rm -f "$cid" >/dev/null 2>&1 || true

--- a/distribution/tutorials/orchestration/run-docker.sh
+++ b/distribution/tutorials/orchestration/run-docker.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
-cid="$(docker create -p 2000-2010:2000-2010 predic8/membrane:7.0 "$@")"
+cid="$(docker create -it -p 2000-2010:2000-2010 predic8/membrane:7.0 "$@")"
 
 cleanup() {
   docker rm -f "$cid" >/dev/null 2>&1 || true

--- a/distribution/tutorials/security/run-docker.sh
+++ b/distribution/tutorials/security/run-docker.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
-cid="$(docker create -p 2000-2010:2000-2010 predic8/membrane:7.0 "$@")"
+cid="$(docker create -it -p 2000-2010:2000-2010 predic8/membrane:7.0 "$@")"
 
 cleanup() {
   docker rm -f "$cid" >/dev/null 2>&1 || true

--- a/distribution/tutorials/soap/run-docker.sh
+++ b/distribution/tutorials/soap/run-docker.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
-cid="$(docker create -p 2000-2010:2000-2010 predic8/membrane:7.0 "$@")"
+cid="$(docker create -it -p 2000-2010:2000-2010 predic8/membrane:7.0 "$@")"
 
 cleanup() {
   docker rm -f "$cid" >/dev/null 2>&1 || true

--- a/distribution/tutorials/transformation/run-docker.sh
+++ b/distribution/tutorials/transformation/run-docker.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
-cid="$(docker create -p 2000-2010:2000-2010 predic8/membrane:7.0 "$@")"
+cid="$(docker create -it -p 2000-2010:2000-2010 predic8/membrane:7.0 "$@")"
 
 cleanup() {
   docker rm -f "$cid" >/dev/null 2>&1 || true

--- a/distribution/tutorials/xml/run-docker.sh
+++ b/distribution/tutorials/xml/run-docker.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
-cid="$(docker create -p 2000-2010:2000-2010 predic8/membrane:7.0 "$@")"
+cid="$(docker create -it -p 2000-2010:2000-2010 predic8/membrane:7.0 "$@")"
 
 cleanup() {
   docker rm -f "$cid" >/dev/null 2>&1 || true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Docker containers created from tutorial scripts now run in interactive mode with pseudo-TTY allocation enabled, providing a better user experience when executing tutorials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->