### PR TITLE
Status code change in response from 4XX to 500

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/cli/RouterCLI.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/RouterCLI.java
@@ -47,9 +47,7 @@ import java.nio.file.Path;
 import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.Scanner;
-import java.util.stream.Collectors;
 
 import static com.predic8.membrane.annot.Constants.*;
 import static com.predic8.membrane.core.cli.util.JwkGenerator.generateJWK;

--- a/core/src/main/java/com/predic8/membrane/core/exceptions/ProblemDetails.java
+++ b/core/src/main/java/com/predic8/membrane/core/exceptions/ProblemDetails.java
@@ -31,6 +31,8 @@ import static com.predic8.membrane.core.exceptions.ProblemDetailsXML.createXMLCo
 import static com.predic8.membrane.core.http.MimeType.APPLICATION_PROBLEM_JSON;
 import static com.predic8.membrane.core.http.MimeType.TEXT_PLAIN_UTF8;
 import static com.predic8.membrane.core.http.Response.statusCode;
+import static com.predic8.membrane.core.interceptor.Interceptor.Flow.REQUEST;
+import static com.predic8.membrane.core.interceptor.Interceptor.Flow.RESPONSE;
 import static com.predic8.membrane.core.util.ExceptionUtil.concatMessageAndCauseMessages;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Locale.ROOT;
