### PR TITLE
ForInterceptor: support use in response flow (#2988)

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/flow/ForInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/flow/ForInterceptor.java
@@ -13,16 +13,21 @@
    limitations under the License. */
 package com.predic8.membrane.core.interceptor.flow;
 
-import com.predic8.membrane.annot.*;
-import com.predic8.membrane.core.exceptions.*;
-import com.predic8.membrane.core.exchange.*;
-import com.predic8.membrane.core.interceptor.*;
-import com.predic8.membrane.core.lang.*;
-import com.predic8.membrane.core.lang.ExchangeExpression.*;
-import com.predic8.membrane.core.util.*;
-import org.slf4j.*;
+import com.predic8.membrane.annot.MCAttribute;
+import com.predic8.membrane.annot.MCElement;
+import com.predic8.membrane.annot.Required;
+import com.predic8.membrane.core.exceptions.ProblemDetails;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.interceptor.Interceptor;
+import com.predic8.membrane.core.interceptor.Outcome;
+import com.predic8.membrane.core.lang.ExchangeExpression;
+import com.predic8.membrane.core.lang.ExchangeExpression.Language;
+import com.predic8.membrane.core.lang.ExchangeExpressionException;
+import com.predic8.membrane.core.util.ConfigurationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.List;
 
 import static com.predic8.membrane.core.interceptor.Interceptor.Flow.REQUEST;
 import static com.predic8.membrane.core.interceptor.Interceptor.Flow.RESPONSE;
@@ -96,7 +101,9 @@ public class ForInterceptor extends AbstractFlowWithChildrenInterceptor {
             for (Object o2 : l) {
                 log.debug("type: {}, it: {}",o2.getClass(),o2);
                 exc.setProperty("it", o2);
-                invokeFlowHandlers(exc, flow, interceptors);
+                Outcome outcome = invokeFlowHandlers(exc, flow, interceptors);
+                if (outcome != CONTINUE)
+                    return outcome;
             }
         }
 

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/flow/ForInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/flow/ForInterceptor.java
@@ -95,14 +95,20 @@ public class ForInterceptor extends AbstractFlowWithChildrenInterceptor {
             log.debug("List detected {}",l);
             for (Object o2 : l) {
                 log.debug("type: {}, it: {}",o2.getClass(),o2);
-                if (flow.isRequest()) {
-                    exc.setProperty("it", o2);
-                    getFlowController().invokeRequestHandlers(exc, interceptors);
-                }
+                exc.setProperty("it", o2);
+                invokeFlowHandlers(exc, flow, interceptors);
             }
         }
 
         return CONTINUE;
+    }
+
+    private Outcome invokeFlowHandlers(Exchange exc, Flow flow, List<Interceptor> interceptors) {
+        return switch (flow) {
+            case REQUEST -> getFlowController().invokeRequestHandlers(exc, interceptors);
+            case RESPONSE -> getFlowController().invokeResponseHandlers(exc, interceptors);
+            default -> throw new RuntimeException("Should never happen");
+        };
     }
 
     public Language getLanguage() {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/flow/ForInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/flow/ForInterceptorTest.java
@@ -19,9 +19,10 @@ import com.predic8.membrane.core.http.Response;
 import com.predic8.membrane.core.interceptor.AbstractInterceptor;
 import com.predic8.membrane.core.interceptor.Outcome;
 import com.predic8.membrane.core.router.DummyTestRouter;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
+import static com.predic8.membrane.core.interceptor.Outcome.*;
 import static com.predic8.membrane.core.lang.ExchangeExpression.Language.SPEL;
 import static java.util.List.of;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -47,7 +48,7 @@ public class ForInterceptorTest {
     }
 
     /** A &lt;for&gt; over the three-element SpEL list literal {@code {'a','b','c'}} with one nested interceptor. */
-    private static ForInterceptor forOverThreeItems(CountingInterceptor nested) {
+    private static ForInterceptor forOverThreeItems(AbstractInterceptor nested) {
         var fi = new ForInterceptor();
         fi.setLanguage(SPEL);
         fi.setIn("{'a','b','c'}");
@@ -76,5 +77,64 @@ public class ForInterceptorTest {
         assertEquals(CONTINUE, forOverThreeItems(nested).handleResponse(exc));
         assertEquals(3, nested.responseCalls);
         assertEquals(0, nested.requestCalls);
+    }
+
+    @Nested
+    class NonContinueOutcomeStopsLoopAndPropagates {
+
+        /** Nested interceptor that counts invocations per flow and returns a configured outcome. */
+        private static class OutcomeInterceptor extends AbstractInterceptor {
+            int requestCalls;
+            int responseCalls;
+            private final Outcome requestOutcome;
+            private final Outcome responseOutcome;
+
+            OutcomeInterceptor(Outcome requestOutcome, Outcome responseOutcome) {
+                this.requestOutcome = requestOutcome;
+                this.responseOutcome = responseOutcome;
+            }
+
+            @Override
+            public Outcome handleRequest(Exchange exc) {
+                requestCalls++;
+                return requestOutcome;
+            }
+
+            @Override
+            public Outcome handleResponse(Exchange exc) {
+                responseCalls++;
+                return responseOutcome;
+            }
+        }
+
+        @Test
+        void abortInRequestFlow() {
+            var nested = new OutcomeInterceptor(ABORT, CONTINUE);
+            var exc = new Exchange(null);
+            exc.setRequest(new Request.Builder().build());
+
+            assertEquals(ABORT, forOverThreeItems(nested).handleRequest(exc));
+            assertEquals(1, nested.requestCalls);
+        }
+
+        @Test
+        void returnInRequestFlow() {
+            var nested = new OutcomeInterceptor(RETURN, CONTINUE);
+            var exc = new Exchange(null);
+            exc.setRequest(new Request.Builder().build());
+
+            assertEquals(RETURN, forOverThreeItems(nested).handleRequest(exc));
+            assertEquals(1, nested.requestCalls);
+        }
+
+        @Test
+        void abortInResponseFlow() {
+            var nested = new OutcomeInterceptor(CONTINUE, ABORT);
+            var exc = new Exchange(null);
+            exc.setResponse(Response.ok().build());
+
+            assertEquals(ABORT, forOverThreeItems(nested).handleResponse(exc));
+            assertEquals(1, nested.responseCalls);
+        }
     }
 }

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/flow/ForInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/flow/ForInterceptorTest.java
@@ -29,26 +29,37 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ForInterceptorTest {
 
-    /** Nested interceptor that counts how often it is invoked in each flow. */
+    /** Nested interceptor that counts how often it is invoked in each flow and returns a configured outcome. */
     private static class CountingInterceptor extends AbstractInterceptor {
         int requestCalls;
         int responseCalls;
+        private final Outcome requestOutcome;
+        private final Outcome responseOutcome;
+
+        CountingInterceptor() {
+            this(CONTINUE, CONTINUE);
+        }
+
+        CountingInterceptor(Outcome requestOutcome, Outcome responseOutcome) {
+            this.requestOutcome = requestOutcome;
+            this.responseOutcome = responseOutcome;
+        }
 
         @Override
         public Outcome handleRequest(Exchange exc) {
             requestCalls++;
-            return CONTINUE;
+            return requestOutcome;
         }
 
         @Override
         public Outcome handleResponse(Exchange exc) {
             responseCalls++;
-            return CONTINUE;
+            return responseOutcome;
         }
     }
 
     /** A &lt;for&gt; over the three-element SpEL list literal {@code {'a','b','c'}} with one nested interceptor. */
-    private static ForInterceptor forOverThreeItems(AbstractInterceptor nested) {
+    private static ForInterceptor forOverThreeItems(CountingInterceptor nested) {
         var fi = new ForInterceptor();
         fi.setLanguage(SPEL);
         fi.setIn("{'a','b','c'}");
@@ -82,34 +93,9 @@ public class ForInterceptorTest {
     @Nested
     class NonContinueOutcomeStopsLoopAndPropagates {
 
-        /** Nested interceptor that counts invocations per flow and returns a configured outcome. */
-        private static class OutcomeInterceptor extends AbstractInterceptor {
-            int requestCalls;
-            int responseCalls;
-            private final Outcome requestOutcome;
-            private final Outcome responseOutcome;
-
-            OutcomeInterceptor(Outcome requestOutcome, Outcome responseOutcome) {
-                this.requestOutcome = requestOutcome;
-                this.responseOutcome = responseOutcome;
-            }
-
-            @Override
-            public Outcome handleRequest(Exchange exc) {
-                requestCalls++;
-                return requestOutcome;
-            }
-
-            @Override
-            public Outcome handleResponse(Exchange exc) {
-                responseCalls++;
-                return responseOutcome;
-            }
-        }
-
         @Test
         void abortInRequestFlow() {
-            var nested = new OutcomeInterceptor(ABORT, CONTINUE);
+            var nested = new CountingInterceptor(ABORT, CONTINUE);
             var exc = new Exchange(null);
             exc.setRequest(new Request.Builder().build());
 
@@ -119,7 +105,7 @@ public class ForInterceptorTest {
 
         @Test
         void returnInRequestFlow() {
-            var nested = new OutcomeInterceptor(RETURN, CONTINUE);
+            var nested = new CountingInterceptor(RETURN, CONTINUE);
             var exc = new Exchange(null);
             exc.setRequest(new Request.Builder().build());
 
@@ -129,7 +115,7 @@ public class ForInterceptorTest {
 
         @Test
         void abortInResponseFlow() {
-            var nested = new OutcomeInterceptor(CONTINUE, ABORT);
+            var nested = new CountingInterceptor(CONTINUE, ABORT);
             var exc = new Exchange(null);
             exc.setResponse(Response.ok().build());
 

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/flow/ForInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/flow/ForInterceptorTest.java
@@ -1,0 +1,80 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+package com.predic8.membrane.core.interceptor.flow;
+
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.http.Request;
+import com.predic8.membrane.core.http.Response;
+import com.predic8.membrane.core.interceptor.AbstractInterceptor;
+import com.predic8.membrane.core.interceptor.Outcome;
+import com.predic8.membrane.core.router.DummyTestRouter;
+import org.junit.jupiter.api.Test;
+
+import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
+import static com.predic8.membrane.core.lang.ExchangeExpression.Language.SPEL;
+import static java.util.List.of;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ForInterceptorTest {
+
+    /** Nested interceptor that counts how often it is invoked in each flow. */
+    private static class CountingInterceptor extends AbstractInterceptor {
+        int requestCalls;
+        int responseCalls;
+
+        @Override
+        public Outcome handleRequest(Exchange exc) {
+            requestCalls++;
+            return CONTINUE;
+        }
+
+        @Override
+        public Outcome handleResponse(Exchange exc) {
+            responseCalls++;
+            return CONTINUE;
+        }
+    }
+
+    /** A &lt;for&gt; over the three-element SpEL list literal {@code {'a','b','c'}} with one nested interceptor. */
+    private static ForInterceptor forOverThreeItems(CountingInterceptor nested) {
+        var fi = new ForInterceptor();
+        fi.setLanguage(SPEL);
+        fi.setIn("{'a','b','c'}");
+        fi.setFlow(of(nested));
+        fi.init(new DummyTestRouter());
+        return fi;
+    }
+
+    @Test
+    void runsNestedForEachItemInRequestFlow() {
+        var nested = new CountingInterceptor();
+        var exc = new Exchange(null);
+        exc.setRequest(new Request.Builder().build());
+
+        assertEquals(CONTINUE, forOverThreeItems(nested).handleRequest(exc));
+        assertEquals(3, nested.requestCalls);
+        assertEquals(0, nested.responseCalls);
+    }
+
+    @Test
+    void runsNestedForEachItemInResponseFlow() {
+        var nested = new CountingInterceptor();
+        var exc = new Exchange(null);
+        exc.setResponse(Response.ok().build());
+
+        assertEquals(CONTINUE, forOverThreeItems(nested).handleResponse(exc));
+        assertEquals(3, nested.responseCalls);
+        assertEquals(0, nested.requestCalls);
+    }
+}


### PR DESCRIPTION
The <for> interceptor only invoked its nested flow in the request flow (guarded by flow.isRequest()), so in the response flow nothing ran.

Dispatch to invokeRequestHandlers/invokeResponseHandlers based on the current flow, mirroring the pattern already used by IfInterceptor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for loop iteration behavior, validating nested interceptor execution in both request and response flows.
  * Added scenarios for non-`CONTINUE` outcomes to ensure the loop stops appropriately and the outcome is correctly propagated.
  * Included checks that the current list element is consistently made available during each iteration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->