### PR TITLE
Add limits to chunked body parsing to prevent OOM errors

### DIFF
--- a/annot/src/main/java/com/predic8/membrane/annot/Constants.java
+++ b/annot/src/main/java/com/predic8/membrane/annot/Constants.java
@@ -14,10 +14,9 @@
 
 package com.predic8.membrane.annot;
 
-import javax.xml.*;
-import javax.xml.namespace.*;
-import java.io.*;
-import java.util.*;
+import javax.xml.namespace.QName;
+import java.io.FileInputStream;
+import java.util.Properties;
 
 public class Constants {
 
@@ -30,6 +29,19 @@ public class Constants {
      * Users should use the environment variable instead.
      */
     public static final String MEMBRANE_DISABLE_TERM_COLORS_PROPERTY = "membrane.disable.term.colors";
+
+	/**
+	 * Size of the IO buffer used for reading HTTP bodies.
+	 */
+	public static final String MEMBRANE_CORE_HTTP_BODY_BUFFERSIZE = "membrane.core.http.body.buffersize";
+	public static final int MEMBRANE_CORE_HTTP_BODY_BUFFERSIZE_DEFAULT = 8192;
+
+	/**
+	 * Maximum size of an HTTP chunk in bytes. Limit is checked to avoid DoS attacks.
+	 * Without this, a sender can trigger a 2 GiB byte[] allocation with just "7FFFFFFF\r\n
+	 */
+	public static final String MEMBRANE_CORE_HTTP_BODY_MAXCHUNKLENGTH = "membrane.core.http.body.maxchunklength";
+	public static final int MEMBRANE_CORE_HTTP_BODY_MAXCHUNKLENGTH_DEFAULT = 100 * 1024 * 1024;
 
     public static final String CRLF = "" + ((char) 13) + ((char) 10);
 

--- a/core/src/main/java/com/predic8/membrane/core/http/Body.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/Body.java
@@ -21,6 +21,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 
+import static com.predic8.membrane.annot.Constants.*;
+
 /**
  * A message body (streaming, if possible). Use a subclass of {@link ChunkedBody} instead, if
  * "Transfer-Encoding: chunked" is set on the input.
@@ -41,10 +43,10 @@ public class Body extends AbstractBody {
 	private final static int MAX_CHUNK_LENGTH;
 
 	static {
-		String bufferSize = System.getProperty("membrane.core.http.body.buffersize");
-		BUFFER_SIZE = bufferSize == null ? 8192 : Integer.parseInt(bufferSize);
-		String maxChunkLength = System.getProperty("membrane.core.http.body.maxchunklength");
-		MAX_CHUNK_LENGTH = maxChunkLength == null ? 1_000_000_000 : Integer.parseInt(maxChunkLength);
+		var bufferSize = System.getProperty(MEMBRANE_CORE_HTTP_BODY_BUFFERSIZE);
+		BUFFER_SIZE = bufferSize == null ? MEMBRANE_CORE_HTTP_BODY_BUFFERSIZE_DEFAULT : Integer.parseInt(bufferSize);
+		var maxChunkLength = System.getProperty(MEMBRANE_CORE_HTTP_BODY_MAXCHUNKLENGTH);
+		MAX_CHUNK_LENGTH = maxChunkLength == null ? MEMBRANE_CORE_HTTP_BODY_MAXCHUNKLENGTH_DEFAULT : Integer.parseInt(maxChunkLength);
 	}
 
 	private final InputStream inputStream;

--- a/core/src/main/java/com/predic8/membrane/core/http/ChunkedBody.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/ChunkedBody.java
@@ -43,6 +43,18 @@ public class ChunkedBody extends AbstractBody {
 
     private static final Logger log = LoggerFactory.getLogger(ChunkedBody.class.getName());
 
+    /**
+     * Maximum hex digits in a chunk-size field. Prevents Long.parseLong from receiving a
+     * value that overflows a long (would require >8 digits), with a margin.
+     */
+    private static final int MAX_CHUNK_SIZE_HEX_DIGITS = 4;
+    /**
+     * Hard cap on a single chunk in bytes (100 MiB).
+     * Without this, a sender can trigger a 2 GiB byte[] allocation with just "7FFFFFFF\r\n"
+     * — Integer.MAX_VALUE is a valid input for Integer.parseInt but immediately causes OOM.
+     */
+    static final int MAX_CHUNK_BYTES = 100 * 1024 * 1024;
+
     private final InputStream inputStream;
     private long lengthStreamed;
     private Header trailer;
@@ -94,22 +106,40 @@ public class ChunkedBody extends AbstractBody {
 
         int c;
         while ((c = in.read()) != -1) {
-            if (c == 13) {
-                in.read(); // LF
+            if (c == 13) { // CR — end of chunk-size line
+                in.read(); // consume LF
                 break;
             }
 
-            // ignore chunk extensions
+            // chunk-ext: ignore everything from ';' through the terminating LF
             if (c == ';') {
                 //noinspection StatementWithEmptyBody
-                while ((c = in.read()) != 10)
+                while ((c = in.read()) != 10 && c != -1)
                     ;
+                break; // LF consumed; chunk-size line is done
             }
 
+            if (buffer.length() >= MAX_CHUNK_SIZE_HEX_DIGITS) {
+                log.info("Chunk-size {} exceeds limit: {}",buffer.length(), MAX_CHUNK_SIZE_HEX_DIGITS);
+                throw new IOException("Chunk-size exceeds limit");
+            }
             buffer.append((char) c);
         }
 
-        return Integer.parseInt(buffer.toString().trim(), 16);
+        var hex = buffer.toString().trim();
+        if (hex.isEmpty()) {
+            throw new IOException("Empty chunk-size field");
+        }
+        int size;
+        try {
+            size = Integer.parseInt(hex, 16);
+        } catch (NumberFormatException e) {
+            throw new IOException("Invalid chunk-size value: '" + hex + "'", e);
+        }
+        if (size < 0 || size > MAX_CHUNK_BYTES) {
+            throw new IOException("Chunk size " + size + " exceeds limit of " + MAX_CHUNK_BYTES + " bytes");
+        }
+        return size;
     }
 
     @Override

--- a/core/src/main/java/com/predic8/membrane/core/http/ChunkedBody.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/ChunkedBody.java
@@ -24,7 +24,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.predic8.membrane.annot.Constants.CRLF_BYTES;
+import static com.predic8.membrane.annot.Constants.*;
 import static com.predic8.membrane.core.http.ChunkedBodyTransferer.ZERO;
 import static com.predic8.membrane.core.util.ByteUtil.readByteArray;
 import static java.lang.Long.toHexString;
@@ -47,13 +47,18 @@ public class ChunkedBody extends AbstractBody {
      * Maximum hex digits in a chunk-size field. Prevents Long.parseLong from receiving a
      * value that overflows a long (would require >8 digits), with a margin.
      */
-    private static final int MAX_CHUNK_SIZE_HEX_DIGITS = 4;
+    private static final int MAX_CHUNK_SIZE_HEX_DIGITS = 8;
+
     /**
-     * Hard cap on a single chunk in bytes (100 MiB).
+     * Hard cap on a single chunk in bytes
      * Without this, a sender can trigger a 2 GiB byte[] allocation with just "7FFFFFFF\r\n"
-     * — Integer.MAX_VALUE is a valid input for Integer.parseInt but immediately causes OOM.
      */
-    static final int MAX_CHUNK_BYTES = 100 * 1024 * 1024;
+    private static int MAX_CHUNK_BYTES;
+
+    static {
+        var v = System.getProperty(MEMBRANE_CORE_HTTP_BODY_MAXCHUNKLENGTH);
+        MAX_CHUNK_BYTES = v == null ? MEMBRANE_CORE_HTTP_BODY_MAXCHUNKLENGTH_DEFAULT : Integer.parseInt(v);
+    }
 
     private final InputStream inputStream;
     private long lengthStreamed;
@@ -102,7 +107,7 @@ public class ChunkedBody extends AbstractBody {
     }
 
     public static int readChunkSize(InputStream in) throws IOException {
-        StringBuilder buffer = new StringBuilder();
+        var buffer = new StringBuilder();
 
         int c;
         while ((c = in.read()) != -1) {
@@ -126,20 +131,23 @@ public class ChunkedBody extends AbstractBody {
             buffer.append((char) c);
         }
 
+        return parseChunkSize(buffer);
+    }
+
+    static int parseChunkSize(StringBuilder buffer) throws IOException {
         var hex = buffer.toString().trim();
         if (hex.isEmpty()) {
             throw new IOException("Empty chunk-size field");
         }
-        int size;
         try {
-            size = Integer.parseInt(hex, 16);
+            int size = Integer.parseInt(hex, 16);
+            if (size < 0 || size > MAX_CHUNK_BYTES) {
+                throw new IOException("Chunk size %d exceeds limit of %d bytes".formatted(size, MAX_CHUNK_BYTES));
+            }
+            return size;
         } catch (NumberFormatException e) {
-            throw new IOException("Invalid chunk-size value: '" + hex + "'", e);
+            throw new IOException("Invalid chunk-size value: %s".formatted(hex), e);
         }
-        if (size < 0 || size > MAX_CHUNK_BYTES) {
-            throw new IOException("Chunk size " + size + " exceeds limit of " + MAX_CHUNK_BYTES + " bytes");
-        }
-        return size;
     }
 
     @Override

--- a/core/src/test/java/com/predic8/membrane/core/http/ChunkedBodyTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/http/ChunkedBodyTest.java
@@ -14,38 +14,59 @@
 
 package com.predic8.membrane.core.http;
 
-import com.fasterxml.jackson.databind.*;
-import com.google.common.io.*;
-import com.predic8.membrane.core.config.security.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.Resources;
 import com.predic8.membrane.core.config.security.KeyStore;
-import com.predic8.membrane.core.exchange.*;
-import com.predic8.membrane.core.interceptor.*;
-import com.predic8.membrane.core.proxies.*;
-import com.predic8.membrane.core.router.*;
-import com.predic8.membrane.core.transport.http.*;
-import com.predic8.membrane.core.transport.http.client.*;
-import okhttp3.*;
-import org.apache.commons.httpclient.methods.*;
-import org.jetbrains.annotations.*;
-import org.junit.jupiter.api.*;
+import com.predic8.membrane.core.config.security.SSLParser;
+import com.predic8.membrane.core.config.security.TrustStore;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.interceptor.AbstractInterceptor;
+import com.predic8.membrane.core.interceptor.HTTPClientInterceptor;
+import com.predic8.membrane.core.interceptor.Outcome;
+import com.predic8.membrane.core.proxies.ServiceProxy;
+import com.predic8.membrane.core.proxies.ServiceProxyKey;
+import com.predic8.membrane.core.router.Router;
+import com.predic8.membrane.core.router.TestRouter;
+import com.predic8.membrane.core.transport.http.HttpClient;
+import com.predic8.membrane.core.transport.http.HttpServerHandler;
+import com.predic8.membrane.core.transport.http.client.HttpClientConfiguration;
+import okhttp3.Call;
+import okhttp3.OkHttpClient;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
-import javax.net.ssl.*;
-import java.io.*;
-import java.net.*;
-import java.security.*;
-import java.security.cert.*;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.*;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URL;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 
-import static com.google.common.io.Resources.*;
-import static com.predic8.membrane.annot.Constants.*;
+import static com.google.common.io.Resources.getResource;
+import static com.predic8.membrane.annot.Constants.CRLF;
+import static com.predic8.membrane.annot.Constants.MEMBRANE_CORE_HTTP_BODY_MAXCHUNKLENGTH_DEFAULT;
 import static com.predic8.membrane.core.http.ChunkedBody.*;
-import static com.predic8.membrane.core.http.ChunksBuilder.*;
-import static com.predic8.membrane.core.http.Request.*;
-import static com.predic8.membrane.core.interceptor.Outcome.*;
-import static com.predic8.membrane.core.transport.http2.Http2ServerHandler.*;
-import static java.lang.Thread.*;
-import static java.nio.charset.StandardCharsets.*;
+import static com.predic8.membrane.core.http.ChunksBuilder.chunks;
+import static com.predic8.membrane.core.http.Request.get;
+import static com.predic8.membrane.core.interceptor.Outcome.RETURN;
+import static com.predic8.membrane.core.transport.http2.Http2ServerHandler.HTTP2_SERVER;
+import static java.lang.Thread.sleep;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ChunkedBodyTest {
@@ -447,6 +468,93 @@ public class ChunkedBodyTest {
         return new ByteArrayInputStream(chunks().add("""
                 { "foo": 42 }""").add("""
                 { "foo": 43 }""").build());
+    }
+
+    // -------------------------------------------------------------------------
+    // parseChunkSize unit tests
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class ParseChunkSizeTest {
+
+        // -- valid inputs ------------------------------------------------------
+
+        @ParameterizedTest
+        @MethodSource("validChunkSizes")
+        void validInputsParseCorrectly(String input, int expected) throws IOException {
+            assertEquals(expected, parseChunkSize(buf(input)));
+        }
+
+        static Stream<Arguments> validChunkSizes() {
+            return Stream.of(
+                    Arguments.of("0",    0),          // terminating chunk
+                    Arguments.of("1",    1),
+                    Arguments.of("ff",   255),        // lowercase hex
+                    Arguments.of("FF",   255),        // uppercase hex
+                    Arguments.of("3d2F", 15663),      // mixed case
+                    Arguments.of("  a  ", 10),        // whitespace trimmed
+                    Arguments.of(Integer.toHexString(MEMBRANE_CORE_HTTP_BODY_MAXCHUNKLENGTH_DEFAULT),
+                                 MEMBRANE_CORE_HTTP_BODY_MAXCHUNKLENGTH_DEFAULT)  // exactly at limit
+            );
+        }
+
+        // -- too large --------------------------------------------------------
+
+        @Test
+        void oneByteOverLimitIsRejected() {
+            assertThrows(IOException.class,
+                    () -> parseChunkSize(buf(Integer.toHexString(MEMBRANE_CORE_HTTP_BODY_MAXCHUNKLENGTH_DEFAULT + 1))));
+        }
+
+        @Test
+        void integerMaxValueIsRejected() {
+            // 7FFFFFFF = Integer.MAX_VALUE = 2 GiB — parses without NumberFormatException but exceeds cap
+            assertThrows(IOException.class, () -> parseChunkSize(buf("7fffffff")));
+        }
+
+        @Test
+        void overflowsIntegerParseIsRejectedAsInvalidValue() {
+            // 80000000 exceeds Integer.MAX_VALUE → Integer.parseInt throws NumberFormatException
+            assertThrows(IOException.class, () -> parseChunkSize(buf("80000000")));
+        }
+
+        @Test
+        void maxUnsignedHexIsRejectedAsInvalidValue() {
+            assertThrows(IOException.class, () -> parseChunkSize(buf("ffffffff")));
+        }
+
+        // -- negative (sign prefix accepted by Integer.parseInt) --------------
+
+        @Test
+        void negativeValueIsRejected() {
+            assertThrows(IOException.class, () -> parseChunkSize(buf("-1")));
+        }
+
+        // -- empty / blank ----------------------------------------------------
+
+        @Test
+        void emptyBufferIsRejected() {
+            assertThrows(IOException.class, () -> parseChunkSize(buf("")));
+        }
+
+        @Test
+        void blankBufferIsRejected() {
+            assertThrows(IOException.class, () -> parseChunkSize(buf("   ")));
+        }
+
+        // -- non-hex characters -----------------------------------------------
+
+        @ParameterizedTest
+        @ValueSource(strings = {"xyz", "1g", "0x1a", "12 34", "1.0"})
+        void nonHexInputIsRejected(String input) {
+            assertThrows(IOException.class, () -> parseChunkSize(buf(input)));
+        }
+
+        // -- helper -----------------------------------------------------------
+
+        private static StringBuilder buf(String s) {
+            return new StringBuilder(s);
+        }
     }
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter HTTP chunked transfer parsing with robust validation, clearer error messages, and safer handling of chunk extensions
  * Enforced maximum chunk payload size (100 MiB by default) to prevent oversized chunks

* **New Features**
  * Exposed configurable defaults for chunk/max sizes and buffer size

* **Tests**
  * Added comprehensive unit tests covering valid and invalid chunk-size cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/membrane/api-gateway/pull/2964?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->