### PR TITLE
Add Dependabot configuration for Maven updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    target-branch: "master"
+    schedule:
+      interval: "daily"
+      open-pull-requests-limit: 0
+  
+  - package-ecosystem: "maven"
+    directory: "/"
+    target-branch: "6.X"
+    schedule:
+      interval: "daily"
+      open-pull-requests-limit: 0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,13 @@ updates:
   - package-ecosystem: "maven"
     directory: "/"
     target-branch: "master"
+    open-pull-requests-limit: 0
     schedule:
       interval: "daily"
-      open-pull-requests-limit: 0
   
   - package-ecosystem: "maven"
     directory: "/"
     target-branch: "6.X"
+    open-pull-requests-limit: 0
     schedule:
       interval: "daily"
-      open-pull-requests-limit: 0


### PR DESCRIPTION
Configure Dependabot for Maven dependencies with daily updates for master and 6.X branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated dependency-management configuration to run daily Maven update checks at the repository root.
  * Configured updates for the master and 6.X branches, with no open-pull-requests allowed (open PRs limit set to 0).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->