### PR TITLE
Fix flaky OrchestrationTutorialTest: Update orchestration tutorial to use fruitshop

### DIFF
--- a/distribution/src/test/java/com/predic8/membrane/tutorials/orchestration/OrchestrationTutorialTest.java
+++ b/distribution/src/test/java/com/predic8/membrane/tutorials/orchestration/OrchestrationTutorialTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -29,16 +30,17 @@ public class OrchestrationTutorialTest extends AbstractOrchestrationTutorialTest
     }
 
     @Test
-    void latestProduct_isReturned() {
+    void latestProductCopy_isCreatedWithFixedPrice() {
         // @formatter:off
         given()
         .when()
-            .get("http://localhost:2000/products/latest")
+            .post("http://localhost:2000/products/latest/copy")
         .then()
-            .statusCode(200)
+            .statusCode(201)
             .body("id", notNullValue())
             .body("name", notNullValue())
-            .body("price", greaterThan(0f));
+            .body("price", equalTo(5))
+            .body("name", containsString("Copy"));
         // @formatter:on
     }
 

--- a/distribution/src/test/java/com/predic8/membrane/tutorials/orchestration/OrchestrationTutorialTest.java
+++ b/distribution/src/test/java/com/predic8/membrane/tutorials/orchestration/OrchestrationTutorialTest.java
@@ -17,7 +17,9 @@ package com.predic8.membrane.tutorials.orchestration;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class OrchestrationTutorialTest extends AbstractOrchestrationTutorialTest {
 
@@ -27,23 +29,16 @@ public class OrchestrationTutorialTest extends AbstractOrchestrationTutorialTest
     }
 
     @Test
-    void books_areReturnedById() {
+    void latestProduct_isReturned() {
         // @formatter:off
         given()
         .when()
-            .get("http://localhost:2000/books/{id}", "OL29474405M")
+            .get("http://localhost:2000/products/latest")
         .then()
             .statusCode(200)
-            .body("title", equalTo("So Long, and Thanks for All the Fish"))
-            .body("author", equalTo("Douglas Adams"));
-
-        given()
-        .when()
-            .get("http://localhost:2000/books/{id}", "OL26333978M")
-        .then()
-            .statusCode(200)
-            .body("title", equalTo("Foucault's pendulum"))
-            .body("author", equalTo("Umberto Eco"));
+            .body("id", notNullValue())
+            .body("name", notNullValue())
+            .body("price", greaterThan(0f));
         // @formatter:on
     }
 

--- a/distribution/tutorials/orchestration/30-Orchestration.yaml
+++ b/distribution/tutorials/orchestration/30-Orchestration.yaml
@@ -2,26 +2,30 @@
 #
 # Tutorial: Orchestration
 #
-# Shows how to create an API that combines two backend calls into one API.
-# 1) Fetch the newest product id from the fruitshop product list.
-# 2) Use that id to fetch full product details.
+# Shows how to create an API that combines multiple backend calls into one API.
+# 1) Fetch the newest product from fruitshop.
+# 2) Create a new product with a copy of this product and a fixed price of 5.
 #
 # Try:
-#    curl localhost:2000/products/latest
+#    curl -X POST localhost:2000/products/latest/copy
 
 api:
   port: 2000
   path:
-    uri: /products/latest
+    uri: /products/latest/copy
   flow:
     - request:
         - call:
             url: https://api.predic8.de/shop/v2/products?sort=id&order=desc&limit=1
-        - setProperty:
-            name: id
-            value: ${$.products[0].id}
-            language: jsonpath
+        - template:
+            contentType: application/json
+            src: |
+              {
+                "name": ${jsonPath('$.products[0].name') + ' Copy'},
+                "price": 5
+              }
         - call:
-            url: https://api.predic8.de/shop/v2/products/${properties.id}
+            method: POST
+            url: https://api.predic8.de/shop/v2/products
     - return:
-        status: 200
+        status: 201

--- a/distribution/tutorials/orchestration/30-Orchestration.yaml
+++ b/distribution/tutorials/orchestration/30-Orchestration.yaml
@@ -3,34 +3,25 @@
 # Tutorial: Orchestration
 #
 # Shows how to create an API that combines two backend calls into one API.
-# 1) Fetch a book by id.
-# 2) Use the author key from the book payload to fetch the author.
+# 1) Fetch the newest product id from the fruitshop product list.
+# 2) Use that id to fetch full product details.
 #
 # Try:
-#    curl localhost:2000/books/OL29474405M
-#    curl localhost:2000/books/OL26333978M
+#    curl localhost:2000/products/latest
 
 api:
   port: 2000
   path:
-    uri: /books/{id}
+    uri: /products/latest
   flow:
     - request:
         - call:
-            url: https://openlibrary.org/books/${pathParam.id}.json
+            url: https://api.predic8.de/shop/v2/products?sort=id&order=desc&limit=1
         - setProperty:
-            name: title
-            value: ${$.title}
+            name: id
+            value: ${$.products[0].id}
             language: jsonpath
         - call:
-            url: https://openlibrary.org${$.authors[0].key}.json
-            language: jsonpath
-        - template:
-            contentType: application/json
-            src: |
-              {
-                "title": ${property.title},
-                "author": ${jsonPath('$.name')}
-              }
+            url: https://api.predic8.de/shop/v2/products/${properties.id}
     - return:
         status: 200


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote orchestration tutorial from a library/books example to a product catalog workflow that creates a copied product via /products/latest/copy; the flow now builds a new product with name suffixed "Copy" and a fixed price of 5, returning HTTP 201.

* **Tests**
  * Updated tests to remove the old books checks and verify the new copy endpoint returns 201, non-null id/name, exact price 5, and that name contains "Copy".

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/membrane/api-gateway/pull/2940)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/membrane/api-gateway/pull/2940)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->