### PR TITLE
Fix BalancerUtil to pick up all Clusters: port changes from f57e1b6 to 7.X

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/balancer/BalancerUtil.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/balancer/BalancerUtil.java
@@ -15,37 +15,84 @@
 package com.predic8.membrane.core.interceptor.balancer;
 
 import com.predic8.membrane.core.interceptor.*;
-import com.predic8.membrane.core.interceptor.chain.ChainInterceptor;
+import com.predic8.membrane.core.interceptor.flow.AbstractFlowInterceptor;
+import com.predic8.membrane.core.interceptor.flow.IfInterceptor;
+import com.predic8.membrane.core.interceptor.flow.choice.AbstractCaseOtherwise;
+import com.predic8.membrane.core.interceptor.flow.choice.ChooseInterceptor;
 import com.predic8.membrane.core.proxies.*;
 import com.predic8.membrane.core.router.Router;
 
 import java.util.*;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 public class BalancerUtil {
 
+	/**
+	 * The various getFlow() methods only expose the direct child flow of an interceptor.
+	 * Branching interceptors such as if/else and choose/case keep additional flow lists
+	 * outside of getFlow(), so those branches must be added explicitly while walking the flow tree.
+	 */
 	private static Stream<List<Interceptor>> allFlows(Router router) {
-		return Stream.of(
-				router.getRuleManager()
-						.getRules()
-						.stream()
-						.map(Proxy::getFlow),
+		Set<Interceptor> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+		return Stream.concat(ruleFlows(router), globalFlows(router))
+				.flatMap(flow -> allFlows(flow, visited));
+	}
+
+	private static Stream<List<Interceptor>> ruleFlows(Router router) {
+		return router.getRuleManager()
+				.getRules()
+				.stream()
+				.map(Proxy::getFlow);
+	}
+
+	private static Stream<List<Interceptor>> globalFlows(Router router) {
+		return Optional.ofNullable(router.getRegistry())
+				.stream()
+				.flatMap(registry -> registry.getBean(GlobalInterceptor.class).stream())
+				.map(GlobalInterceptor::getFlow);
+	}
+
+	private static Stream<List<Interceptor>> allFlows(List<Interceptor> flow, Set<Interceptor> visited) {
+		if (flow == null) {
+			return Stream.empty();
+		}
+		return Stream.concat(
+				Stream.of(flow),
+				flow.stream().flatMap(interceptor -> childFlows(interceptor, visited))
+		);
+	}
+
+	private static Stream<List<Interceptor>> childFlows(Interceptor interceptor, Set<Interceptor> visited) {
+		if (interceptor == null || !visited.add(interceptor)) {
+			return Stream.empty();
+		}
+		return directChildFlows(interceptor)
+				.flatMap(flow -> allFlows(flow, visited));
+	}
+
+	private static Stream<List<Interceptor>> directChildFlows(Interceptor interceptor) {
+		if (interceptor instanceof ChooseInterceptor chooseInterceptor) {
+			return chooseInterceptor.getChoices().stream()
+					.map(AbstractCaseOtherwise::getFlow);
+		}
+		if (interceptor instanceof IfInterceptor ifInterceptor) {
+			return Stream.of(ifInterceptor.getFlow(), ifInterceptor.getElseInterceptor());
+		}
+		if (interceptor instanceof AbstractFlowInterceptor flowInterceptor) {
+			return Stream.of(flowInterceptor.getFlow());
+		}
+		return Stream.empty();
+	}
+
+	private static Stream<Balancer> balancerBeans(Router router) {
+		return Stream.concat(
 				Optional.ofNullable(router.getRegistry())
 						.stream()
-						.flatMap(registry -> registry.getBeans(ChainInterceptor.class).stream())
-						.map(ChainInterceptor::getFlow),
+						.flatMap(registry -> registry.getBeans(Balancer.class).stream()),
 				Optional.ofNullable(router.getBeanFactory())
-						.map(ctx -> ctx.getBeansOfType(ChainInterceptor.class)
-								.values()
-								.stream()
-								.map(ChainInterceptor::getFlow))
-						.orElseGet(Stream::empty),
-				Optional.ofNullable(router.getRegistry())
-						.stream()
-						.flatMap(registry -> registry.getBean(GlobalInterceptor.class).stream())
-						.map(GlobalInterceptor::getFlow)
-		).flatMap(Function.identity());
+						.map(ctx -> ctx.getBeansOfType(Balancer.class).values().stream())
+						.orElseGet(Stream::empty)
+		).distinct();
 	}
 
 	public static List<LoadBalancingInterceptor> collectBalancers(Router router) {
@@ -62,16 +109,7 @@ public class BalancerUtil {
 		return Stream.concat(
 				collectBalancers(router).stream()
 						.flatMap(lbi -> lbi.getClusterManager().getClusters().stream()),
-				Stream.concat(
-						Optional.ofNullable(router.getRegistry())
-								.stream()
-								.flatMap(registry -> registry.getBeans(Balancer.class).stream())
-								.flatMap(b -> b.getClusters().stream()),
-						Optional.ofNullable(router.getBeanFactory())
-								.map(ctx -> ctx.getBeansOfType(Balancer.class).values().stream()
-										.flatMap(b -> b.getClusters().stream()))
-								.orElseGet(Stream::empty)
-				)
+				balancerBeans(router).flatMap(b -> b.getClusters().stream())
 		).distinct().toList();
 	}
 
@@ -91,15 +129,7 @@ public class BalancerUtil {
 	}
 
 	public static boolean hasLoadBalancing(Router router) {
-		for (Proxy r : router.getRuleManager().getRules()) {
-			List<Interceptor> interceptors = r.getFlow();
-			if (interceptors == null)
-				continue;
-			for (Interceptor i : interceptors)
-				if (i instanceof LoadBalancingInterceptor)
-					return true;
-		}
-		return false;
+		return !collectBalancers(router).isEmpty();
 	}
 
 	public static void up(Router router, String balancerName, String cName, String host, int port) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/balancer/BalancerUtil.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/balancer/BalancerUtil.java
@@ -15,59 +15,79 @@
 package com.predic8.membrane.core.interceptor.balancer;
 
 import com.predic8.membrane.core.interceptor.*;
+import com.predic8.membrane.core.interceptor.chain.ChainInterceptor;
 import com.predic8.membrane.core.proxies.*;
-import com.predic8.membrane.core.router.*;
+import com.predic8.membrane.core.router.Router;
 
 import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 public class BalancerUtil {
 
-	public static List<Cluster> collectClusters(Router router) {
-		ArrayList<Cluster> result = new ArrayList<>();
-		for (Proxy r : router.getRuleManager().getRules()) {
-			List<Interceptor> interceptors = r.getFlow();
-			if (interceptors != null)
-				for (Interceptor i : interceptors)
-					if (i instanceof LoadBalancingInterceptor)
-						result.addAll(((LoadBalancingInterceptor)i).getClusterManager().getClusters());
-		}
-		return result;
+	private static Stream<List<Interceptor>> allFlows(Router router) {
+		return Stream.of(
+				router.getRuleManager()
+						.getRules()
+						.stream()
+						.map(Proxy::getFlow),
+				Optional.ofNullable(router.getRegistry())
+						.stream()
+						.flatMap(registry -> registry.getBeans(ChainInterceptor.class).stream())
+						.map(ChainInterceptor::getFlow),
+				Optional.ofNullable(router.getBeanFactory())
+						.map(ctx -> ctx.getBeansOfType(ChainInterceptor.class)
+								.values()
+								.stream()
+								.map(ChainInterceptor::getFlow))
+						.orElseGet(Stream::empty),
+				Optional.ofNullable(router.getRegistry())
+						.stream()
+						.flatMap(registry -> registry.getBean(GlobalInterceptor.class).stream())
+						.map(GlobalInterceptor::getFlow)
+		).flatMap(Function.identity());
 	}
 
 	public static List<LoadBalancingInterceptor> collectBalancers(Router router) {
-		ArrayList<LoadBalancingInterceptor> result = new ArrayList<>();
-		for (Proxy r : router.getRuleManager().getRules()) {
-			List<Interceptor> interceptors = r.getFlow();
-			if (interceptors != null)
-				for (Interceptor i : interceptors)
-					if (i instanceof LoadBalancingInterceptor)
-						result.add((LoadBalancingInterceptor)i);
-		}
-		return result;
+		return allFlows(router)
+				.filter(Objects::nonNull)
+				.flatMap(List::stream)
+				.filter(LoadBalancingInterceptor.class::isInstance)
+				.map(LoadBalancingInterceptor.class::cast)
+				.distinct()
+				.toList();
+	}
+
+	public static List<Cluster> collectClusters(Router router) {
+		return Stream.concat(
+				collectBalancers(router).stream()
+						.flatMap(lbi -> lbi.getClusterManager().getClusters().stream()),
+				Stream.concat(
+						Optional.ofNullable(router.getRegistry())
+								.stream()
+								.flatMap(registry -> registry.getBeans(Balancer.class).stream())
+								.flatMap(b -> b.getClusters().stream()),
+						Optional.ofNullable(router.getBeanFactory())
+								.map(ctx -> ctx.getBeansOfType(Balancer.class).values().stream()
+										.flatMap(b -> b.getClusters().stream()))
+								.orElseGet(Stream::empty)
+				)
+		).distinct().toList();
 	}
 
 	public static Balancer lookupBalancer(Router router, String name) {
-		for (Proxy r : router.getRuleManager().getRules()) {
-			List<Interceptor> interceptors = r.getFlow();
-			if (interceptors != null)
-				for (Interceptor i : interceptors)
-					if (i instanceof LoadBalancingInterceptor)
-						if (((LoadBalancingInterceptor)i).getName().equalsIgnoreCase(name))
-							return ((LoadBalancingInterceptor) i).getClusterManager();
-		}
-		throw new RuntimeException("balancer with name \"" + name + "\" not found.");
+		return collectBalancers(router).stream()
+				.filter(lbi -> lbi.getName() != null && lbi.getName().equalsIgnoreCase(name))
+				.map(LoadBalancingInterceptor::getClusterManager)
+				.findFirst()
+				.orElseThrow(() -> new RuntimeException("balancer with name %s not found.".formatted(name)));
 	}
 
 	public static LoadBalancingInterceptor lookupBalancerInterceptor(Router router, String name) {
-		for (Proxy r : router.getRuleManager().getRules()) {
-			List<Interceptor> interceptors = r.getFlow();
-			if (interceptors != null)
-				for (Interceptor i : interceptors)
-					if (i instanceof LoadBalancingInterceptor)
-						if (((LoadBalancingInterceptor)i).getName().equalsIgnoreCase(name))
-							return (LoadBalancingInterceptor) i;
-		}
-		throw new RuntimeException("balancer with name \"" + name + "\" not found.");
+		return collectBalancers(router).stream()
+				.filter(lbi -> lbi.getName() != null && lbi.getName().equalsIgnoreCase(name))
+				.findFirst()
+				.orElseThrow(() -> new RuntimeException("balancer with name %s not found.".formatted(name)));
 	}
 
 	public static boolean hasLoadBalancing(Router router) {
@@ -122,8 +142,8 @@ public class BalancerUtil {
 		return lookupBalancer(router, balancerName).getSessionsByNode(cName, node);
 	}
 
-	public static String getSingleClusterNameOrDefault(Balancer balancer){
-		if(balancer.getClusters().size() == 1)
+	public static String getSingleClusterNameOrDefault(Balancer balancer) {
+		if (balancer.getClusters().size() == 1)
 			return balancer.getClusters().getFirst().getName();
 		return Cluster.DEFAULT_NAME;
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined discovery of load balancers and clusters by unifying flows across router and global configuration sources with improved deduplication.
  * Standardized lookup behavior for load balancers and their interceptors, with consistent case-insensitive matching.
  * Improved error messages for lookup failures and simplified presence checks for load balancing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/membrane/api-gateway/pull/2952?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->