### PR TITLE
annot: flag @Mc* setters which have a non-void return type as an error #2862

### DIFF
--- a/annot/src/main/java/com/predic8/membrane/annot/SpringConfigurationXSDGeneratingAnnotationProcessor.java
+++ b/annot/src/main/java/com/predic8/membrane/annot/SpringConfigurationXSDGeneratingAnnotationProcessor.java
@@ -461,6 +461,7 @@ public class SpringConfigurationXSDGeneratingAnnotationProcessor extends Abstrac
             scan(main, ii, (TypeElement) ((DeclaredType) superclass).asElement());
 
         for (Element e2 : te.getEnclosedElements()) {
+            validateMcSetterReturnType(e2);
             MCAttribute a = e2.getAnnotation(MCAttribute.class);
             if (a != null) {
                 AttributeInfo ai = new AttributeInfo();
@@ -528,6 +529,28 @@ public class SpringConfigurationXSDGeneratingAnnotationProcessor extends Abstrac
                 throw new ProcessingException("@MCChildElement(order=...) must be unique.", cei.getE());
         }
         Collections.sort(ii.getChildElementSpecs());
+    }
+
+    private void validateMcSetterReturnType(Element e2) {
+        if (!(e2 instanceof ExecutableElement executableElement))
+            return;
+        String annotationName = getMcSetterAnnotationName(e2);
+        if (annotationName == null)
+            return;
+        if (executableElement.getReturnType().getKind() != TypeKind.VOID)
+            throw new ProcessingException("Setter annotated with @" + annotationName + " must return void.", e2);
+    }
+
+    private String getMcSetterAnnotationName(Element e2) {
+        if (e2.getAnnotation(MCAttribute.class) != null)
+            return "MCAttribute";
+        if (e2.getAnnotation(MCChildElement.class) != null)
+            return "MCChildElement";
+        if (e2.getAnnotation(MCTextContent.class) != null)
+            return "MCTextContent";
+        if (e2.getAnnotation(MCOtherAttributes.class) != null)
+            return "MCOtherAttributes";
+        return null;
     }
 
     private boolean isRequired(Element e2) {

--- a/annot/src/test/java/com/predic8/membrane/annot/SpringConfigXSDErrorsTest.java
+++ b/annot/src/test/java/com/predic8/membrane/annot/SpringConfigXSDErrorsTest.java
@@ -355,4 +355,22 @@ public class SpringConfigXSDErrorsTest {
         ), result);
     }
 
+    @Test
+    public void mcSetterMustReturnVoid() {
+        var sources = splitSources(MC_MAIN_DEMO + """
+        package com.predic8.membrane.demo;
+        import com.predic8.membrane.annot.*;
+        @MCElement(name="demo")
+        public class DemoElement {
+            @MCAttribute
+            public String setName(String name) { return name; }
+        }
+        """);
+        var result = CompilerHelper.compile(sources, false);
+
+        assertCompilerResult(false, of(
+                error("Setter annotated with @MCAttribute must return void.")
+        ), result);
+    }
+
 }

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/jwt/HeaderJwtRetriever.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/jwt/HeaderJwtRetriever.java
@@ -51,9 +51,8 @@ public class HeaderJwtRetriever implements JwtRetriever{
 
     @Required
     @MCAttribute
-    public HeaderJwtRetriever setHeader(String header) {
+    public void setHeader(String header) {
         this.header = header;
-        return this;
     }
 
     public String getRemoveFromValue() {
@@ -61,8 +60,7 @@ public class HeaderJwtRetriever implements JwtRetriever{
     }
 
     @MCAttribute
-    public HeaderJwtRetriever setRemoveFromValue(String removeFromValue) {
+    public void setRemoveFromValue(String removeFromValue) {
         this.removeFromValue = removeFromValue;
-        return this;
     }
 }

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/jwt/Jwks.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/jwt/Jwks.java
@@ -100,13 +100,12 @@ public class Jwks {
     }
 
     @MCChildElement
-    public Jwks setJwks(List<Jwk> jwks) {
+    public void setJwks(List<Jwk> jwks) {
         if (router != null) {  // set in init, so we can't update prior to that call
             if (jwks == null) throw new ConfigurationException("JWKs list must not be null.");
             this.keysByKid = buildKeyMap(jwks);
         }
         this.jwks = (jwks == null) ? emptyList() : jwks;  // unnecessary, mainly for consistency when debugging
-        return this;
     }
 
     public String getJwksUris() {
@@ -232,9 +231,8 @@ public class Jwks {
         }
 
         @MCAttribute
-        public Jwk setKid(String kid) {
+        public void setKid(String kid) {
             this.kid = kid;
-            return this;
         }
 
         /**

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/jwt/JwtAuthInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/jwt/JwtAuthInterceptor.java
@@ -197,9 +197,8 @@ public class JwtAuthInterceptor extends AbstractInterceptor {
      * <p>Use "any!!" to allow any audience value. This is strongly discouraged.</p>
      */
     @MCAttribute
-    public JwtAuthInterceptor setExpectedAud(String expectedAud) {
+    public void setExpectedAud(String expectedAud) {
         this.expectedAud = expectedAud;
-        return this;
     }
 
     /**
@@ -209,9 +208,8 @@ public class JwtAuthInterceptor extends AbstractInterceptor {
      * @example 67c869d3-0cd4-4a99-86db-088bed1a9601
      */
     @MCAttribute
-    public JwtAuthInterceptor setExpectedTid(String expectedTid) {
+    public void setExpectedTid(String expectedTid) {
         this.expectedTid = expectedTid;
-        return this;
     }
 
     @Override

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/ntlm/NtlmInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/ntlm/NtlmInterceptor.java
@@ -156,9 +156,8 @@ public class NtlmInterceptor extends AbstractInterceptor {
     }
 
     @MCChildElement(order = 1)
-    public NtlmInterceptor setNTLMRetriever(NTLMRetriever NTLMRetriever) {
+    public void setNTLMRetriever(NTLMRetriever NTLMRetriever) {
         this.NTLMRetriever = NTLMRetriever;
-        return this;
     }
 
     public NTLMRetriever getNTLMRetriever() {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/session/SessionManager.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/session/SessionManager.java
@@ -437,9 +437,8 @@ public abstract class SessionManager {
      * @default false
      */
     @MCAttribute
-    public SessionManager setSecure(boolean secure) {
+    public void setSecure(boolean secure) {
         this.secure = secure;
-        return this;
     }
 
     public boolean isSessionCookie() {
@@ -451,9 +450,8 @@ public abstract class SessionManager {
      * @default false
      */
     @MCAttribute
-    public SessionManager setSessionCookie(boolean sessionCookie) {
+    public void setSessionCookie(boolean sessionCookie) {
         this.sessionCookie = sessionCookie;
-        return this;
     }
 
     protected String getKeyOfCookie(String validCookie) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Setter methods across interceptor classes now return void instead of instance references, eliminating fluent chaining support.
  * Added compile-time validation for annotated setters to enforce void return types.

* **Tests**
  * Added test case validating annotated setter return type requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->