### PR TITLE
Add filtering by host, port, and path for MCP tool's getExchanges

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/mcp/ExchangeUtils.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/mcp/ExchangeUtils.java
@@ -1,0 +1,130 @@
+package com.predic8.membrane.core.interceptor.mcp;
+
+import com.predic8.membrane.core.exchange.AbstractExchange;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.proxies.Proxy;
+import org.jetbrains.annotations.Nullable;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.regex.PatternSyntaxException;
+
+import static com.predic8.membrane.core.util.HttpUtil.isAbsoluteURI;
+
+final class ExchangeUtils {
+
+    private ExchangeUtils() {
+    }
+
+    static boolean matchesExchangeFilter(AbstractExchange exchange, @Nullable String host, @Nullable Integer port, @Nullable String pathPattern) {
+        return matchesHost(exchange, host)
+               && matchesPort(exchange, port)
+               && matchesPathPattern(exchange, pathPattern);
+    }
+
+    private static boolean matchesHost(AbstractExchange exchange, @Nullable String host) {
+        if (host == null) {
+            return true;
+        }
+
+        String requestHost = getRequestHost(exchange);
+        return requestHost != null && requestHost.equalsIgnoreCase(host);
+    }
+
+    private static boolean matchesPort(AbstractExchange exchange, @Nullable Integer port) {
+        if (port == null) {
+            return true;
+        }
+
+        Integer requestPort = getRequestPort(exchange);
+        return requestPort != null && requestPort.equals(port);
+    }
+
+    private static boolean matchesPathPattern(AbstractExchange exchange, @Nullable String pathPattern) {
+        if (pathPattern == null) {
+            return true;
+        }
+
+        String requestPath = getRequestPath(exchange);
+        return requestPath != null && (requestPath.startsWith(pathPattern) || matchesRegex(requestPath, pathPattern)); //TODO keep 'startsWith'?
+    }
+
+    private static boolean matchesRegex(String requestPath, String pathPattern) {
+        try {
+            return requestPath.matches(pathPattern);
+        } catch (PatternSyntaxException ignored) {
+            return false;
+        }
+    }
+
+    private static @Nullable String getRequestHost(AbstractExchange exchange) {
+        URI authority = getRequestAuthority(exchange);
+        return authority != null ? authority.getHost() : null;
+    }
+
+    private static @Nullable Integer getRequestPort(AbstractExchange exchange) {
+        URI authority = getRequestAuthority(exchange);
+        if (authority != null) {
+            int authorityPort = authority.getPort();
+            if (authorityPort != -1) {
+                return authorityPort;
+            }
+        }
+
+        Proxy proxy = exchange.getProxy();
+        if (proxy != null && proxy.getKey() != null && proxy.getKey().getPort() > 0) {
+            return proxy.getKey().getPort();
+        }
+        return null;
+    }
+
+    private static @Nullable URI getRequestAuthority(AbstractExchange exchange) {
+        if (exchange instanceof Exchange exc) {
+            String host = exc.getOriginalHostHeaderHost();
+            if (host != null && !host.isBlank()) {
+                try {
+                    String port = exc.getOriginalHostHeaderPort();
+                    return new URI("http://" + host + (port.isBlank() ? "" : ":" + port));
+                } catch (URISyntaxException ignored) {}
+            }
+        }
+
+        String uri = exchange.getRequest().getUri();
+        if (uri != null && isAbsoluteURI(uri)) {
+            try {
+                return new URI(uri);
+            } catch (URISyntaxException ignored) {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    private static @Nullable String getRequestPath(AbstractExchange exchange) {
+        if (exchange instanceof Exchange exc) {
+            try {
+                return exc.getOriginalRelativeURI();
+            } catch (RuntimeException ignored) {}
+        }
+
+        String uri = exchange.getRequest().getUri();
+        if (uri == null) {
+            return null;
+        }
+        if (!isAbsoluteURI(uri)) {
+            return uri;
+        }
+
+        try {
+            URI parsed = new URI(uri);
+            String path = parsed.getRawPath();
+            if (path == null || path.isEmpty()) {
+                path = "/";
+            }
+            return parsed.getRawQuery() == null ? path : path + "?" + parsed.getRawQuery();
+        } catch (URISyntaxException ignored) {
+            return uri;
+        }
+    }
+}

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/mcp/MCPUtil.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/mcp/MCPUtil.java
@@ -98,6 +98,22 @@ public final class MCPUtil {
         throw new InvalidToolArgumentsException("Tool argument '" + name + "' must be a boolean");
     }
 
+    public static @Nullable String getOptionalStringArgument(MCPToolsCall call, String name) {
+        Object value = call.getArgument(name);
+        if (value == null) {
+            return null;
+        }
+        if (!(value instanceof String text)) {
+            throw new InvalidToolArgumentsException("Tool argument '" + name + "' must be a string");
+        }
+
+        String trimmed = text.trim();
+        if (trimmed.isEmpty()) {
+            throw new InvalidToolArgumentsException("Tool argument '" + name + "' must not be blank");
+        }
+        return trimmed;
+    }
+
     public static void rejectUnexpectedArguments(MCPToolsCall call, Set<String> allowed) {
         for (String argumentName : call.getArguments().keySet()) {
             if (!allowed.contains(argumentName)) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/mcp/MembraneMCPServer.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/mcp/MembraneMCPServer.java
@@ -237,7 +237,7 @@ public class MembraneMCPServer extends AbstractInterceptor {
     }
 
     private MCPToolsCallResponse getExchanges(MCPToolsCall call, Exchange exc) {
-        rejectUnexpectedArguments(call, Set.of("limit", "includeBodies", "host", "port", "pathPattern", "path"));
+        rejectUnexpectedArguments(call, Set.of("limit", "includeBodies", "host", "port", "pathPattern"));
 
         List<AbstractExchange> filteredExchanges = Optional.ofNullable(getRouter().getExchangeStore().getAllExchangesAsList())
                 .orElse(List.of())

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/mcp/MembraneMCPServer.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/mcp/MembraneMCPServer.java
@@ -26,6 +26,7 @@ import static com.predic8.membrane.core.http.Request.METHOD_POST;
 import static com.predic8.membrane.core.http.Response.accepted;
 import static com.predic8.membrane.core.http.Response.statusCode;
 import static com.predic8.membrane.core.interceptor.Outcome.RETURN;
+import static com.predic8.membrane.core.interceptor.mcp.ExchangeUtils.matchesExchangeFilter;
 import static com.predic8.membrane.core.interceptor.mcp.MCPUtil.*;
 import static com.predic8.membrane.core.interceptor.mcp.McpSessionContext.McpSessionState.INITIALIZED;
 import static com.predic8.membrane.core.interceptor.mcp.McpSessionContext.McpSessionState.READY;
@@ -239,18 +240,25 @@ public class MembraneMCPServer extends AbstractInterceptor {
     private MCPToolsCallResponse getExchanges(MCPToolsCall call, Exchange exc) {
         rejectUnexpectedArguments(call, Set.of("limit", "includeBodies", "host", "port", "pathPattern"));
 
+        // do not inline: args must be validated fist
+        String host = getOptionalStringArgument(call, "host");
+        Integer port = getOptionalPort(call);
+        String pathPattern = getOptionalStringArgument(call, "pathPattern");
+        int limit = getOptionalIntArgument(call, "limit", maxExchanges, 1, maxExchanges);
+        boolean includeBodies = getOptionalBooleanArgument(call, "includeBodies", false);
+
         List<AbstractExchange> filteredExchanges = Optional.ofNullable(getRouter().getExchangeStore().getAllExchangesAsList())
                 .orElse(List.of())
                 .stream()
-                .filter(exchange -> ExchangeUtils.matchesExchangeFilter(exchange, getOptionalStringArgument(call, "host"), getOptionalPort(call), getOptionalStringArgument(call, "pathPattern")))
+                .filter(exchange -> matchesExchangeFilter(exchange, host, port, pathPattern))
                 .toList();
-        List<AbstractExchange> exchanges = filteredExchanges.subList(Math.max(0, filteredExchanges.size() - getOptionalIntArgument(call, "limit", maxExchanges, 1, maxExchanges)), filteredExchanges.size());
+        List<AbstractExchange> exchanges = filteredExchanges.subList(Math.max(0, filteredExchanges.size() - limit), filteredExchanges.size());
 
         return MCPToolsCallResponse.from(call)
                 .withJson(Map.of(
                         "exchanges",
                         exchanges.stream()
-                                .map(exchange -> MCPUtil.describeExchange(exchange, MCPUtil.getOptionalBooleanArgument(call, "includeBodies", false), payloadSanitizer))
+                                .map(exchange -> MCPUtil.describeExchange(exchange, includeBodies, payloadSanitizer))
                                 .filter(Objects::nonNull)
                                 .toList()
                 ));

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/mcp/MembraneMCPServer.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/mcp/MembraneMCPServer.java
@@ -26,6 +26,7 @@ import static com.predic8.membrane.core.http.Request.METHOD_POST;
 import static com.predic8.membrane.core.http.Response.accepted;
 import static com.predic8.membrane.core.http.Response.statusCode;
 import static com.predic8.membrane.core.interceptor.Outcome.RETURN;
+import static com.predic8.membrane.core.interceptor.mcp.MCPUtil.*;
 import static com.predic8.membrane.core.interceptor.mcp.McpSessionContext.McpSessionState.INITIALIZED;
 import static com.predic8.membrane.core.interceptor.mcp.McpSessionContext.McpSessionState.READY;
 import static com.predic8.membrane.core.jsonrpc.JSONRPCRequest.parse;
@@ -203,7 +204,7 @@ public class MembraneMCPServer extends AbstractInterceptor {
                 ))
                 .register(new McpToolDefinition(
                         "getExchanges",
-                        "Gets recent HTTP exchanges with sanitized headers and optional bodies",
+                        "Gets recent HTTP exchanges with sanitized headers, optional bodies, and request filters",
                         getExchangesSchema(),
                         this::getExchanges
                 ))
@@ -216,7 +217,7 @@ public class MembraneMCPServer extends AbstractInterceptor {
     }
 
     private MCPToolsCallResponse listProxies(MCPToolsCall call, Exchange exc) {
-        MCPUtil.rejectUnexpectedArguments(call, Set.of());
+        rejectUnexpectedArguments(call, Set.of());
         return MCPToolsCallResponse.from(call)
                 .withJson(Map.of(
                         "proxies",
@@ -230,29 +231,33 @@ public class MembraneMCPServer extends AbstractInterceptor {
     }
 
     private MCPToolsCallResponse getStatistics(MCPToolsCall call, Exchange exc) {
-        MCPUtil.rejectUnexpectedArguments(call, Set.of());
+        rejectUnexpectedArguments(call, Set.of());
         return MCPToolsCallResponse.from(call)
                 .withJson(getRouter().getStatistics());
     }
 
     private MCPToolsCallResponse getExchanges(MCPToolsCall call, Exchange exc) {
-        MCPUtil.rejectUnexpectedArguments(call, Set.of("limit", "includeBodies"));
+        rejectUnexpectedArguments(call, Set.of("limit", "includeBodies", "host", "port", "pathPattern", "path"));
 
-        int limit = MCPUtil.getOptionalIntArgument(call, "limit", maxExchanges, 1, maxExchanges);
-        boolean includeBodies = MCPUtil.getOptionalBooleanArgument(call, "includeBodies", false);
-
-        List<AbstractExchange> exchanges = Optional.ofNullable(getRouter().getExchangeStore().getAllExchangesAsList())
-                .orElse(List.of());
-        int start = Math.max(0, exchanges.size() - limit);
+        List<AbstractExchange> filteredExchanges = Optional.ofNullable(getRouter().getExchangeStore().getAllExchangesAsList())
+                .orElse(List.of())
+                .stream()
+                .filter(exchange -> ExchangeUtils.matchesExchangeFilter(exchange, getOptionalStringArgument(call, "host"), getOptionalPort(call), getOptionalStringArgument(call, "pathPattern")))
+                .toList();
+        List<AbstractExchange> exchanges = filteredExchanges.subList(Math.max(0, filteredExchanges.size() - getOptionalIntArgument(call, "limit", maxExchanges, 1, maxExchanges)), filteredExchanges.size());
 
         return MCPToolsCallResponse.from(call)
                 .withJson(Map.of(
                         "exchanges",
-                        exchanges.subList(start, exchanges.size()).stream()
-                                .map(exchange -> MCPUtil.describeExchange(exchange, includeBodies, payloadSanitizer))
+                        exchanges.stream()
+                                .map(exchange -> MCPUtil.describeExchange(exchange, MCPUtil.getOptionalBooleanArgument(call, "includeBodies", false), payloadSanitizer))
                                 .filter(Objects::nonNull)
                                 .toList()
                 ));
+    }
+
+    private static @Nullable Integer getOptionalPort(MCPToolsCall call) {
+        return call.getArgument("port") == null ? null : getOptionalIntArgument(call, "port", -1, 1, 65535);
     }
 
     private Map<String, Object> getExchangesSchema() {
@@ -260,7 +265,10 @@ public class MembraneMCPServer extends AbstractInterceptor {
                 "type", "object",
                 "properties", Map.of(
                         "limit", Map.of("type", "integer", "minimum", 1, "maximum", maxExchanges),
-                        "includeBodies", Map.of("type", "boolean")
+                        "includeBodies", Map.of("type", "boolean"),
+                        "host", Map.of("type", "string"),
+                        "port", Map.of("type", "integer", "minimum", 1, "maximum", 65535),
+                        "pathPattern", Map.of("type", "string", "description", "Matches by prefix or regex")
                 ),
                 "additionalProperties", false
         );

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/mcp/MembraneMCPServer.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/mcp/MembraneMCPServer.java
@@ -272,6 +272,7 @@ public class MembraneMCPServer extends AbstractInterceptor {
 
     /**
      * @description Maximum number of exchanges that can be returned by the getExchanges MCP tool.
+     * @default 100
      */
     @MCAttribute
     public void setMaxExchanges(int maxExchanges) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/mcp/MembraneMCPServer.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/mcp/MembraneMCPServer.java
@@ -1,6 +1,7 @@
 package com.predic8.membrane.core.interceptor.mcp;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.predic8.membrane.annot.MCAttribute;
 import com.predic8.membrane.annot.MCElement;
 import com.predic8.membrane.core.exchange.AbstractExchange;
 import com.predic8.membrane.core.exchange.Exchange;
@@ -45,25 +46,17 @@ public class MembraneMCPServer extends AbstractInterceptor {
 
     private static final Logger log = LoggerFactory.getLogger(MembraneMCPServer.class);
 
-    private static final int MAX_EXCHANGES = 100;
+    private static final int DEFAULT_MAX_EXCHANGES = 100;
 
     private static final Map<String, Object> EMPTY_OBJECT_SCHEMA = Map.of(
             "type", "object",
             "properties", Map.of(),
             "additionalProperties", false
     );
-    private static final Map<String, Object> GET_EXCHANGES_SCHEMA = Map.of(
-            "type", "object",
-            "properties", Map.of(
-                    "limit", Map.of("type", "integer", "minimum", 1, "maximum", MAX_EXCHANGES),
-                    "includeBodies", Map.of("type", "boolean")
-            ),
-            "additionalProperties", false
-    );
-
     private final Map<String, McpSessionContext> sessionContexts = new ConcurrentHashMap<>();
     private final McpPayloadSanitizer payloadSanitizer = new McpPayloadSanitizer();
-    private final McpToolRegistry toolRegistry = buildToolRegistry();
+    private int maxExchanges = DEFAULT_MAX_EXCHANGES;
+    private McpToolRegistry toolRegistry = buildToolRegistry();
 
     @Override
     public Outcome handleRequest(Exchange exc) {
@@ -211,7 +204,7 @@ public class MembraneMCPServer extends AbstractInterceptor {
                 .register(new McpToolDefinition(
                         "getExchanges",
                         "Gets recent HTTP exchanges with sanitized headers and optional bodies",
-                        GET_EXCHANGES_SCHEMA,
+                        getExchangesSchema(),
                         this::getExchanges
                 ))
                 .register(new McpToolDefinition(
@@ -245,7 +238,7 @@ public class MembraneMCPServer extends AbstractInterceptor {
     private MCPToolsCallResponse getExchanges(MCPToolsCall call, Exchange exc) {
         MCPUtil.rejectUnexpectedArguments(call, Set.of("limit", "includeBodies"));
 
-        int limit = MCPUtil.getOptionalIntArgument(call, "limit", MAX_EXCHANGES, 1, MAX_EXCHANGES);
+        int limit = MCPUtil.getOptionalIntArgument(call, "limit", maxExchanges, 1, maxExchanges);
         boolean includeBodies = MCPUtil.getOptionalBooleanArgument(call, "includeBodies", false);
 
         List<AbstractExchange> exchanges = Optional.ofNullable(getRouter().getExchangeStore().getAllExchangesAsList())
@@ -260,6 +253,33 @@ public class MembraneMCPServer extends AbstractInterceptor {
                                 .filter(Objects::nonNull)
                                 .toList()
                 ));
+    }
+
+    private Map<String, Object> getExchangesSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "limit", Map.of("type", "integer", "minimum", 1, "maximum", maxExchanges),
+                        "includeBodies", Map.of("type", "boolean")
+                ),
+                "additionalProperties", false
+        );
+    }
+
+    public int getMaxExchanges() {
+        return maxExchanges;
+    }
+
+    /**
+     * @description Maximum number of exchanges that can be returned by the getExchanges MCP tool.
+     */
+    @MCAttribute
+    public void setMaxExchanges(int maxExchanges) {
+        if (maxExchanges < 1) {
+            throw new IllegalArgumentException("maxExchanges must be >= 1");
+        }
+        this.maxExchanges = maxExchanges;
+        toolRegistry = buildToolRegistry();
     }
 
     private McpHttpResult badRequest(Exchange exc, @Nullable JSONRPCRequest request, int code, String message, Exception exception) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * getExchanges tool now supports optional filters: host, port, and pathPattern alongside limit and includeBodies for targeted retrieval.

* **Bug Fixes**
  * Invalid pathPattern values are handled safely (won’t break queries).
  * Tool argument validation tightened to reject unexpected arguments.

* **Documentation**
  * getExchanges schema and description updated to document the new filter parameters and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->