### PR TITLE
Update HttpTimeoutTest to expect 504 instead of 500 status code

### DIFF
--- a/core/src/test/java/com/predic8/membrane/core/transport/http/HttpTimeoutTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/transport/http/HttpTimeoutTest.java
@@ -106,7 +106,7 @@ public class HttpTimeoutTest {
             Exchange exc = get("http://localhost:3023").buildExchange();
             client.call(exc);
 
-            assertEquals(500, exc.getResponse().getStatusCode());
+            assertEquals(504, exc.getResponse().getStatusCode());
         }
 
         watch.stop();


### PR DESCRIPTION
Following the changes of 87dd5e93519476399fde9829a20e7ead82f24e9d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected HTTP status code response when backend requests exceed the configured timeout threshold, now properly returning `504 Gateway Timeout` instead of `500 Internal Server Error`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/membrane/api-gateway/pull/2958?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->