@@ -369,6 +371,12 @@ public class ProblemDetails {
      * If a user error (4XX) occurs in the response flow, convert error code to 500.
      */
     private int correctStatusCodeForResponse(Exchange exc, int status) {
+        if (flow == REQUEST)
+            return status;
+        if (flow == RESPONSE && status >= 400 && status < 500)
+            return 500;
+
+        // flow is not set. If there is already a response, it is probably the response flow.
         if (exc != null && exc.getResponse() != null && status >= 400 && status < 500)
             return 500;
         return status;

--- a/core/src/main/java/com/predic8/membrane/core/exceptions/ProblemDetails.java
+++ b/core/src/main/java/com/predic8/membrane/core/exceptions/ProblemDetails.java
@@ -11,23 +11,30 @@
 
 package com.predic8.membrane.core.exceptions;
 
-import com.fasterxml.jackson.core.*;
-import com.fasterxml.jackson.databind.*;
-import com.predic8.membrane.core.exchange.*;
-import com.predic8.membrane.core.http.*;
-import com.predic8.membrane.core.interceptor.*;
-import org.jetbrains.annotations.*;
-import org.slf4j.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.http.Response;
+import com.predic8.membrane.core.interceptor.Interceptor;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 
-import static com.predic8.membrane.core.exceptions.ProblemDetailsXML.*;
-import static com.predic8.membrane.core.http.MimeType.*;
-import static com.predic8.membrane.core.http.Response.*;
-import static com.predic8.membrane.core.util.ExceptionUtil.*;
-import static java.nio.charset.StandardCharsets.*;
-import static java.util.Locale.*;
-import static java.util.UUID.*;
+import static com.predic8.membrane.core.exceptions.ProblemDetailsXML.createXMLContent;
+import static com.predic8.membrane.core.http.MimeType.APPLICATION_PROBLEM_JSON;
+import static com.predic8.membrane.core.http.MimeType.TEXT_PLAIN_UTF8;
+import static com.predic8.membrane.core.http.Response.statusCode;
+import static com.predic8.membrane.core.util.ExceptionUtil.concatMessageAndCauseMessages;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Locale.ROOT;
+import static java.util.UUID.randomUUID;
 
 
 /**
@@ -344,7 +351,7 @@ public class ProblemDetails {
     }
 
     private Response createContent(Map<String, Object> root, Exchange exchange) {
-        Response.ResponseBuilder builder = statusCode(status);
+        var builder = statusCode(correctStatusCodeForResponse(exchange,status));
         try {
             if (exchange != null && (acceptXML(exchange) || exchange.getRequest().isXML())) {
                 createXMLContent(root, builder);
@@ -356,6 +363,15 @@ public class ProblemDetails {
             builder.contentType(TEXT_PLAIN_UTF8);
         }
         return builder.build();
+    }
+
+    /**
+     * If a user error (4XX) occurs in the response flow, convert error code to 500.
+     */
+    private int correctStatusCodeForResponse(Exchange exc, int status) {
+        if (exc != null && exc.getResponse() != null && status >= 400 && status < 500)
+            return 500;
+        return status;
     }
 
     private boolean acceptXML(Exchange exchange) {

--- a/core/src/main/java/com/predic8/membrane/core/exceptions/ProblemDetails.java
+++ b/core/src/main/java/com/predic8/membrane/core/exceptions/ProblemDetails.java
@@ -353,7 +353,9 @@ public class ProblemDetails {
     }
 
     private Response createContent(Map<String, Object> root, Exchange exchange) {
-        var builder = statusCode(correctStatusCodeForResponse(exchange,status));
+        var effectiveStatus = correctStatusCodeForResponse(exchange, status);
+        root.put(STATUS, effectiveStatus);   // keep body in sync with HTTP status
+        var builder = statusCode(effectiveStatus);
         try {
             if (exchange != null && (acceptXML(exchange) || exchange.getRequest().isXML())) {
                 createXMLContent(root, builder);

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/xml/Xml2JsonInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/xml/Xml2JsonInterceptor.java
@@ -146,7 +146,7 @@ public class Xml2JsonInterceptor extends AbstractInterceptor {
             log.info(msg, e);
             log.debug("", e);
         }
-        internal(router.getConfiguration().isProduction(), getDisplayName()).flow(flow).status(flow == REQUEST ? 400 : 500)
+        internal(router.getConfiguration().isProduction(), getDisplayName()).flow(flow).status(400)
                 .detail(msg)
                 .exception(e)
                 .topLevel("charset-from-header", exc.getMessage(flow).getHeader().getCharset())

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/xslt/XSLTInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/xslt/XSLTInterceptor.java
@@ -13,29 +13,33 @@
    limitations under the License. */
 package com.predic8.membrane.core.interceptor.xslt;
 
-import com.predic8.membrane.annot.*;
-import com.predic8.membrane.core.exceptions.*;
-import com.predic8.membrane.core.exchange.*;
-import com.predic8.membrane.core.http.*;
-import com.predic8.membrane.core.interceptor.*;
-import com.predic8.membrane.core.multipart.*;
-import com.predic8.membrane.core.util.*;
-import org.jetbrains.annotations.*;
-import org.slf4j.*;
+import com.predic8.membrane.annot.MCAttribute;
+import com.predic8.membrane.annot.MCElement;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.http.Message;
+import com.predic8.membrane.core.interceptor.AbstractInterceptor;
+import com.predic8.membrane.core.interceptor.Outcome;
+import com.predic8.membrane.core.multipart.XOPReconstitutor;
+import com.predic8.membrane.core.util.ConfigurationException;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import javax.xml.transform.*;
-import javax.xml.transform.stream.*;
-import java.io.*;
-import java.util.*;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.stream.StreamSource;
+import java.util.Map;
 
-import static com.predic8.membrane.core.exceptions.ProblemDetails.*;
 import static com.predic8.membrane.core.exceptions.ProblemDetails.internal;
-import static com.predic8.membrane.core.interceptor.Interceptor.Flow.*;
-import static com.predic8.membrane.core.interceptor.Outcome.*;
+import static com.predic8.membrane.core.exceptions.ProblemDetails.user;
+import static com.predic8.membrane.core.interceptor.Interceptor.Flow.REQUEST;
+import static com.predic8.membrane.core.interceptor.Interceptor.Flow.RESPONSE;
 import static com.predic8.membrane.core.interceptor.Outcome.ABORT;
+import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
 import static com.predic8.membrane.core.util.ExceptionUtil.getRootCause;
-import static com.predic8.membrane.core.util.text.StringUtil.*;
-import static com.predic8.membrane.core.util.text.TextUtil.*;
+import static com.predic8.membrane.core.util.text.StringUtil.tail;
+import static com.predic8.membrane.core.util.text.StringUtil.truncateAfter;
+import static com.predic8.membrane.core.util.text.TextUtil.linkURL;
+import static com.predic8.membrane.core.util.text.TextUtil.removeFinalChar;
 
 /**
  * @description <p>
@@ -75,7 +79,8 @@ public class XSLTInterceptor extends AbstractInterceptor {
         } catch (TransformerException e) {
             log.debug("", e);
             var cause = getRootCause(e);
-            if (cause.getMessage() != null && cause.getMessage().contains("not allowed in prolog")) {
+            // rolog matches Prolog and prolog
+            if (cause.getMessage() != null && cause.getMessage().contains("rolog")) {
                 user(router.getConfiguration().isProduction(), getDisplayName())
                         .title("Content not allowed in prolog of XML input.")
                         .detail("Check for extra characters before the XML declaration <?xml ... ?>")

--- a/core/src/main/java/com/predic8/membrane/core/lang/xpath/XPathExchangeExpression.java
+++ b/core/src/main/java/com/predic8/membrane/core/lang/xpath/XPathExchangeExpression.java
@@ -14,23 +14,31 @@
 
 package com.predic8.membrane.core.lang.xpath;
 
-import com.predic8.membrane.core.config.xml.*;
-import com.predic8.membrane.core.exchange.*;
-import com.predic8.membrane.core.http.*;
-import com.predic8.membrane.core.interceptor.*;
-import com.predic8.membrane.core.lang.*;
-import com.predic8.membrane.core.router.*;
-import com.predic8.membrane.core.util.xml.*;
-import com.predic8.membrane.core.util.xml.parser.*;
-import org.jetbrains.annotations.*;
-import org.slf4j.*;
-import org.w3c.dom.*;
+import com.predic8.membrane.core.config.xml.XmlConfig;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.http.Message;
+import com.predic8.membrane.core.interceptor.Interceptor;
+import com.predic8.membrane.core.interceptor.XMLSupport;
+import com.predic8.membrane.core.lang.AbstractExchangeExpression;
+import com.predic8.membrane.core.lang.ExchangeExpressionException;
+import com.predic8.membrane.core.router.Router;
+import com.predic8.membrane.core.util.xml.XMLUtil;
+import com.predic8.membrane.core.util.xml.XPathUtil;
+import com.predic8.membrane.core.util.xml.parser.HardenedXmlParser;
+import com.predic8.membrane.core.util.xml.parser.XmlParser;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.NodeList;
 
-import javax.xml.namespace.*;
-import javax.xml.xpath.*;
+import javax.xml.namespace.QName;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathEvaluationResult;
+import javax.xml.xpath.XPathExpressionException;
 
-import static com.predic8.membrane.core.util.text.StringUtil.*;
-import static javax.xml.xpath.XPathConstants.*;
+import static com.predic8.membrane.core.util.text.StringUtil.tail;
+import static com.predic8.membrane.core.util.text.StringUtil.truncateAfter;
+import static javax.xml.xpath.XPathConstants.NODESET;
 
 public class XPathExchangeExpression extends AbstractExchangeExpression {
 
@@ -116,14 +124,16 @@ public class XPathExchangeExpression extends AbstractExchangeExpression {
             }
         } catch (RuntimeException e) {
             // Parser errors may escape as unchecked exceptions.
-            if (causeMessageContains(e, "not allowed in prolog")) {
+            // Matches: prolog and Prolog
+            if (causeMessageContains(e, "rolog")) {
                 throw new ExchangeExpressionException(expression, e, "Content not allowed in prolog of XML input.")
                         .detail("There are extra characters before the XML declaration <?xml ... ?>")
                         .body(truncateAfter(msg.getBodyAsStringDecoded(), 50))
                         .excludeException();
             }
 
-            if (causeMessageContains(e, "is not allowed in trailing section")) {
+            // Matches: Content and content
+            if (causeMessageContains(e, "ontent")) {
                 throw new ExchangeExpressionException(expression, e, "Content not allowed in trailing section of XML input.")
                         .detail("There are extra characters after the XML root element (after the final closing tag like </root>).")
                         .body(tail(msg.getBodyAsStringDecoded(), 50))

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/xml/Xml2JsonInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/xml/Xml2JsonInterceptorTest.java
@@ -14,21 +14,30 @@
 package com.predic8.membrane.core.interceptor.xml;
 
 
-import com.fasterxml.jackson.databind.*;
-import com.predic8.membrane.core.exchange.*;
-import com.predic8.membrane.core.http.*;
-import com.predic8.membrane.core.interceptor.*;
-import com.predic8.membrane.core.router.*;
-import org.apache.commons.io.*;
-import org.jetbrains.annotations.*;
-import org.junit.jupiter.api.*;
-import org.slf4j.*;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.http.MimeType;
+import com.predic8.membrane.core.http.Request;
+import com.predic8.membrane.core.http.Response;
+import com.predic8.membrane.core.interceptor.Outcome;
+import com.predic8.membrane.core.router.DefaultRouter;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.*;
-import java.nio.charset.*;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
 
 import static com.predic8.membrane.core.http.MimeType.*;
-import static java.nio.charset.StandardCharsets.*;
+import static com.predic8.membrane.core.http.Request.get;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.*;
 
 
@@ -93,6 +102,14 @@ public class Xml2JsonInterceptorTest {
     void validTestxml2jsonResponse() throws Exception {
         assertEquals(UMLAUTS,
                 getJsonRootFromStream(processThroughInterceptorResponse(loadResource("/xml/content-utf-8-encoding-utf-8.xml"))).get("bar").get("futf").asText());
+    }
+
+    @Test
+    void statusCodeOfResponseError() throws URISyntaxException {
+        var exc = get("/foo").buildExchange();
+        exc.setResponse(Response.ok().contentType(TEXT_XML).body("<unclosed>").build());
+        interceptor.handleResponse(exc);
+        assertEquals(500, exc.getResponse().getStatusCode());
     }
 
     private JsonNode getJsonRootFromStream(InputStream stream) throws IOException {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/xslt/XSLTInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/xslt/XSLTInterceptorTest.java
@@ -13,22 +13,20 @@
    limitations under the License. */
 package com.predic8.membrane.core.interceptor.xslt;
 
-import com.predic8.membrane.core.exchange.*;
-import com.predic8.membrane.core.http.*;
-import com.predic8.membrane.core.interceptor.*;
-import com.predic8.membrane.core.router.*;
-import org.hamcrest.*;
-import org.junit.jupiter.api.*;
-import org.xml.sax.*;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.router.DummyTestRouter;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.InputSource;
 
-import javax.xml.xpath.*;
-import java.io.*;
-import java.net.*;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 
 import static com.predic8.membrane.core.http.Request.get;
-import static com.predic8.membrane.core.http.Response.*;
+import static com.predic8.membrane.core.http.Response.ok;
 import static com.predic8.membrane.core.interceptor.Outcome.ABORT;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class XSLTInterceptorTest {
 
@@ -83,7 +81,7 @@ public class XSLTInterceptorTest {
         i.init(new DummyTestRouter());
         assertEquals(ABORT, i.handleRequest(exc));
         assertEquals(400, exc.getResponse().getStatusCode());
-        String body = exc.getResponse().getBodyAsStringDecoded();
+        var body = exc.getResponse().getBodyAsStringDecoded();
         assertTrue(body.contains("rubbish"));
         assertTrue(body.contains("not allowed in prolog"));
     }

--- a/core/src/test/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIPublisherInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIPublisherInterceptorTest.java
@@ -16,26 +16,31 @@
 
 package com.predic8.membrane.core.openapi.serviceproxy;
 
-import com.fasterxml.jackson.databind.*;
-import com.predic8.membrane.core.exchange.*;
-import com.predic8.membrane.core.http.*;
-import com.predic8.membrane.core.openapi.util.*;
-import com.predic8.membrane.core.proxies.*;
-import com.predic8.membrane.core.router.*;
-import com.predic8.membrane.core.util.*;
-import io.swagger.v3.parser.*;
-import org.junit.jupiter.api.*;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.http.Header;
+import com.predic8.membrane.core.http.Request;
+import com.predic8.membrane.core.openapi.util.OpenAPITestUtils;
+import com.predic8.membrane.core.proxies.NullProxy;
+import com.predic8.membrane.core.router.DefaultRouter;
+import com.predic8.membrane.core.util.URIFactory;
+import io.swagger.v3.parser.ObjectMapperFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.io.*;
-import java.util.*;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
-import static com.predic8.membrane.core.http.MimeType.*;
-import static com.predic8.membrane.core.interceptor.Outcome.*;
+import static com.predic8.membrane.core.http.MimeType.APPLICATION_PROBLEM_JSON;
+import static com.predic8.membrane.core.interceptor.Outcome.RETURN;
 import static org.junit.jupiter.api.Assertions.*;
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class OpenAPIPublisherInterceptorTest {
 
     private final ObjectMapper omYaml = ObjectMapperFactory.createYaml();
@@ -68,7 +73,7 @@ public class OpenAPIPublisherInterceptorTest {
     }
 
     @Test
-    public void constructor() {
+    void constructor() {
         assertTrue(interceptor.apis.size() >= 27);
         assertNotNull(interceptor.apis.get("references-test-v1-0"));
         assertNotNull(interceptor.apis.get("strings-test-api-v1-0"));
@@ -78,14 +83,14 @@ public class OpenAPIPublisherInterceptorTest {
         assertNotNull(interceptor.apis.get("references-response-test-v1-0"));
     }
 
-    final List<String> uiParameters() {
+    final static List<String> uiParameters() {
         return new ArrayList<>() {{
             add(UI_OLD);
             add(OpenAPIPublisherInterceptor.PATH_UI);
         }};
     }
 
-    final List<String> metaParameters() {
+    final static List<String> metaParameters() {
         return new ArrayList<>() {{
             add(META_OLD);
             add(OpenAPIPublisherInterceptor.PATH);
@@ -94,7 +99,7 @@ public class OpenAPIPublisherInterceptorTest {
 
     @ParameterizedTest
     @MethodSource("metaParameters")
-    public void getApiDirectory(String testPath) throws Exception {
+    void getApiDirectory(String testPath) throws Exception {
         get.getRequest().setUri(testPath);
         assertEquals( RETURN, interceptor.handleRequest(get));
         assertTrue(OpenAPITestUtils.getMapFromResponse(get).size() >= 27);
@@ -102,9 +107,9 @@ public class OpenAPIPublisherInterceptorTest {
 
     @ParameterizedTest
     @MethodSource("metaParameters")
-    public void getHTMLOverview(String testPath) {
+    void getHTMLOverview(String testPath) {
         get.getRequest().setUri(testPath);
-        Header header = new Header();
+        var header = new Header();
         header.setAccept("html");
         get.getRequest().setHeader(header);
         assertEquals( RETURN, interceptor.handleRequest(get));
@@ -113,7 +118,7 @@ public class OpenAPIPublisherInterceptorTest {
 
     @ParameterizedTest
     @MethodSource("uiParameters")
-    public void getSwaggerUI(String testPath) {
+    void getSwaggerUI(String testPath) {
         get.getRequest().setUri(testPath + "/nested-objects-and-arrays-test-api-v1-0");
         assertEquals( RETURN, interceptor.handleRequest(get));
         assertTrue(get.getResponse().getBodyAsStringDecoded().contains("html"));
@@ -121,7 +126,7 @@ public class OpenAPIPublisherInterceptorTest {
 
     @ParameterizedTest
     @MethodSource("uiParameters")
-    public void getSwaggerUIWrongId(String testPath) throws Exception {
+    void getSwaggerUIWrongId(String testPath) throws Exception {
         get.getRequest().setUri(testPath + "/wrong-id-0");
         assertEquals( RETURN, interceptor.handleRequest(get));
         assertEquals( 404, get.getResponse().getStatusCode());
@@ -130,7 +135,7 @@ public class OpenAPIPublisherInterceptorTest {
 
     @ParameterizedTest
     @MethodSource("uiParameters")
-    public void getSwaggerUINoId(String testPath) throws Exception {
+    void getSwaggerUINoId(String testPath) throws Exception {
         get.getRequest().setUri(testPath);
         assertEquals( RETURN, interceptor.handleRequest(get));
         assertEquals( 404, get.getResponse().getStatusCode());

--- a/core/src/test/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIPublisherInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIPublisherInterceptorTest.java
@@ -83,14 +83,14 @@ public class OpenAPIPublisherInterceptorTest {
         assertNotNull(interceptor.apis.get("references-response-test-v1-0"));
     }
 
-    final static List<String> uiParameters() {
+    static List<String> uiParameters() {
         return new ArrayList<>() {{
             add(UI_OLD);
             add(OpenAPIPublisherInterceptor.PATH_UI);
         }};
     }
 
-    final static List<String> metaParameters() {
+    static List<String> metaParameters() {
         return new ArrayList<>() {{
             add(META_OLD);
             add(OpenAPIPublisherInterceptor.PATH);

--- a/core/src/test/java/com/predic8/membrane/core/openapi/validators/exceptions/ExceptionInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/validators/exceptions/ExceptionInterceptorTest.java
@@ -16,20 +16,26 @@
 
 package com.predic8.membrane.core.openapi.validators.exceptions;
 
-import com.fasterxml.jackson.databind.*;
-import com.predic8.membrane.core.exchange.*;
-import com.predic8.membrane.core.http.*;
-import com.predic8.membrane.core.openapi.serviceproxy.*;
-import com.predic8.membrane.core.openapi.validators.security.*;
-import com.predic8.membrane.core.router.*;
-import org.junit.jupiter.api.*;
-import org.springframework.http.*;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.http.Request;
+import com.predic8.membrane.core.openapi.serviceproxy.OpenAPIInterceptor;
+import com.predic8.membrane.core.openapi.serviceproxy.OpenAPISpec;
+import com.predic8.membrane.core.openapi.validators.security.AbstractSecurityValidatorTest;
+import com.predic8.membrane.core.router.Router;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static com.predic8.membrane.core.interceptor.Outcome.*;
-import static com.predic8.membrane.core.openapi.serviceproxy.OpenAPISpec.YesNoOpenAPIOption.*;
-import static com.predic8.membrane.core.openapi.util.OpenAPITestUtils.*;
+import static com.predic8.membrane.core.http.Request.get;
+import static com.predic8.membrane.core.http.Response.ok;
+import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
+import static com.predic8.membrane.core.interceptor.Outcome.RETURN;
+import static com.predic8.membrane.core.openapi.serviceproxy.OpenAPISpec.YesNoOpenAPIOption.YES;
+import static com.predic8.membrane.core.openapi.util.OpenAPITestUtils.createProxy;
 import static com.predic8.membrane.test.TestUtil.getPathFromResource;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 public class ExceptionInterceptorTest extends AbstractSecurityValidatorTest {
 
@@ -58,7 +64,7 @@ public class ExceptionInterceptorTest extends AbstractSecurityValidatorTest {
     @Test
     void unknownType() throws Exception {
         Exchange exc = new Request.Builder().get("/unknown-type").buildExchange();
-        exc.setResponse(Response.ok().body("{}").contentType(MediaType.APPLICATION_JSON.toString()).build());
+        exc.setResponse(ok().body("{}").contentType(APPLICATION_JSON.toString()).build());
         exc.setOriginalRequestUri("/unknown-type");
 
         assertEquals(CONTINUE, interceptor.handleRequest(exc));
@@ -68,14 +74,14 @@ public class ExceptionInterceptorTest extends AbstractSecurityValidatorTest {
 
     @Test
     void nowhere() throws Exception {
-        Exchange exc = new Request.Builder().get("/nowhere").buildExchange();
-        exc.setResponse(Response.ok().body("{}").contentType(MediaType.APPLICATION_JSON.toString()).build());
+        var exc = get("/nowhere").buildExchange();
+        exc.setResponse(ok().body("{}").contentType(APPLICATION_JSON.toString()).build());
         exc.setOriginalRequestUri("/nowhere");
 
         assertEquals(CONTINUE, interceptor.handleRequest(exc));
         assertEquals(RETURN, interceptor.handleResponse(exc));
 
-        assertEquals(400,exc.getResponse().getStatusCode());
+        assertEquals(500,exc.getResponse().getStatusCode());
         JsonNode json = om.readTree(exc.getResponse().getBodyAsStream());
         assertEquals("https://membrane-api.io/problems/user/openapi",json.get("type").asText());
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More consistent HTTP status handling: some 4xx cases are now normalized to 500 in response flows.
  * XML→JSON transformation failures now consistently yield a 400 status.
  * Improved detection and mapping of XML parsing errors for more accurate error responses.

* **Tests**
  * Added test coverage for response error status behavior.
  * Test suites modernized and cleaned up for clarity and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/membrane/api-gateway/pull/2949?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->