### PR TITLE
Update SOAP Fault transformation to use namespace references

### DIFF
--- a/distribution/tutorials/transformation/80-SOAP-Fault-Groovy.yaml
+++ b/distribution/tutorials/transformation/80-SOAP-Fault-Groovy.yaml
@@ -11,6 +11,14 @@
 #    curl -v -H "Content-Type: application/json" -d @plum.json http://localhost:2000/products
 #    curl -v -H "Content-Type: application/json" -d @plum.json http://localhost:2000/products -H "X-Mock-Mode: fault"
 
+components:
+  ns:
+    xmlConfig:
+      namespaces:
+        - prefix: s11
+          uri: http://schemas.xmlsoap.org/soap/envelope/
+
+---
 api:
   name: Products API
   port: 2000
@@ -22,8 +30,9 @@ api:
           location: json-to-soap-request.groovy
     - response:
         - if:
-            test: //*[local-name()='Fault']
+            test: //s11:Fault
             language: XPath
+            $ref: "#/components/ns"
             flow:
               - groovy:
                   location: soap-fault-to-json.groovy


### PR DESCRIPTION
- Added explicit namespace handling (`s11`) for SOAP Fault detection in XPath expressions.
- Introduced a shared `$ref` to include namespace configuration in the YAML tutorial.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SOAP fault detection to properly recognize faults with namespace prefixes in API responses, improving compatibility with namespaced SOAP messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->