### PR TITLE
Add `JSON_SCHEMA_VERSION` constant to fix: automatic version update not working #2920

### DIFF
--- a/annot/src/main/java/com/predic8/membrane/annot/Constants.java
+++ b/annot/src/main/java/com/predic8/membrane/annot/Constants.java
@@ -36,22 +36,27 @@ public class Constants {
 	public static final byte[] CRLF_BYTES = { 13, 10 };
 
 	public static final String VERSION;
+	public static final String JSON_SCHEMA_VERSION;
 
 	static {
 		String version = "7.2"; // fallback
+		String jsonSchemaVersion = "7.2"; // fallback
 		try {
 			Properties p = new Properties(); // Production
 			p.load(Constants.class.getResourceAsStream("/META-INF/maven/org.membrane-soa/service-proxy-core/pom.properties"));
 			version = p.getProperty("version");
+			jsonSchemaVersion = version;
 		} catch (Exception e) {
 			try {
 				Properties p = new Properties(); // Development
 				p.load(new FileInputStream("target/maven-archiver/pom.properties"));
-				version = p.getProperty("version") + " - DEVELOPMENT";
+				jsonSchemaVersion = p.getProperty("version");
+				version = jsonSchemaVersion + " - DEVELOPMENT";
 			} catch (Exception ignored) {
 			}
 		}
 		VERSION = version;
+		JSON_SCHEMA_VERSION = jsonSchemaVersion;
 	}
 
 	public static final String ISO_8859_1 = "ISO-8859-1";

--- a/annot/src/main/java/com/predic8/membrane/annot/generator/JsonSchemaGenerator.java
+++ b/annot/src/main/java/com/predic8/membrane/annot/generator/JsonSchemaGenerator.java
@@ -29,7 +29,7 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.util.*;
 
-import static com.predic8.membrane.annot.Constants.VERSION;
+import static com.predic8.membrane.annot.Constants.JSON_SCHEMA_VERSION;
 import static com.predic8.membrane.annot.generator.kubernetes.model.SchemaFactory.*;
 import static com.predic8.membrane.annot.generator.util.SchemaGeneratorUtil.escapeJsonContent;
 import static javax.tools.StandardLocation.CLASS_OUTPUT;
@@ -71,7 +71,7 @@ public class JsonSchemaGenerator extends AbstractGrammar {
     private void assemble(Model m, MainInfo main) throws IOException {
         // Reset so multiple calls would be possible
         flowDefCreated = false;
-        schema = schema("membrane").version(VERSION);
+        schema = schema("membrane").version(JSON_SCHEMA_VERSION);
         noEnvelopeParserSourceByDefName.clear();
 
         addParserDefinitions(m, main);

--- a/distribution/src/test/java/com/predic8/membrane/examples/withoutinternet/env/ConsistentVersionNumbers.java
+++ b/distribution/src/test/java/com/predic8/membrane/examples/withoutinternet/env/ConsistentVersionNumbers.java
@@ -70,6 +70,7 @@ public class ConsistentVersionNumbers {
 	public static final Option RELEASE = Option.builder("release").desc("Release version").hasArg().argName("x.y.z").build();
 
 	private static final Pattern CONSTANTS_VERSION_PATTERN = Pattern.compile("(\\s*String version = \")(\\d+.\\d+)(\";.*)");
+	private static final Pattern CONSTANTS_JSON_SCHEMA_VERSION_PATTERN = Pattern.compile("(\\s*String jsonSchemaVersion = \")([^\"]+)(\";.*)");
 	private static final Pattern RPM_SPEC_VERSION_PATTERN = Pattern.compile("(Version:\\s+)(\\S+)(.*)");
 	private static final Pattern HELP_REFERENCE_VERSION_PATTERN = Pattern.compile("(path.replace\\(\"%VERSION%\", \")([^\"]*)(\"\\))");
 	private static final Pattern YAML_SCHEMA_VERSION_PATTERN = Pattern.compile("(\\s*#\\s*yaml-language-server:\\s*\\$schema=https://www\\.membrane-api\\.io/v)(\\d+\\.\\d+(?:\\.\\d+)?)(\\.json\\b.*)");
@@ -155,6 +156,7 @@ public class ConsistentVersionNumbers {
 	private static void handleConstants(File file, VersionTransformer versionTransformer) throws Exception {
 		//		String version = "5.1"; // fallback
 		handleByRegex(file, versionTransformer, CONSTANTS_VERSION_PATTERN, v -> "%d.%d".formatted(v.getMajor(), v.getMinor()));
+		handleByRegex(file, versionTransformer, CONSTANTS_JSON_SCHEMA_VERSION_PATTERN, Semver::getValue);
 	}
 
 	private static void handleRpmSpec(File file, VersionTransformer versionTransformer) throws Exception {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Separated JSON schema version tracking from the main application version to enable independent version management.

* **Tests**
  * Extended version consistency validation to cover schema versioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->