### PR TITLE
Add configurable maxExchanges property for MCP tools

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/mcp/MembraneMCPServer.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/mcp/MembraneMCPServer.java
@@ -272,6 +272,7 @@ public class MembraneMCPServer extends AbstractInterceptor {
 
     /**
      * @description Maximum number of exchanges that can be returned by the getExchanges MCP tool.
+     * @default 100
      */
     @MCAttribute
     public void setMaxExchanges(int maxExchanges) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/mcp/MembraneMCPServer.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/mcp/MembraneMCPServer.java
@@ -1,6 +1,7 @@
 package com.predic8.membrane.core.interceptor.mcp;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.predic8.membrane.annot.MCAttribute;
 import com.predic8.membrane.annot.MCElement;
 import com.predic8.membrane.core.exchange.AbstractExchange;
 import com.predic8.membrane.core.exchange.Exchange;
@@ -45,25 +46,17 @@ public class MembraneMCPServer extends AbstractInterceptor {
 
     private static final Logger log = LoggerFactory.getLogger(MembraneMCPServer.class);
 
-    private static final int MAX_EXCHANGES = 100;
+    private static final int DEFAULT_MAX_EXCHANGES = 100;
 
     private static final Map<String, Object> EMPTY_OBJECT_SCHEMA = Map.of(
             "type", "object",
             "properties", Map.of(),
             "additionalProperties", false
     );
-    private static final Map<String, Object> GET_EXCHANGES_SCHEMA = Map.of(
-            "type", "object",
-            "properties", Map.of(
-                    "limit", Map.of("type", "integer", "minimum", 1, "maximum", MAX_EXCHANGES),
-                    "includeBodies", Map.of("type", "boolean")
-            ),
-            "additionalProperties", false
-    );
-
     private final Map<String, McpSessionContext> sessionContexts = new ConcurrentHashMap<>();
     private final McpPayloadSanitizer payloadSanitizer = new McpPayloadSanitizer();
-    private final McpToolRegistry toolRegistry = buildToolRegistry();
+    private int maxExchanges = DEFAULT_MAX_EXCHANGES;
+    private McpToolRegistry toolRegistry = buildToolRegistry();
 
     @Override
     public Outcome handleRequest(Exchange exc) {
@@ -211,7 +204,7 @@ public class MembraneMCPServer extends AbstractInterceptor {
                 .register(new McpToolDefinition(
                         "getExchanges",
                         "Gets recent HTTP exchanges with sanitized headers and optional bodies",
-                        GET_EXCHANGES_SCHEMA,
+                        getExchangesSchema(),
                         this::getExchanges
                 ))
                 .register(new McpToolDefinition(
@@ -245,7 +238,7 @@ public class MembraneMCPServer extends AbstractInterceptor {
     private MCPToolsCallResponse getExchanges(MCPToolsCall call, Exchange exc) {
         MCPUtil.rejectUnexpectedArguments(call, Set.of("limit", "includeBodies"));
 
-        int limit = MCPUtil.getOptionalIntArgument(call, "limit", MAX_EXCHANGES, 1, MAX_EXCHANGES);
+        int limit = MCPUtil.getOptionalIntArgument(call, "limit", maxExchanges, 1, maxExchanges);
         boolean includeBodies = MCPUtil.getOptionalBooleanArgument(call, "includeBodies", false);
 
         List<AbstractExchange> exchanges = Optional.ofNullable(getRouter().getExchangeStore().getAllExchangesAsList())
@@ -260,6 +253,33 @@ public class MembraneMCPServer extends AbstractInterceptor {
                                 .filter(Objects::nonNull)
                                 .toList()
                 ));
+    }
+
+    private Map<String, Object> getExchangesSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "limit", Map.of("type", "integer", "minimum", 1, "maximum", maxExchanges),
+                        "includeBodies", Map.of("type", "boolean")
+                ),
+                "additionalProperties", false
+        );
+    }
+
+    public int getMaxExchanges() {
+        return maxExchanges;
+    }
+
+    /**
+     * @description Maximum number of exchanges that can be returned by the getExchanges MCP tool.
+     */
+    @MCAttribute
+    public void setMaxExchanges(int maxExchanges) {
+        if (maxExchanges < 1) {
+            throw new IllegalArgumentException("maxExchanges must be >= 1");
+        }
+        this.maxExchanges = maxExchanges;
+        toolRegistry = buildToolRegistry();
     }
 
     private McpHttpResult badRequest(Exchange exc, @Nullable JSONRPCRequest request, int code, String message, Exception exception) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The MCP server's maximum exchange limit is now configurable through settings, replacing the hardcoded default of 100. Administrators can customize this value to optimize memory usage and query performance based on deployment requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->