### PR TITLE
Add element id to json schema

### DIFF
--- a/annot/src/main/java/com/predic8/membrane/annot/generator/JsonSchemaGenerator.java
+++ b/annot/src/main/java/com/predic8/membrane/annot/generator/JsonSchemaGenerator.java
@@ -134,7 +134,7 @@ public class JsonSchemaGenerator extends AbstractGrammar {
         String id = elementInfo.getId();
         if (id == null || id.isBlank()) return schema;
 
-        ((AbstractSchema) schema).elementId(id);
+        ((AbstractSchema) schema).id(id);
         return schema;
     }
 

--- a/annot/src/main/java/com/predic8/membrane/annot/generator/kubernetes/model/AbstractSchema.java
+++ b/annot/src/main/java/com/predic8/membrane/annot/generator/kubernetes/model/AbstractSchema.java
@@ -25,7 +25,7 @@ public abstract class AbstractSchema<T extends AbstractSchema<T>> implements ISc
 
     protected String title;
     protected String name;
-    protected String elementId;
+    protected String id;
     protected String type;
     protected String description;
     protected List<String> typeList;
@@ -77,8 +77,8 @@ public abstract class AbstractSchema<T extends AbstractSchema<T>> implements ISc
         return self();
     }
 
-    public T elementId(String id) {
-        this.elementId = id;
+    public T id(String id) {
+        this.id = id;
         return self();
     }
 
@@ -110,8 +110,8 @@ public abstract class AbstractSchema<T extends AbstractSchema<T>> implements ISc
             node.put("type", type);
         }
 
-        if (elementId != null && !elementId.isBlank()) {
-            node.put("x-element-id", elementId);
+        if (id != null && !id.isBlank()) {
+            node.put("id", id);
         }
 
         return node;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSON schemas now include an optional "id" metadata field when provided, enabling stronger element identification.

* **Refactor**
  * Centralized and simplified schema generation flow; tagging of element IDs is now applied in a single, guarded step to reduce duplicate returns and streamline output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->