### PR TITLE
Update OpenTelemetry BOM to version 1.63.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -37,7 +37,7 @@
             <dependency>
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-bom</artifactId>
-                <version>1.52.0</version>
+                <version>1.63.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Prevents unsafe warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenTelemetry BOM to version 1.63.0, bringing the latest improvements to observability and telemetry infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->