### PR TITLE
supress stacktrace when `ExitException` is thrown

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/cli/RouterCLI.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/RouterCLI.java
@@ -176,12 +176,13 @@ public class RouterCLI {
         } catch (ConfigurationParsingException e) {
             // Keep with one param to log otherwise first color code will be ignored!
             try {
-                log.error("{}", "%s%s%s\n%s".formatted(RED(),e.getMessage(), RESET(),e.getFormattedReport()));
+                log.error("{}", "%s%s%s\n%s".formatted(RED(), e.getMessage(), RESET(), e.getFormattedReport()));
             } catch (JsonProcessingException ex) {
                 throw new RuntimeException(ex);
             }
-        }
-        catch (Exception ex) {
+        } catch (ExitException ignored) {
+            // do nothing
+        } catch (Exception ex) {
             SpringConfigurationErrorHandler.handleRootCause(ex, log);
         }
         System.exit(1);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message formatting in the CLI router, with better spacing for exception logs and reports.
  * Enhanced exception handling to properly distinguish between different error types during CLI operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->