### PR TITLE
Improvement: Allow explicit Content-Type override in SoapBodyTemplateInterce…

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/templating/SoapBodyTemplateInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/templating/SoapBodyTemplateInterceptor.java
@@ -13,17 +13,18 @@
    limitations under the License. */
 package com.predic8.membrane.core.interceptor.templating;
 
-import com.predic8.membrane.annot.*;
-import com.predic8.membrane.core.exchange.*;
-import com.predic8.membrane.core.http.*;
-import com.predic8.membrane.core.util.soap.*;
+import com.predic8.membrane.annot.MCAttribute;
+import com.predic8.membrane.annot.MCElement;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.util.soap.SoapVersion;
 
-import static com.predic8.membrane.core.http.MimeType.TEXT_XML;
-import static com.predic8.membrane.core.util.soap.SoapVersion.*;
-import static java.nio.charset.StandardCharsets.*;
+import static com.predic8.membrane.core.util.soap.SoapVersion.SOAP_11;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
- * @description Renders a SOAP body for legacy integration
+ * @description Renders a SOAP body for legacy integration. The Content-Type defaults to the type of the
+ * configured SOAP version (<code>text/xml</code> for 1.1, <code>application/soap+xml</code> for 1.2). Setting
+ * <code>contentType</code> explicitly overrides this, e.g. to add a charset.
  * @topic 2. Enterprise Integration Patterns
  */
 @MCElement(name="soapBody", mixed = true)
@@ -60,7 +61,8 @@ public class SoapBodyTemplateInterceptor extends TemplateInterceptor {
 
     @Override
     public String getContentType() {
-        return version.getContentType();
+        // A content type configured by the user takes precedence over the SOAP version default.
+        return contentType != null ? contentType : version.getContentType();
     }
 
     public String getVersion() {
@@ -74,6 +76,7 @@ public class SoapBodyTemplateInterceptor extends TemplateInterceptor {
 
     @Override
     protected String getDefaultContentType() {
-        return TEXT_XML;
+        // No fixed default: an unset content type falls back to the SOAP version's type in getContentType().
+        return null;
     }
 }

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/templating/SoapBodyTemplateInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/templating/SoapBodyTemplateInterceptorTest.java
@@ -13,12 +13,13 @@
    limitations under the License. */
 package com.predic8.membrane.core.interceptor.templating;
 
-import com.predic8.membrane.core.util.*;
-import org.junit.jupiter.api.*;
-import org.junit.jupiter.params.*;
-import org.junit.jupiter.params.provider.*;
+import com.predic8.membrane.core.util.ConfigurationException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class SoapBodyTemplateInterceptorTest {
 
@@ -56,6 +57,23 @@ class SoapBodyTemplateInterceptorTest {
         i.setVersion("1.2");
         assertEquals("1.2", i.getVersion());
         assertEquals("application/soap+xml", i.getContentType());
+    }
+
+    @Test
+    void explicitContentType_overridesVersionDefault() {
+        SoapBodyTemplateInterceptor i = new SoapBodyTemplateInterceptor();
+        i.setContentType("text/xml;charset=UTF-8");
+
+        assertEquals("text/xml;charset=UTF-8", i.getContentType());
+    }
+
+    @Test
+    void explicitContentType_overridesEvenForSoap12() {
+        SoapBodyTemplateInterceptor i = new SoapBodyTemplateInterceptor();
+        i.setVersion("1.2");
+        i.setContentType("text/xml;charset=UTF-8");
+
+        assertEquals("text/xml;charset=UTF-8", i.getContentType());
     }
 
     private static void setSoapVersion(String version) {


### PR DESCRIPTION
…ptor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SOAP message content type handling. User-configured content types now take precedence over default SOAP version settings, ensuring more predictable behavior in response and header processing.

* **Tests**
  * Added test cases to verify that explicitly configured content types are properly retained and remain unchanged across SOAP version modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->