### PR TITLE
OpenAPI-Validator: Split request and response validation

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/openapi/OpenAPIValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/OpenAPIValidator.java
@@ -24,7 +24,6 @@ import com.predic8.membrane.core.openapi.util.MethodNotAllowException;
 import com.predic8.membrane.core.openapi.util.PathDoesNotMatchException;
 import com.predic8.membrane.core.openapi.util.UriUtil;
 import com.predic8.membrane.core.openapi.validators.OperationValidator;
-import com.predic8.membrane.core.openapi.validators.PathParametersValidator;
 import com.predic8.membrane.core.openapi.validators.ValidationContext;
 import com.predic8.membrane.core.openapi.validators.ValidationErrors;
 import com.predic8.membrane.core.util.ConfigurationException;
@@ -38,8 +37,10 @@ import java.net.URISyntaxException;
 import java.util.Map;
 
 import static com.predic8.membrane.core.openapi.util.UriUtil.normalizeUri;
+import static com.predic8.membrane.core.openapi.validators.OperationValidator.resolve;
 import static com.predic8.membrane.core.openapi.validators.ValidationContext.ValidatedEntityType.METHOD;
 import static com.predic8.membrane.core.openapi.validators.ValidationContext.ValidatedEntityType.PATH;
+import static com.predic8.membrane.core.openapi.validators.ValidationContext.fromRequest;
 import static java.lang.String.format;
 
 public class OpenAPIValidator {
@@ -79,54 +80,82 @@ public class OpenAPIValidator {
     }
 
     public ValidationErrors validate(Request<? extends Body> request) {
-        return validateMessage(request, null);
+        return prepareValidation(request).validateRequest(request);
     }
 
     public ValidationErrors validateResponse(Request<? extends Body> request, Response<? extends Body> response) {
-        return validateMessage(request, response);
+        return prepareValidation(request).validateResponse(response);
     }
 
-    private ValidationErrors validateMessage(Request<? extends Body> req, Response<? extends Body> res) {
-
+    public ValidationPlan prepareValidation(Request<? extends Body> request) {
         for (Map.Entry<String, PathItem> path : rec.getApi().getPaths().entrySet()) {
             try {
-                return validateMethodsAndParametersIfPathMatches(req, res, path.getKey(), path.getValue());
+                return prepareValidationForMatchingPath(request, path.getKey(), path.getValue());
             } catch (PathDoesNotMatchException ignored) {
                 // All paths from the OpenAPI that do not match will cause an exception while parsing the path and parameter. Then the next uriTemplate
                 // is tried until we get a match or there is no matching path in the OpenAPI.
             }
         }
 
-        return ValidationErrors.error( ValidationContext.fromRequest(req)
-                .entity(req.getPath())
+        return ValidationPlan.error(ValidationErrors.error(fromRequest(request)
+                .entity(request.getPath())
                 .entityType(PATH)
-                .statusCode(404), format("Path %s is invalid.", req.getPath()));
+                .statusCode(404), format("Path %s is invalid.", request.getPath())));
     }
 
-    private ValidationErrors validateMethodsAndParametersIfPathMatches(Request<? extends Body> req, Response<? extends Body> response, String uriTemplate, PathItem pathItem) throws PathDoesNotMatchException {
+    private ValidationPlan prepareValidationForMatchingPath(Request<? extends Body> request, String uriTemplate, PathItem pathItem) throws PathDoesNotMatchException {
+        String pathTemplate = normalizeUri(basePath + uriTemplate);
+        request.parsePathParameters(pathTemplate);
 
-        // Throws exception if path or parameters do not match
-        req.parsePathParameters(normalizeUri(basePath + uriTemplate));
-
-        var ctx = ValidationContext.fromRequest(req);
-
-        var errors = validateMethods(ctx.uriTemplate(uriTemplate), req, response, pathItem);
-
-        // If there is no response it is a request by logic, so we validate the request parameters
-        if (response == null) {
-            errors.add(new PathParametersValidator(rec.getApi()).validatePathParameters(ctx.uriTemplate(uriTemplate), req, pathItem.getParameters()));
-        }
-        return errors;
-    }
-
-    private ValidationErrors validateMethods(ValidationContext ctx, Request<? extends Body> req, Response<? extends Body> response, PathItem pathItem) {
-        var errors = new ValidationErrors();
+        var ctx = fromRequest(request).uriTemplate(uriTemplate);
         try {
-            return errors.add(new OperationValidator(rec.getApi()).validateOperation(ctx, req, response, pathItem));
+            return ValidationPlan.resolved(pathTemplate, ctx, resolve(rec.getApi(), request.getMethod(), pathItem));
         } catch (MethodNotAllowException e) {
-            return errors.add(ctx.statusCode(405)
-                    .entity(req.getMethod())
-                    .entityType(METHOD), format("Method %s is not allowed", req.getMethod()));
+            return ValidationPlan.error(ValidationErrors.error(ctx.statusCode(405)
+                    .entity(request.getMethod())
+                    .entityType(METHOD), format("Method %s is not allowed", request.getMethod())));
+        }
+    }
+
+    public static final class ValidationPlan {
+
+        private final String pathTemplate;
+        private final ValidationContext ctx;
+        private final OperationValidator operationValidator;
+        private final ValidationErrors operationErrors;
+
+        private ValidationPlan(String pathTemplate, ValidationContext ctx, OperationValidator operationValidator, ValidationErrors operationErrors) {
+            this.pathTemplate = pathTemplate;
+            this.ctx = ctx;
+            this.operationValidator = operationValidator;
+            this.operationErrors = operationErrors;
+        }
+
+        private static ValidationPlan resolved(String pathTemplate, ValidationContext ctx, OperationValidator operationValidator) {
+            return new ValidationPlan(pathTemplate, ctx, operationValidator, ValidationErrors.empty());
+        }
+
+        private static ValidationPlan error(ValidationErrors errors) {
+            return new ValidationPlan(null, null, null, errors);
+        }
+
+        public ValidationErrors validateRequest(Request<? extends Body> request) {
+            if (operationErrors.hasErrors())
+                return operationErrors;
+
+            try {
+                request.parsePathParameters(pathTemplate);
+            } catch (PathDoesNotMatchException e) {
+                throw new IllegalStateException("ValidationPlan no longer matches request path %s.".formatted(request.getPath()), e);
+            }
+
+            return operationValidator.validateRequest(ctx, request);
+        }
+
+        public ValidationErrors validateResponse(Response<? extends Body> response) {
+            if (operationErrors.hasErrors())
+                return operationErrors;
+            return operationValidator.validateResponse(ctx, response);
         }
     }
 

--- a/core/src/main/java/com/predic8/membrane/core/openapi/OpenAPIValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/OpenAPIValidator.java
@@ -16,20 +16,31 @@
 
 package com.predic8.membrane.core.openapi;
 
-import com.predic8.membrane.core.openapi.model.*;
-import com.predic8.membrane.core.openapi.serviceproxy.*;
-import com.predic8.membrane.core.openapi.util.*;
-import com.predic8.membrane.core.openapi.validators.*;
-import com.predic8.membrane.core.util.*;
-import io.swagger.v3.oas.models.*;
-import org.slf4j.*;
+import com.predic8.membrane.core.openapi.model.Body;
+import com.predic8.membrane.core.openapi.model.Request;
+import com.predic8.membrane.core.openapi.model.Response;
+import com.predic8.membrane.core.openapi.serviceproxy.OpenAPIRecord;
+import com.predic8.membrane.core.openapi.util.MethodNotAllowException;
+import com.predic8.membrane.core.openapi.util.PathDoesNotMatchException;
+import com.predic8.membrane.core.openapi.util.UriUtil;
+import com.predic8.membrane.core.openapi.validators.OperationValidator;
+import com.predic8.membrane.core.openapi.validators.PathParametersValidator;
+import com.predic8.membrane.core.openapi.validators.ValidationContext;
+import com.predic8.membrane.core.openapi.validators.ValidationErrors;
+import com.predic8.membrane.core.util.ConfigurationException;
+import com.predic8.membrane.core.util.URIFactory;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.PathItem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.net.*;
-import java.util.*;
+import java.net.URISyntaxException;
+import java.util.Map;
 
-import static com.predic8.membrane.core.openapi.util.UriUtil.*;
-import static com.predic8.membrane.core.openapi.validators.ValidationContext.ValidatedEntityType.*;
-import static java.lang.String.*;
+import static com.predic8.membrane.core.openapi.util.UriUtil.normalizeUri;
+import static com.predic8.membrane.core.openapi.validators.ValidationContext.ValidatedEntityType.METHOD;
+import static com.predic8.membrane.core.openapi.validators.ValidationContext.ValidatedEntityType.PATH;
+import static java.lang.String.format;
 
 public class OpenAPIValidator {
 
@@ -97,9 +108,9 @@ public class OpenAPIValidator {
         // Throws exception if path or parameters do not match
         req.parsePathParameters(normalizeUri(basePath + uriTemplate));
 
-        ValidationContext ctx = ValidationContext.fromRequest(req);
+        var ctx = ValidationContext.fromRequest(req);
 
-        ValidationErrors errors = validateMethods(ctx.uriTemplate(uriTemplate), req, response, pathItem);
+        var errors = validateMethods(ctx.uriTemplate(uriTemplate), req, response, pathItem);
 
         // If there is no response it is a request by logic, so we validate the request parameters
         if (response == null) {
@@ -109,7 +120,7 @@ public class OpenAPIValidator {
     }
 
     private ValidationErrors validateMethods(ValidationContext ctx, Request<? extends Body> req, Response<? extends Body> response, PathItem pathItem) {
-        ValidationErrors errors = new ValidationErrors();
+        var errors = new ValidationErrors();
         try {
             return errors.add(new OperationValidator(rec.getApi()).validateOperation(ctx, req, response, pathItem));
         } catch (MethodNotAllowException e) {

--- a/core/src/main/java/com/predic8/membrane/core/openapi/OpenAPIValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/OpenAPIValidator.java
@@ -37,7 +37,6 @@ import java.net.URISyntaxException;
 import java.util.Map;
 
 import static com.predic8.membrane.core.openapi.util.UriUtil.normalizeUri;
-import static com.predic8.membrane.core.openapi.validators.OperationValidator.resolve;
 import static com.predic8.membrane.core.openapi.validators.ValidationContext.ValidatedEntityType.METHOD;
 import static com.predic8.membrane.core.openapi.validators.ValidationContext.ValidatedEntityType.PATH;
 import static com.predic8.membrane.core.openapi.validators.ValidationContext.fromRequest;
@@ -87,6 +86,12 @@ public class OpenAPIValidator {
         return prepareValidation(request).validateResponse(response);
     }
 
+    /**
+     * Prepares a plan to later use it for request or response validation separately.
+     * Must be called for both request and response validation. If there is response but no
+     * request validation the operation must be found first in order to validate against the
+     * proper operation.
+     */
     public ValidationPlan prepareValidation(Request<? extends Body> request) {
         for (Map.Entry<String, PathItem> path : rec.getApi().getPaths().entrySet()) {
             try {
@@ -109,7 +114,7 @@ public class OpenAPIValidator {
 
         var ctx = fromRequest(request).uriTemplate(uriTemplate);
         try {
-            return ValidationPlan.resolved(pathTemplate, ctx, resolve(rec.getApi(), request.getMethod(), pathItem));
+            return ValidationPlan.create(pathTemplate, ctx, OperationValidator.create(rec.getApi(), request.getMethod(), pathItem));
         } catch (MethodNotAllowException e) {
             return ValidationPlan.error(ValidationErrors.error(ctx.statusCode(405)
                     .entity(request.getMethod())
@@ -121,17 +126,21 @@ public class OpenAPIValidator {
 
         private final String pathTemplate;
         private final ValidationContext ctx;
-        private final OperationValidator operationValidator;
-        private final ValidationErrors operationErrors;
+        private final OperationValidator validator;
 
-        private ValidationPlan(String pathTemplate, ValidationContext ctx, OperationValidator operationValidator, ValidationErrors operationErrors) {
+        /**
+         * TODO Explain
+         */
+        private final ValidationErrors errors;
+
+        private ValidationPlan(String pathTemplate, ValidationContext ctx, OperationValidator validator, ValidationErrors errors) {
             this.pathTemplate = pathTemplate;
             this.ctx = ctx;
-            this.operationValidator = operationValidator;
-            this.operationErrors = operationErrors;
+            this.validator = validator;
+            this.errors = errors;
         }
 
-        private static ValidationPlan resolved(String pathTemplate, ValidationContext ctx, OperationValidator operationValidator) {
+        private static ValidationPlan create(String pathTemplate, ValidationContext ctx, OperationValidator operationValidator) {
             return new ValidationPlan(pathTemplate, ctx, operationValidator, ValidationErrors.empty());
         }
 
@@ -140,8 +149,9 @@ public class OpenAPIValidator {
         }
 
         public ValidationErrors validateRequest(Request<? extends Body> request) {
-            if (operationErrors.hasErrors())
-                return operationErrors;
+            // There might be already path and method validation errors.
+            if (errors.hasErrors())
+                return errors;
 
             try {
                 request.parsePathParameters(pathTemplate);
@@ -149,13 +159,14 @@ public class OpenAPIValidator {
                 throw new IllegalStateException("ValidationPlan no longer matches request path %s.".formatted(request.getPath()), e);
             }
 
-            return operationValidator.validateRequest(ctx, request);
+            return validator.validateRequest(ctx, request);
         }
 
         public ValidationErrors validateResponse(Response<? extends Body> response) {
-            if (operationErrors.hasErrors())
-                return operationErrors;
-            return operationValidator.validateResponse(ctx, response);
+            // There might be already path and method validation errors.
+            if (errors.hasErrors())
+                return errors;
+            return validator.validateResponse(ctx, response);
         }
     }
 

--- a/core/src/main/java/com/predic8/membrane/core/openapi/OpenAPIValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/OpenAPIValidator.java
@@ -168,6 +168,10 @@ public class OpenAPIValidator {
                 return errors;
             return validator.validateResponse(ctx, response);
         }
+
+        public ValidationErrors getOperationResolutionErrors() {
+            return errors;
+        }
     }
 
     public OpenAPI getApi() {

--- a/core/src/main/java/com/predic8/membrane/core/openapi/OpenAPIValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/OpenAPIValidator.java
@@ -169,7 +169,7 @@ public class OpenAPIValidator {
             return validator.validateResponse(ctx, response);
         }
 
-        public ValidationErrors getOperationResolutionErrors() {
+        public ValidationErrors getErrors() {
             return errors;
         }
     }

--- a/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIInterceptor.java
@@ -62,7 +62,7 @@ public class OpenAPIInterceptor extends AbstractInterceptor {
 
     private static final Logger log = LoggerFactory.getLogger(OpenAPIInterceptor.class.getName());
     public static final String OPENAPI_RECORD = "OPENAPI_RECORD";
-    public static final String OPENAPI_VALIDATOR = "membrane.openapi.validator";
+    public static final String OPENAPI_VALIDATOR_CTX_PROPERTY = "membrane.openapi.validator.ctx";
 
     protected APIProxy apiProxy;
 
@@ -210,8 +210,8 @@ public class OpenAPIInterceptor extends AbstractInterceptor {
 
         if (!validateRequests && !validateResponses) return empty();
 
-        Request<?> request = validateRequests ? getOpenapiValidatorRequest(exc) : getOperationRequest(exc);
-        ValidationPlan validationPlan = getOrCreateValidationPlan(rec, exc, request);
+        Request<?> request = validateRequests ? getOpenapiValidatorRequest(exc) : getOperationRequestOnlyForResponseValidation(exc);
+        var validationPlan = getOrCreateValidationPlan(rec, exc, request);
 
         if (!validateRequests)
             return empty();
@@ -223,7 +223,7 @@ public class OpenAPIInterceptor extends AbstractInterceptor {
         if (!shouldValidate(rec.getApi(), RESPONSES))
             return empty();
 
-        ValidationPlan validationPlan = exc.getProperty(OPENAPI_VALIDATOR, ValidationPlan.class);
+        ValidationPlan validationPlan = exc.getProperty(OPENAPI_VALIDATOR_CTX_PROPERTY, ValidationPlan.class);
         if (validationPlan == null)
             validationPlan = getOrCreateValidationPlan(rec, exc, getOpenapiValidatorRequest(exc));
 
@@ -231,16 +231,22 @@ public class OpenAPIInterceptor extends AbstractInterceptor {
     }
 
     private ValidationPlan getOrCreateValidationPlan(OpenAPIRecord rec, Exchange exc, Request<?> request) {
-        ValidationPlan validationPlan = exc.getProperty(OPENAPI_VALIDATOR, ValidationPlan.class);
+        var validationPlan = exc.getProperty(OPENAPI_VALIDATOR_CTX_PROPERTY, ValidationPlan.class);
         if (validationPlan != null)
             return validationPlan;
 
         validationPlan = new OpenAPIValidator(router.getConfiguration().getUriFactory(), rec).prepareValidation(request);
-        exc.setProperty(OPENAPI_VALIDATOR, validationPlan);
+
+        // Store the plan in request flow for response validation in the response flow
+        exc.setProperty(OPENAPI_VALIDATOR_CTX_PROPERTY, validationPlan);
         return validationPlan;
     }
 
-    private Request<?> getOperationRequest(Exchange exc) {
+    /**
+     * Lightweight creation of a Request object for response validation only. In case only the response should be validated,
+     * we need some context.
+     */
+    private Request<?> getOperationRequestOnlyForResponseValidation(Exchange exc) {
         return new Request<>(exc.getRequest().getMethod(), exc.getRequest().getUri());
     }
 

--- a/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIInterceptor.java
@@ -16,32 +16,38 @@
 
 package com.predic8.membrane.core.openapi.serviceproxy;
 
-import com.predic8.membrane.annot.*;
-import com.predic8.membrane.core.exchange.*;
+import com.predic8.membrane.annot.MCElement;
+import com.predic8.membrane.core.exchange.Exchange;
 import com.predic8.membrane.core.http.ReadingBodyException;
-import com.predic8.membrane.core.interceptor.*;
-import com.predic8.membrane.core.openapi.*;
-import com.predic8.membrane.core.openapi.validators.*;
-import com.predic8.membrane.core.proxies.*;
+import com.predic8.membrane.core.interceptor.AbstractInterceptor;
+import com.predic8.membrane.core.interceptor.Outcome;
+import com.predic8.membrane.core.openapi.OpenAPIParsingException;
+import com.predic8.membrane.core.openapi.OpenAPIValidator;
+import com.predic8.membrane.core.openapi.validators.ValidationErrors;
+import com.predic8.membrane.core.proxies.RuleKey;
 import com.predic8.membrane.core.util.ConfigurationException;
-import io.swagger.v3.oas.models.*;
-import io.swagger.v3.oas.models.servers.*;
-import jakarta.mail.internet.*;
-import org.slf4j.*;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+import jakarta.mail.internet.ParseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.*;
-import java.net.*;
+import java.net.URL;
 import java.util.*;
 
-import static com.predic8.membrane.core.exceptions.ProblemDetails.*;
-import static com.predic8.membrane.core.exchange.Exchange.*;
-import static com.predic8.membrane.core.interceptor.Interceptor.Flow.*;
-import static com.predic8.membrane.core.interceptor.Interceptor.Flow.Set.*;
-import static com.predic8.membrane.core.interceptor.Outcome.*;
+import static com.predic8.membrane.core.exceptions.ProblemDetails.internal;
+import static com.predic8.membrane.core.exceptions.ProblemDetails.user;
+import static com.predic8.membrane.core.exchange.Exchange.SNI_SERVER_NAME;
+import static com.predic8.membrane.core.interceptor.Interceptor.Flow.REQUEST;
+import static com.predic8.membrane.core.interceptor.Interceptor.Flow.RESPONSE;
+import static com.predic8.membrane.core.interceptor.Interceptor.Flow.Set.REQUEST_RESPONSE_FLOW;
+import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
+import static com.predic8.membrane.core.interceptor.Outcome.RETURN;
 import static com.predic8.membrane.core.openapi.serviceproxy.APIProxy.*;
-import static com.predic8.membrane.core.openapi.util.UriUtil.*;
-import static com.predic8.membrane.core.openapi.util.Utils.*;
-import static java.util.Comparator.*;
+import static com.predic8.membrane.core.openapi.util.UriUtil.getUrlWithoutPath;
+import static com.predic8.membrane.core.openapi.util.Utils.getOpenapiValidatorRequest;
+import static com.predic8.membrane.core.openapi.util.Utils.getOpenapiValidatorResponse;
+import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.*;
 
 /**
@@ -193,14 +199,25 @@ public class OpenAPIInterceptor extends AbstractInterceptor {
         return null;
     }
 
-    private ValidationErrors validateRequest(OpenAPIRecord rec, Exchange exc) throws IOException, ParseException {
+
+    private ValidationErrors validateRequest(OpenAPIRecord rec, Exchange exc) throws ParseException {
+        // @TODO
+        // Create OpenAPIValidator here.
+        // Split validation in:
+        // - var validator = new OpenAPIValidator(...)
+        // - validator.validateOperation (Call path till validateOperation) // Operation should be stored in the validator
+        // - validateRequest(...)  // operation stored in validator should be used
+        // - Store validator in exchange (key: membrane.openapi.validator)
+        // - validateResponse(...) // operation stored in validator should be used
+
+        // Attention: Consider case: validateRequest = false and validateResponse = true
         if (!shouldValidate(rec.getApi(), REQUESTS))
             return new ValidationErrors();
 
         return new OpenAPIValidator(router.getConfiguration().getUriFactory(), rec).validate(getOpenapiValidatorRequest(exc));
     }
 
-    private ValidationErrors validateResponse(OpenAPIRecord rec, Exchange exc) throws IOException, ParseException {
+    private ValidationErrors validateResponse(OpenAPIRecord rec, Exchange exc) throws ParseException {
         ValidationErrors errors = new ValidationErrors();
         if (!shouldValidate(rec.getApi(), RESPONSES))
             return errors;

--- a/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIInterceptor.java
@@ -214,7 +214,7 @@ public class OpenAPIInterceptor extends AbstractInterceptor {
         var validationPlan = getOrCreateValidationPlan(rec, exc, request);
 
         if (!validateRequests)
-            return empty();
+            return validationPlan.getOperationResolutionErrors();
 
         return validationPlan.validateRequest(request);
     }

--- a/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIInterceptor.java
@@ -23,6 +23,8 @@ import com.predic8.membrane.core.interceptor.AbstractInterceptor;
 import com.predic8.membrane.core.interceptor.Outcome;
 import com.predic8.membrane.core.openapi.OpenAPIParsingException;
 import com.predic8.membrane.core.openapi.OpenAPIValidator;
+import com.predic8.membrane.core.openapi.OpenAPIValidator.ValidationPlan;
+import com.predic8.membrane.core.openapi.model.Request;
 import com.predic8.membrane.core.openapi.validators.ValidationErrors;
 import com.predic8.membrane.core.proxies.RuleKey;
 import com.predic8.membrane.core.util.ConfigurationException;
@@ -47,6 +49,7 @@ import static com.predic8.membrane.core.openapi.serviceproxy.APIProxy.*;
 import static com.predic8.membrane.core.openapi.util.UriUtil.getUrlWithoutPath;
 import static com.predic8.membrane.core.openapi.util.Utils.getOpenapiValidatorRequest;
 import static com.predic8.membrane.core.openapi.util.Utils.getOpenapiValidatorResponse;
+import static com.predic8.membrane.core.openapi.validators.ValidationErrors.empty;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.*;
 
@@ -59,6 +62,7 @@ public class OpenAPIInterceptor extends AbstractInterceptor {
 
     private static final Logger log = LoggerFactory.getLogger(OpenAPIInterceptor.class.getName());
     public static final String OPENAPI_RECORD = "OPENAPI_RECORD";
+    public static final String OPENAPI_VALIDATOR = "membrane.openapi.validator";
 
     protected APIProxy apiProxy;
 
@@ -201,27 +205,43 @@ public class OpenAPIInterceptor extends AbstractInterceptor {
 
 
     private ValidationErrors validateRequest(OpenAPIRecord rec, Exchange exc) throws ParseException {
-        // @TODO
-        // Create OpenAPIValidator here.
-        // Split validation in:
-        // - var validator = new OpenAPIValidator(...)
-        // - validator.validateOperation (Call path till validateOperation) // Operation should be stored in the validator
-        // - validateRequest(...)  // operation stored in validator should be used
-        // - Store validator in exchange (key: membrane.openapi.validator)
-        // - validateResponse(...) // operation stored in validator should be used
+        var validateRequests = shouldValidate(rec.getApi(), REQUESTS);
+        var validateResponses = shouldValidate(rec.getApi(), RESPONSES);
 
-        // Attention: Consider case: validateRequest = false and validateResponse = true
-        if (!shouldValidate(rec.getApi(), REQUESTS))
-            return new ValidationErrors();
+        if (!validateRequests && !validateResponses) return empty();
 
-        return new OpenAPIValidator(router.getConfiguration().getUriFactory(), rec).validate(getOpenapiValidatorRequest(exc));
+        Request<?> request = validateRequests ? getOpenapiValidatorRequest(exc) : getOperationRequest(exc);
+        ValidationPlan validationPlan = getOrCreateValidationPlan(rec, exc, request);
+
+        if (!validateRequests)
+            return empty();
+
+        return validationPlan.validateRequest(request);
     }
 
     private ValidationErrors validateResponse(OpenAPIRecord rec, Exchange exc) throws ParseException {
-        ValidationErrors errors = new ValidationErrors();
         if (!shouldValidate(rec.getApi(), RESPONSES))
-            return errors;
-        return new OpenAPIValidator(router.getConfiguration().getUriFactory(), rec).validateResponse(getOpenapiValidatorRequest(exc), getOpenapiValidatorResponse(exc));
+            return empty();
+
+        ValidationPlan validationPlan = exc.getProperty(OPENAPI_VALIDATOR, ValidationPlan.class);
+        if (validationPlan == null)
+            validationPlan = getOrCreateValidationPlan(rec, exc, getOpenapiValidatorRequest(exc));
+
+        return validationPlan.validateResponse(getOpenapiValidatorResponse(exc));
+    }
+
+    private ValidationPlan getOrCreateValidationPlan(OpenAPIRecord rec, Exchange exc, Request<?> request) {
+        ValidationPlan validationPlan = exc.getProperty(OPENAPI_VALIDATOR, ValidationPlan.class);
+        if (validationPlan != null)
+            return validationPlan;
+
+        validationPlan = new OpenAPIValidator(router.getConfiguration().getUriFactory(), rec).prepareValidation(request);
+        exc.setProperty(OPENAPI_VALIDATOR, validationPlan);
+        return validationPlan;
+    }
+
+    private Request<?> getOperationRequest(Exchange exc) {
+        return new Request<>(exc.getRequest().getMethod(), exc.getRequest().getUri());
     }
 
     public boolean validationDetails(OpenAPI api) {

--- a/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIInterceptor.java
@@ -214,7 +214,7 @@ public class OpenAPIInterceptor extends AbstractInterceptor {
         var validationPlan = getOrCreateValidationPlan(rec, exc, request);
 
         if (!validateRequests)
-            return validationPlan.getOperationResolutionErrors();
+            return validationPlan.getErrors();
 
         return validationPlan.validateRequest(request);
     }

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/OperationValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/OperationValidator.java
@@ -23,49 +23,52 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.parameters.Parameter;
-import io.swagger.v3.oas.models.parameters.PathParameter;
 
 import java.util.List;
 
 import static com.predic8.membrane.core.openapi.serviceproxy.APIProxy.SECURITY;
 import static com.predic8.membrane.core.openapi.serviceproxy.OpenAPIInterceptor.shouldValidate;
-import static com.predic8.membrane.core.openapi.validators.ValidationContext.ValidatedEntityType.*;
-import static java.lang.String.format;
+import static com.predic8.membrane.core.openapi.validators.ValidationContext.ValidatedEntityType.BODY;
 
 public class OperationValidator {
 
     final OpenAPI api;
-    final ValidationErrors errors = new ValidationErrors();
+    final PathItem pathItem;
+    final Operation operation;
 
-    public OperationValidator(OpenAPI api) {
+    private OperationValidator(OpenAPI api, PathItem pathItem, Operation operation) {
         this.api = api;
+        this.pathItem = pathItem;
+        this.operation = operation;
     }
 
-    public ValidationErrors validateOperation(ValidationContext ctx, Request<?> req, Response<?> response, PathItem pathItem) throws MethodNotAllowException {
-
-        var operation = getOperation(req.getMethod(), pathItem);
+    public static OperationValidator resolve(OpenAPI api, String method, PathItem pathItem) throws MethodNotAllowException {
+        var operation = getOperation(method, pathItem);
         if (operation == null)
             throw new MethodNotAllowException();
-        // @TODO Split till here.
-
-
-        isMethodDeclaredInAPI(ctx, req.getMethod(), operation);
-
-        // If there is no response we have to validate the request
-        if (response == null) {
-            validatePathParameters(ctx, req, operation.getParameters());
-
-            errors.add(new QueryParameterValidator(api,pathItem).validate(ctx, req, operation));
-            errors.add(new RequestHeaderParameterValidator(api,pathItem).validateHeaderParameters(ctx, req, operation));
-            if (shouldValidate(api, SECURITY))
-                errors.add(new SecurityValidator(api).validateSecurity(ctx,req, operation));
-
-            return errors.add(new RequestBodyValidator(api).validate(ctx.entityType(BODY).entity("REQUEST"), req, operation));
-        }
-        return errors.add(new ResponseBodyValidator(api).validate(ctx.entityType(BODY).entity("RESPONSE"), response, operation));
+        return new OperationValidator(api, pathItem, operation);
     }
 
-    private Operation getOperation(String method, PathItem pi) throws MethodNotAllowException {
+    public ValidationErrors validateRequest(ValidationContext ctx, Request<?> req) {
+        var errors = new ValidationErrors();
+        errors.add(validatePathParameters(ctx, req, operation.getParameters()));
+        errors.add(new QueryParameterValidator(api, pathItem).validate(ctx, req, operation));
+        errors.add(new RequestHeaderParameterValidator(api, pathItem).validateHeaderParameters(ctx, req, operation));
+        if (shouldValidate(api, SECURITY))
+            errors.add(new SecurityValidator(api).validateSecurity(ctx, req, operation));
+        errors.add(new RequestBodyValidator(api).validate(ctx.entityType(BODY).entity("REQUEST"), req, operation));
+        return errors.add(validatePathParameters(ctx, req, pathItem.getParameters()));
+    }
+
+    public ValidationErrors validateResponse(ValidationContext ctx, Response<?> response) {
+        return new ResponseBodyValidator(api).validate(ctx.entityType(BODY).entity("RESPONSE"), response, operation);
+    }
+
+    private ValidationErrors validatePathParameters(ValidationContext ctx, Request<?> req, List<Parameter> schemaParameters) {
+        return new PathParametersValidator(api).validatePathParameters(ctx, req, schemaParameters);
+    }
+
+    private static Operation getOperation(String method, PathItem pi) throws MethodNotAllowException {
         return switch (method.toUpperCase()) {
             case "GET" -> pi.getGet();
             case "POST" -> pi.getPost();
@@ -74,31 +77,5 @@ public class OperationValidator {
             case "PATCH" -> pi.getPatch();
             default -> throw new MethodNotAllowException();
         };
-    }
-
-    private void isMethodDeclaredInAPI(ValidationContext ctx, String method, Object apiMethod) {
-        if (apiMethod == null) {
-            errors.add(new ValidationError(ctx.entity(method).entityType(METHOD).statusCode(405), format("Path %s does not support method %s", ctx.getUriTemplate(), method)));
-        }
-    }
-
-    private void validatePathParameters(ValidationContext ctx, Request<?> req, List<Parameter> schemaParameters) {
-
-        if (schemaParameters == null || req.getPathParameters().isEmpty())
-            return;
-        schemaParameters.stream().filter(this::isPathParameter).forEach(parameter -> {
-            String value = req.getPathParameters().get(parameter.getName());
-            if (value == null) {
-                throw new RuntimeException("Should not happen!");
-            }
-            errors.add(new SchemaValidator(api, parameter.getSchema()).validate(ctx.entityType(PATH_PARAMETER)
-                    .entity(parameter.getName())
-                    .path(req.getPath())
-                    .statusCode(400), value));
-        });
-    }
-
-    private boolean isPathParameter(Parameter p) {
-        return p instanceof PathParameter;
     }
 }

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/OperationValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/OperationValidator.java
@@ -71,10 +71,13 @@ public class OperationValidator {
     private static Operation getOperation(String method, PathItem pi) throws MethodNotAllowException {
         return switch (method.toUpperCase()) {
             case "GET" -> pi.getGet();
+            case "HEAD" -> pi.getHead();
+            case "OPTIONS" -> pi.getOptions();
             case "POST" -> pi.getPost();
             case "PUT" -> pi.getPut();
             case "DELETE" -> pi.getDelete();
             case "PATCH" -> pi.getPatch();
+            case "TRACE" -> pi.getTrace();
             default -> throw new MethodNotAllowException();
         };
     }

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/OperationValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/OperationValidator.java
@@ -16,17 +16,21 @@
 
 package com.predic8.membrane.core.openapi.validators;
 
-import com.predic8.membrane.core.openapi.model.*;
-import com.predic8.membrane.core.openapi.util.*;
-import io.swagger.v3.oas.models.*;
-import io.swagger.v3.oas.models.parameters.*;
+import com.predic8.membrane.core.openapi.model.Request;
+import com.predic8.membrane.core.openapi.model.Response;
+import com.predic8.membrane.core.openapi.util.MethodNotAllowException;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.parameters.PathParameter;
 
-import java.util.*;
+import java.util.List;
 
-import static com.predic8.membrane.core.openapi.serviceproxy.APIProxy.*;
-import static com.predic8.membrane.core.openapi.serviceproxy.OpenAPIInterceptor.*;
+import static com.predic8.membrane.core.openapi.serviceproxy.APIProxy.SECURITY;
+import static com.predic8.membrane.core.openapi.serviceproxy.OpenAPIInterceptor.shouldValidate;
 import static com.predic8.membrane.core.openapi.validators.ValidationContext.ValidatedEntityType.*;
-import static java.lang.String.*;
+import static java.lang.String.format;
 
 public class OperationValidator {
 
@@ -39,9 +43,11 @@ public class OperationValidator {
 
     public ValidationErrors validateOperation(ValidationContext ctx, Request<?> req, Response<?> response, PathItem pathItem) throws MethodNotAllowException {
 
-        Operation operation = getOperation(req.getMethod(), pathItem);
+        var operation = getOperation(req.getMethod(), pathItem);
         if (operation == null)
             throw new MethodNotAllowException();
+        // @TODO Split till here.
+
 
         isMethodDeclaredInAPI(ctx, req.getMethod(), operation);
 
@@ -55,9 +61,8 @@ public class OperationValidator {
                 errors.add(new SecurityValidator(api).validateSecurity(ctx,req, operation));
 
             return errors.add(new RequestBodyValidator(api).validate(ctx.entityType(BODY).entity("REQUEST"), req, operation));
-        } else {
-                return errors.add(new ResponseBodyValidator(api).validate(ctx.entityType(BODY).entity("RESPONSE"), response, operation));
         }
+        return errors.add(new ResponseBodyValidator(api).validate(ctx.entityType(BODY).entity("RESPONSE"), response, operation));
     }
 
     private Operation getOperation(String method, PathItem pi) throws MethodNotAllowException {

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/OperationValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/OperationValidator.java
@@ -42,7 +42,7 @@ public class OperationValidator {
         this.operation = operation;
     }
 
-    public static OperationValidator resolve(OpenAPI api, String method, PathItem pathItem) throws MethodNotAllowException {
+    public static OperationValidator create(OpenAPI api, String method, PathItem pathItem) throws MethodNotAllowException {
         var operation = getOperation(method, pathItem);
         if (operation == null)
             throw new MethodNotAllowException();

--- a/core/src/main/java/com/predic8/membrane/core/transport/http/UnableToTunnelException.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/http/UnableToTunnelException.java
@@ -1,3 +1,17 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
 package com.predic8.membrane.core.transport.http;
 
 /**

--- a/core/src/test/java/com/predic8/membrane/core/openapi/OpenAPIValidatorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/OpenAPIValidatorTest.java
@@ -16,18 +16,21 @@
 
 package com.predic8.membrane.core.openapi;
 
-import com.predic8.membrane.core.openapi.model.*;
-import com.predic8.membrane.core.openapi.serviceproxy.*;
-import com.predic8.membrane.core.openapi.validators.*;
-import com.predic8.membrane.core.util.*;
-import org.junit.jupiter.api.*;
+import com.predic8.membrane.core.openapi.model.Request;
+import com.predic8.membrane.core.openapi.serviceproxy.OpenAPIRecord;
+import com.predic8.membrane.core.openapi.serviceproxy.OpenAPISpec;
+import com.predic8.membrane.core.util.URIFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import java.io.*;
+import java.io.IOException;
 
 import static com.predic8.membrane.core.openapi.model.Request.get;
-import static com.predic8.membrane.core.openapi.util.OpenAPITestUtils.*;
-import static com.predic8.membrane.core.openapi.validators.ValidationContext.ValidatedEntityType.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static com.predic8.membrane.core.openapi.util.OpenAPITestUtils.getResourceAsStream;
+import static com.predic8.membrane.core.openapi.util.OpenAPITestUtils.parseOpenAPI;
+import static com.predic8.membrane.core.openapi.validators.ValidationContext.ValidatedEntityType.METHOD;
+import static com.predic8.membrane.core.openapi.validators.ValidationContext.ValidatedEntityType.PATH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class OpenAPIValidatorTest {
 

--- a/core/src/test/java/com/predic8/membrane/core/openapi/OpenAPIValidatorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/OpenAPIValidatorTest.java
@@ -65,6 +65,12 @@ class OpenAPIValidatorTest {
     }
 
     @Test
+    void prepareValidationCanBeUsedForRequestValidation() {
+        var validationPlan = validator.prepareValidation(get().path("/customers"));
+        assertEquals(0, validationPlan.validateRequest(get().path("/customers")).size());
+    }
+
+    @Test
     void queryStringArrayExploded() {
         assertEquals(0, validator.validate(get().path("/customers?ids=a&ids=b&ids=c")).size());
     }

--- a/core/src/test/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIInterceptorTest.java
@@ -16,22 +16,29 @@
 
 package com.predic8.membrane.core.openapi.serviceproxy;
 
-import com.predic8.membrane.core.exceptions.*;
-import com.predic8.membrane.core.exchange.*;
-import com.predic8.membrane.core.http.*;
+import com.predic8.membrane.core.exceptions.ProblemDetails;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.http.Request;
+import com.predic8.membrane.core.http.Response;
 import com.predic8.membrane.core.openapi.OpenAPIValidator;
-import com.predic8.membrane.core.router.*;
-import com.predic8.membrane.core.util.*;
-import org.jetbrains.annotations.*;
-import org.junit.jupiter.api.*;
+import com.predic8.membrane.core.router.DummyTestRouter;
+import com.predic8.membrane.core.router.Router;
+import com.predic8.membrane.core.util.URIFactory;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
-import static com.predic8.membrane.core.http.MimeType.*;
-import static com.predic8.membrane.core.interceptor.Outcome.*;
-import static com.predic8.membrane.core.openapi.serviceproxy.OpenAPISpec.YesNoOpenAPIOption.*;
-import static com.predic8.membrane.core.openapi.util.JsonTestUtil.*;
-import static com.predic8.membrane.core.openapi.util.OpenAPITestUtils.*;
+import static com.predic8.membrane.core.http.MimeType.APPLICATION_JSON;
+import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
+import static com.predic8.membrane.core.interceptor.Outcome.RETURN;
+import static com.predic8.membrane.core.openapi.serviceproxy.OpenAPISpec.YesNoOpenAPIOption.NO;
+import static com.predic8.membrane.core.openapi.serviceproxy.OpenAPISpec.YesNoOpenAPIOption.YES;
+import static com.predic8.membrane.core.openapi.util.JsonTestUtil.convert2JSON;
+import static com.predic8.membrane.core.openapi.util.OpenAPITestUtils.createProxy;
+import static com.predic8.membrane.core.openapi.util.OpenAPITestUtils.getMapFromResponse;
 import static com.predic8.membrane.core.util.ProblemDetailsTestUtil.parse;
 import static com.predic8.membrane.test.TestUtil.getPathFromResource;
 import static org.junit.jupiter.api.Assertions.*;
@@ -231,7 +238,7 @@ class OpenAPIInterceptorTest {
         interceptor.init(router);
 
         assertEquals(CONTINUE, interceptor.handleRequest(exc));
-        assertNotNull(exc.getProperty(OpenAPIInterceptor.OPENAPI_VALIDATOR, OpenAPIValidator.ValidationPlan.class));
+        assertNotNull(exc.getProperty(OpenAPIInterceptor.OPENAPI_VALIDATOR_CTX_PROPERTY, OpenAPIValidator.ValidationPlan.class));
     }
 
     @Test

--- a/core/src/test/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIInterceptorTest.java
@@ -179,17 +179,13 @@ class OpenAPIInterceptorTest {
         OpenAPIInterceptor interceptor = new OpenAPIInterceptor(createProxy(router, specCustomers));
         interceptor.init(router);
 
-        Exchange requestExc = new Exchange(null);
-        requestExc.setOriginalRequestUri("/customers");
-        requestExc.setRequest(new Request.Builder().method("POST").url(new URIFactory(), "/customers").contentType(APPLICATION_JSON).body(convert2JSON(invalidCustomer())).build());
+        Exchange requestExc = new Request.Builder().post("/customers").contentType(APPLICATION_JSON).body(convert2JSON(invalidCustomer())).buildExchange();
 
         assertEquals(CONTINUE, interceptor.handleRequest(requestExc));
         assertNull(requestExc.getResponse());
 
-        Exchange responseExc = new Exchange(null);
-        responseExc.setOriginalRequestUri("/customers");
-        responseExc.setRequest(new Request.Builder().method("PUT").url(new URIFactory(), "/customers").contentType(APPLICATION_JSON).build());
 
+        Exchange responseExc = new Request.Builder().put("/customers").contentType(APPLICATION_JSON).buildExchange();
         assertEquals(CONTINUE, interceptor.handleRequest(responseExc));
 
         responseExc.setResponse(Response.ok().contentType(APPLICATION_JSON).body(convert2JSON(invalidCustomer())).build());
@@ -203,9 +199,7 @@ class OpenAPIInterceptorTest {
     void requestValidationDisabledResponseValidationEnabled_wrongPathBlocksRequest() throws Exception {
         specCustomers.validateResponses = YES;
 
-        Exchange requestExc = new Exchange(null);
-        requestExc.setOriginalRequestUri("/does-not-exist");
-        requestExc.setRequest(new Request.Builder().method("GET").url(new URIFactory(), "/does-not-exist").build());
+        Exchange requestExc = new Request.Builder().get( "/does-not-exist").buildExchange();
 
         OpenAPIInterceptor interceptor = new OpenAPIInterceptor(createProxy(router, specCustomers));
         interceptor.init(router);

--- a/core/src/test/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIInterceptorTest.java
@@ -144,14 +144,9 @@ class OpenAPIInterceptorTest {
 
         specCustomers.validateRequests = YES;
 
-        Map<String,Object> customer = new HashMap<>();
-        customer.put("id","CUST-7");
-        customer.put("age",110);
-        customer.put("foo",110);
-
         Exchange exc = new Exchange(null);
         exc.setOriginalRequestUri("/customers");
-        exc.setRequest(new Request.Builder().method("POST").url(new URIFactory(), "/customers").contentType(APPLICATION_JSON).body(convert2JSON(customer)).build());
+        exc.setRequest(new Request.Builder().method("POST").url(new URIFactory(), "/customers").contentType(APPLICATION_JSON).body(convert2JSON(invalidCustomer())).build());
 
         OpenAPIInterceptor interceptor = new OpenAPIInterceptor(createProxy(router, specCustomers));
         interceptor.init(router);
@@ -168,6 +163,60 @@ class OpenAPIInterceptorTest {
         Exchange exc = callPut(specCustomers);
         assertEquals("PUT",  getMapFromResponse(exc).get("validation").get("method"));
         testValidationResults(getMapFromResponse(exc), "RESPONSE");
+    }
+
+    @Test
+    void requestValidationDisabledResponseValidationEnabled() throws Exception {
+        specCustomers.validateResponses = YES;
+
+        OpenAPIInterceptor interceptor = new OpenAPIInterceptor(createProxy(router, specCustomers));
+        interceptor.init(router);
+
+        Exchange requestExc = new Exchange(null);
+        requestExc.setOriginalRequestUri("/customers");
+        requestExc.setRequest(new Request.Builder().method("POST").url(new URIFactory(), "/customers").contentType(APPLICATION_JSON).body(convert2JSON(invalidCustomer())).build());
+
+        assertEquals(CONTINUE, interceptor.handleRequest(requestExc));
+        assertNull(requestExc.getResponse());
+
+        Exchange responseExc = new Exchange(null);
+        responseExc.setOriginalRequestUri("/customers");
+        responseExc.setRequest(new Request.Builder().method("PUT").url(new URIFactory(), "/customers").contentType(APPLICATION_JSON).build());
+
+        assertEquals(CONTINUE, interceptor.handleRequest(responseExc));
+
+        responseExc.setResponse(Response.ok().contentType(APPLICATION_JSON).body(convert2JSON(invalidCustomer())).build());
+
+        assertEquals(RETURN, interceptor.handleResponse(responseExc));
+        assertEquals(500, responseExc.getResponse().getStatusCode());
+        testValidationResults(getMapFromResponse(responseExc), "RESPONSE");
+    }
+
+    @Test
+    void requestValidationEnabledResponseValidationDisabled() throws Exception {
+        specCustomers.validateRequests = YES;
+
+        OpenAPIInterceptor interceptor = new OpenAPIInterceptor(createProxy(router, specCustomers));
+        interceptor.init(router);
+
+        Exchange requestExc = new Exchange(null);
+        requestExc.setOriginalRequestUri("/customers");
+        requestExc.setRequest(new Request.Builder().method("POST").url(new URIFactory(), "/customers").contentType(APPLICATION_JSON).body(convert2JSON(invalidCustomer())).build());
+
+        assertEquals(RETURN, interceptor.handleRequest(requestExc));
+        assertEquals(400, requestExc.getResponse().getStatusCode());
+        testValidationResults(getMapFromResponse(requestExc), "REQUEST");
+
+        Exchange responseExc = new Exchange(null);
+        responseExc.setOriginalRequestUri("/customers");
+        responseExc.setRequest(new Request.Builder().method("PUT").url(new URIFactory(), "/customers").contentType(APPLICATION_JSON).build());
+
+        assertEquals(CONTINUE, interceptor.handleRequest(responseExc));
+
+        responseExc.setResponse(Response.ok().contentType(APPLICATION_JSON).body(convert2JSON(invalidCustomer())).build());
+
+        assertEquals(CONTINUE, interceptor.handleResponse(responseExc));
+        assertEquals(200, responseExc.getResponse().getStatusCode());
     }
 
     @Test
@@ -203,15 +252,18 @@ class OpenAPIInterceptorTest {
 
         assertEquals(CONTINUE, interceptor.handleRequest(exc));
 
-        Map<String,Object> customer = new HashMap<>();
-        customer.put("id","CUST-7");
-        customer.put("age",110);
-        customer.put("foo",110);
-
-        exc.setResponse(Response.ok().contentType(APPLICATION_JSON).body(convert2JSON(customer)).build());
+        exc.setResponse(Response.ok().contentType(APPLICATION_JSON).body(convert2JSON(invalidCustomer())).build());
         assertEquals(RETURN, interceptor.handleResponse(exc));
         assertEquals(500,exc.getResponse().getStatusCode());
         return exc;
+    }
+
+    private Map<String, Object> invalidCustomer() {
+        Map<String, Object> customer = new HashMap<>();
+        customer.put("id", "CUST-7");
+        customer.put("age", 110);
+        customer.put("foo", 110);
+        return customer;
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/core/src/test/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIInterceptorTest.java
@@ -19,6 +19,7 @@ package com.predic8.membrane.core.openapi.serviceproxy;
 import com.predic8.membrane.core.exceptions.*;
 import com.predic8.membrane.core.exchange.*;
 import com.predic8.membrane.core.http.*;
+import com.predic8.membrane.core.openapi.OpenAPIValidator;
 import com.predic8.membrane.core.router.*;
 import com.predic8.membrane.core.util.*;
 import org.jetbrains.annotations.*;
@@ -167,6 +168,21 @@ class OpenAPIInterceptorTest {
         Exchange exc = callPut(specCustomers);
         assertEquals("PUT",  getMapFromResponse(exc).get("validation").get("method"));
         testValidationResults(getMapFromResponse(exc), "RESPONSE");
+    }
+
+    @Test
+    void storesValidationPlanForResponseChecks() throws Exception {
+        specCustomers.validateResponses = YES;
+
+        Exchange exc = new Exchange(null);
+        exc.setOriginalRequestUri("/customers");
+        exc.setRequest(new Request.Builder().method("PUT").url(new URIFactory(), "/customers").contentType(APPLICATION_JSON).build());
+
+        OpenAPIInterceptor interceptor = new OpenAPIInterceptor(createProxy(router, specCustomers));
+        interceptor.init(router);
+
+        assertEquals(CONTINUE, interceptor.handleRequest(exc));
+        assertNotNull(exc.getProperty(OpenAPIInterceptor.OPENAPI_VALIDATOR, OpenAPIValidator.ValidationPlan.class));
     }
 
     @Test

--- a/core/src/test/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIInterceptorTest.java
@@ -200,6 +200,41 @@ class OpenAPIInterceptorTest {
     }
 
     @Test
+    void requestValidationDisabledResponseValidationEnabled_wrongPathBlocksRequest() throws Exception {
+        specCustomers.validateResponses = YES;
+
+        Exchange requestExc = new Exchange(null);
+        requestExc.setOriginalRequestUri("/does-not-exist");
+        requestExc.setRequest(new Request.Builder().method("GET").url(new URIFactory(), "/does-not-exist").build());
+
+        OpenAPIInterceptor interceptor = new OpenAPIInterceptor(createProxy(router, specCustomers));
+        interceptor.init(router);
+
+        assertEquals(RETURN, interceptor.handleRequest(requestExc));
+        assertEquals(404, requestExc.getResponse().getStatusCode());
+        assertEquals("/does-not-exist", getMapFromResponse(requestExc).get("validation").get("path"));
+        assertTrue(getMapFromResponse(requestExc).get("validation").containsKey("errors"));
+        assertTrue(((Map<?, ?>) getMapFromResponse(requestExc).get("validation").get("errors")).containsKey("REQUEST/PATH"));
+    }
+
+    @Test
+    void requestValidationDisabledResponseValidationEnabled_wrongMethodBlocksRequest() throws Exception {
+        specCustomers.validateResponses = YES;
+
+        Exchange requestExc = new Exchange(null);
+        requestExc.setOriginalRequestUri("/customers");
+        requestExc.setRequest(new Request.Builder().method("PATCH").url(new URIFactory(), "/customers").build());
+
+        OpenAPIInterceptor interceptor = new OpenAPIInterceptor(createProxy(router, specCustomers));
+        interceptor.init(router);
+
+        assertEquals(RETURN, interceptor.handleRequest(requestExc));
+        assertEquals(405, requestExc.getResponse().getStatusCode());
+        assertEquals("PATCH", getMapFromResponse(requestExc).get("validation").get("method"));
+        assertTrue(((Map<?, ?>) getMapFromResponse(requestExc).get("validation").get("errors")).containsKey("REQUEST/METHOD"));
+    }
+
+    @Test
     void requestValidationEnabledResponseValidationDisabled() throws Exception {
         specCustomers.validateRequests = YES;
 

--- a/core/src/test/java/com/predic8/membrane/test/TestAppender.java
+++ b/core/src/test/java/com/predic8/membrane/test/TestAppender.java
@@ -1,3 +1,17 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
 package com.predic8.membrane.test;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked OpenAPI validation into a two-step flow with reusable per-exchange validation plans, separating request and response validation and caching plans for response checks; streamlined operation dispatch and method handling.

* **Tests**
  * Added tests for prepared validation plans, storage of plans for response validation, and permutations of request/response validation flags.

* **Chores**
  * Added Apache 2.0 license headers to a couple of source files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->