### PR TITLE
fix `NamespacesExampleTest`: Refactor `headerValueEncode` to use `toText` for string conversion

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/llmgateway/NullPolicies.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/llmgateway/NullPolicies.java
@@ -1,3 +1,17 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
 package com.predic8.membrane.core.interceptor.llmgateway;
 
 import com.predic8.membrane.core.exchange.Exchange;

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/llmgateway/Policies.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/llmgateway/Policies.java
@@ -1,3 +1,17 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
 package com.predic8.membrane.core.interceptor.llmgateway;
 
 import com.predic8.membrane.core.exchange.Exchange;

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/llmgateway/SystemPrompt.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/llmgateway/SystemPrompt.java
@@ -1,3 +1,17 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
 package com.predic8.membrane.core.interceptor.llmgateway;
 
 import com.predic8.membrane.annot.MCAttribute;

--- a/core/src/main/java/com/predic8/membrane/core/util/text/SerializationUtil.java
+++ b/core/src/main/java/com/predic8/membrane/core/util/text/SerializationUtil.java
@@ -20,6 +20,7 @@ import java.util.*;
 
 import static com.predic8.membrane.core.http.MimeType.*;
 import static com.predic8.membrane.core.util.text.SerializationFunction.*;
+import static com.predic8.membrane.core.util.text.ToTextSerializer.toText;
 import static java.lang.Character.*;
 import static java.nio.charset.StandardCharsets.*;
 
@@ -150,7 +151,7 @@ public class SerializationUtil {
     public static String headerValueEncode(Object value) {
         if (value == null) return "";
 
-        String s = value.toString();
+        String s = toText(value);
         var out = new StringBuilder(s.length());
 
         for (int i = 0; i < s.length(); i++) {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/llmgateway/provider/AbstractLLMRequestTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/llmgateway/provider/AbstractLLMRequestTest.java
@@ -1,3 +1,17 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
 package com.predic8.membrane.core.interceptor.llmgateway.provider;
 
 import com.predic8.membrane.core.exchange.Exchange;

--- a/core/src/test/java/com/predic8/membrane/core/lang/ScriptingUtilsTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/lang/ScriptingUtilsTest.java
@@ -1,3 +1,17 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
 package com.predic8.membrane.core.lang;
 
 import com.predic8.membrane.core.router.DefaultRouter;

--- a/distribution/examples/xml/namespaces/proxies.xml
+++ b/distribution/examples/xml/namespaces/proxies.xml
@@ -40,7 +40,7 @@
                 <setProperty name="city" value="${//ns1:city}" language="xpath">
                     <spring:ref bean="ns"/>
                 </setProperty>
-                <setHeader name="id" value="${string(/per:person/@id)}" language="xpath">
+                <setHeader name="id" value="${/per:person/@id}" language="xpath">
                     <spring:ref bean="ns"/>
                 </setHeader>
                 <setProperty name="reqIdHeader" value="${header.id}"/>

--- a/distribution/examples/xml/namespaces/proxies.xml
+++ b/distribution/examples/xml/namespaces/proxies.xml
@@ -40,7 +40,7 @@
                 <setProperty name="city" value="${//ns1:city}" language="xpath">
                     <spring:ref bean="ns"/>
                 </setProperty>
-                <setHeader name="id" value="${/per:person/@id}" language="xpath">
+                <setHeader name="id" value="${string(/per:person/@id)}" language="xpath">
                     <spring:ref bean="ns"/>
                 </setHeader>
                 <setProperty name="reqIdHeader" value="${header.id}"/>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NullPolicies, a new policy implementation for the LLM gateway interceptor that provides no-op request handling and token management.

* **Improvements**
  * Enhanced HTTP header safety by properly escaping carriage returns, line feeds, and null characters in serialized header values to prevent protocol violations.

* **Chores**
  * Added Apache License 2.0 copyright headers to multiple source and test files for proper licensing compliance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->