### PR TITLE
Add MDC support for `traceId` and `spanId` in OpenTelemetry logging

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/opentelemetry/OpenTelemetryInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/opentelemetry/OpenTelemetryInterceptor.java
@@ -34,6 +34,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import java.util.ArrayList;
@@ -154,7 +155,23 @@ public class OpenTelemetryInterceptor extends AbstractInterceptor {
         }
 
         span.addEvent("Close Exchange").end();
+        clearMdc();
         return CONTINUE;
+    }
+
+    @Override
+    public void handleAbort(Exchange exc) {
+        var span = getExchangeSpan(exc);
+        if (span != null) {
+            span.setStatus(ERROR, "Exchange aborted");
+            span.end();
+        }
+        clearMdc();
+    }
+
+    private static void clearMdc() {
+        MDC.remove("traceId");
+        MDC.remove("spanId");
     }
 
     private static Span getExchangeSpan(Exchange exc) {
@@ -203,6 +220,10 @@ public class OpenTelemetryInterceptor extends AbstractInterceptor {
                 setExchangeHeader(exc);
                 exc.setProperty(MEMBRANE_OTEL_SPAN, membraneSpan);
                 exc.setProperty(MEMBRANE_OTEL_TRACER, tracer);
+
+                var spanContext = membraneSpan.getSpanContext();
+                MDC.put("traceId", spanContext.getTraceId());
+                MDC.put("spanId", spanContext.getSpanId());
             }
         }
     }

--- a/distribution/examples/monitoring-tracing/opentelemetry/README.md
+++ b/distribution/examples/monitoring-tracing/opentelemetry/README.md
@@ -27,6 +27,13 @@ docker run -it --name jaeger -e COLLECTOR_OTLP_ENABLED=true -p 16686:16686 -p 43
 A span created by Membrane should be visible in the [Jaeger UI](http://localhost:16686).
 ![sample](resources/otel_example.png)
 7. Check the headers printed to the console. You will see headers such as `traceparent`, which indicate the trace and span context involved in the request.
+8. The trace and span IDs are also written into the MDC log context and appear in every log line produced during that request:
+
+   ```
+   12:34:56,789  INFO 42 http-123 OpenTelemetryInterceptor:108 [4bf92f3577b34da6a3ce929d0e0e4736/00f067aa0ba902b7] {} - ...
+   ```
+
+   The `[traceId/spanId]` segment is printed by the included `log4j2.xml`. When no span is active the brackets are empty (`[/]`).
 
 **How it is done**
 
@@ -57,3 +64,9 @@ api:
 **Note on Transport:**
 
 The OTLP exporter is configured by default to use gRPC. To use HTTP, set the `transport` field to `http` and set the `port` to `4318`.
+
+**MDC Log Context:**
+
+The `openTelemetry` plugin writes the current `traceId` and `spanId` into the SLF4J MDC for the duration of each request. This lets any log line emitted by Membrane — or your own interceptors — be correlated directly with a trace in Jaeger without any extra instrumentation. The included `log4j2.xml` exposes them via the `[%X{traceId}/%X{spanId}]` pattern. To add them to your own Log4j2 layout use the same `%X{traceId}` and `%X{spanId}` conversion specifiers.
+
+> **Note:** Place `openTelemetry` either globally in the transport (as shown in `apis.yaml`) or as the **first plugin** in an API flow. Only log lines produced by plugins that run *after* `openTelemetry` will carry the `traceId` and `spanId` in the MDC.

--- a/distribution/examples/monitoring-tracing/opentelemetry/README.md
+++ b/distribution/examples/monitoring-tracing/opentelemetry/README.md
@@ -30,7 +30,7 @@ A span created by Membrane should be visible in the [Jaeger UI](http://localhost
 8. The trace and span IDs are also written into the MDC log context and appear in every log line produced during that request:
 
    ```
-   12:34:56,789  INFO 42 http-123 OpenTelemetryInterceptor:108 [4bf92f3577b34da6a3ce929d0e0e4736/00f067aa0ba902b7] {} - ...
+   10:23:24,309  INFO 71 router /127.0.0.1:51225 LogInterceptor:161 {api=Backend, spanId=c3842209e491c98d, traceId=037203a62701acf8d0da0080dae55aef} 
    ```
 
    The `[traceId/spanId]` segment is printed by the included `log4j2.xml`. When no span is active the brackets are empty (`[/]`).

--- a/distribution/examples/monitoring-tracing/opentelemetry/log4j2.xml
+++ b/distribution/examples/monitoring-tracing/opentelemetry/log4j2.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <!--
+            [%X{traceId}/%X{spanId}] prints the OpenTelemetry trace and span IDs from the SLF4J MDC.
+            They are written by the openTelemetry plugin at the start of every request and removed
+            when the request finishes, so every log line in between is automatically correlated with
+            the corresponding trace in Jaeger (or any other OTLP backend).
+            -->
+            <PatternLayout charset="UTF-8"
+                           disableAnsi="${sys:membrane.disable.term.colors:-false}"
+                           pattern="%d{ABSOLUTE} %highlight{%5p}{ERROR=red, WARN=yellow, INFO=cyan} %tid %tn %c{1}:%L [%X{traceId}/%X{spanId}] %X - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="com.predic8" level="info" additivity="false">
+            <AppenderRef ref="STDOUT" />
+        </Logger>
+        <Root level="info">
+            <AppenderRef ref="STDOUT" />
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenTelemetry trace and span IDs are now automatically included in application log output for improved request tracing and correlation.

* **Bug Fixes**
  * Aborted exchanges are now recorded as errors in tracing and ensure trace/span context is cleared after responses.

* **Documentation**
  * Updated OpenTelemetry example with guidance on observing trace context in logs and a sample Log4j2 configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->