### PR TITLE
membrane-config skill for generating apis.yaml and proxies.xml

### DIFF
--- a/.claude/skills/membrane-config/SKILL.md
+++ b/.claude/skills/membrane-config/SKILL.md
@@ -53,9 +53,19 @@ elements) and evolves; ground every snippet.
    python3 scripts/describe_element.py --list        # all element ids
    ```
 
-4. **Write the config** following the conventions below.
+4. **For any expression, template, or built-in function**, read
+   [references/expressions.md](references/expressions.md) before writing it. The
+   schema does **not** cover this, and it's the easiest place to be confidently
+   wrong: which engine evaluates a string (`template` is Groovy, `setBody`/`if`
+   default to SpEL), how you call a function (`${user()}` in SpEL vs.
+   `${fn.user()}` in a Groovy template), which variables are in scope, and the
+   full built-in catalog (`user()`, `base64Encode`, `hasScope`, `env`, …). These
+   bugs surface as a runtime 500, not a schema error — `validate_config.py` won't
+   catch them.
 
-5. **Validate** (YAML only) — always, before presenting:
+5. **Write the config** following the conventions below.
+
+6. **Validate** (YAML only) — always, before presenting:
    ```bash
    python3 scripts/validate_config.py path/to/apis.yaml
    ```

--- a/.claude/skills/membrane-config/SKILL.md
+++ b/.claude/skills/membrane-config/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: membrane-config
+description: >-
+  Generate a Membrane API Gateway configuration example or snippet — an
+  apis.yaml (default) or, when explicitly asked, a legacy proxies.xml. Use this
+  whenever the user wants a config, example, or snippet for Membrane: routing a
+  port to a backend, a flow with plugins (setHeader, rateLimiter, basicAuthentication,
+  openapi, choose/if, static/return, template, validator, oauth2, llmGateway, ...),
+  TLS termination, SOAP/REST transformation, or "how do I configure X in Membrane".
+  Also trigger for phrases like "membrane config", "apis.yaml example", "proxies.xml",
+  "add a plugin to my gateway config", or "show me the YAML for ...". Grounds output
+  in the project's real tutorials and verifies it against membrane.schema.json.
+---
+
+# Membrane configuration generator
+
+Membrane is configured declaratively. The modern format is `apis.yaml`; a legacy
+Spring `proxies.xml` format also exists. This skill produces correct, idiomatic
+config by doing what a careful engineer does: copy the shape from a real working
+example, confirm exact attribute names against the schema, and validate before
+handing it over.
+
+Two sources of truth, and they play different roles:
+- **`distribution/tutorials/**/*.yaml`** — idiom and style. Heavily commented,
+  curated, and the best examples in the repo. Treat these as gold.
+  `distribution/examples/**` adds more (including `proxies.xml`).
+- **`membrane.schema.json`** — what's actually allowed: every element, its exact
+  attribute names, enum values, and nesting. The model's main failure mode is
+  inventing plausible-but-wrong attribute names; the schema is how you avoid that.
+
+Don't generate config from memory alone. The element set is large (~255
+elements) and evolves; ground every snippet.
+
+## Workflow
+
+1. **Clarify intent only if needed.** What should the gateway do? Default to one
+   `api` on port `2000` forwarding to a `target.url` unless the request implies
+   otherwise. Don't over-ask — most requests map cleanly onto a known pattern.
+
+2. **Find a close example.** Skim [references/cheatsheet.md](references/cheatsheet.md)
+   for the matching pattern, then look at the real tutorial for the live version:
+   ```bash
+   grep -rl "rateLimiter:" distribution/tutorials distribution/examples
+   ```
+   Reading the closest tutorial is the single highest-leverage step — it carries
+   ordering, nesting, and conventions you'd otherwise guess at.
+
+3. **Confirm exact attributes against the schema** for every non-trivial element.
+   Guessing attribute names is the main way these configs go wrong:
+   ```bash
+   python3 scripts/describe_element.py rateLimiter   # attributes + enums + children
+   python3 scripts/describe_element.py --grep auth   # discover element names
+   python3 scripts/describe_element.py --list        # all element ids
+   ```
+
+4. **Write the config** following the conventions below.
+
+5. **Validate** (YAML only) — always, before presenting:
+   ```bash
+   python3 scripts/validate_config.py path/to/apis.yaml
+   ```
+   Fix every reported problem and re-run until it passes. If you only produced a
+   snippet, drop it into a minimal `api:` skeleton in a temp file and validate
+   that, so you're confident the snippet is structurally sound.
+
+The scripts find the schema automatically: they prefer the locally built
+`core/target/classes/com/predic8/membrane/core/config/json/membrane.schema.json`
+and fall back to downloading the published `v7.2.3.json` (cached). They
+bootstrap their own dependencies on first run, so just call them.
+
+## Conventions
+
+Match the tutorials so generated config looks native:
+
+- **Schema header.** Start full files with
+  `# yaml-language-server: $schema=https://www.membrane-api.io/v7.2.3.json` — it
+  gives editors autocompletion and validation.
+- **One top-level key per document.** Each YAML document has exactly one root key
+  (`api`, `global`, `configuration`, `soapProxy`, `sslProxy`). Separate multiple
+  definitions with a `---` line.
+- **Default port 2000** (8443 for TLS), matching the tutorials.
+- **Comment with purpose.** Tutorials briefly say what a block does and, where
+  useful, a `curl` line to try it. Add short comments in that spirit — explain
+  intent, don't narrate syntax.
+- **Snippet vs. full file.** If the user asked for a snippet to drop into an
+  existing config, return just the relevant `flow`/plugin block at the right
+  indentation. If they asked for an example or a runnable config, return a
+  complete file with the header and a `target` or `return`.
+
+## Output
+
+Present the config in a fenced ```yaml (or ```xml) block. Below it, add a line or
+two on what it does and, when it makes the example concrete, how to run and test
+it (e.g. `./membrane.sh -c apis.yaml` then a `curl`). State that you validated it
+against the schema. If a requested feature isn't in the schema (the local build
+can lag the newest features — e.g. some AI plugins), say so and point to the
+tutorial you based it on instead of forcing it through validation.
+
+## XML (proxies.xml)
+
+Only when the user explicitly asks for XML / proxies.xml / the Spring format.
+Same elements, camelCase tags, attributes instead of nested keys, wrapped in
+`<spring:beans>...<router>`. Ground it in a real
+`distribution/examples/**/proxies.xml`; see the XML section of
+[references/cheatsheet.md](references/cheatsheet.md). `validate_config.py` does
+not check XML, so lean harder on matching an existing example.

--- a/.claude/skills/membrane-config/references/cheatsheet.md
+++ b/.claude/skills/membrane-config/references/cheatsheet.md
@@ -114,6 +114,12 @@ api:
 the surrounding element (default `spel`). For request transformation, jsonpath
 reads the body, e.g. `${$.fieldName}`.
 
+> For anything involving a built-in function (`user()`, `base64Encode`,
+> `hasScope`, …), the SpEL-vs-Groovy call difference (`${user()}` vs.
+> `${fn.user()}`), or which variables are in scope, see
+> [expressions.md](expressions.md). The schema does not cover this and it's a
+> common source of runtime 500s.
+
 ```yaml
 target:
   method: GET

--- a/.claude/skills/membrane-config/references/cheatsheet.md
+++ b/.claude/skills/membrane-config/references/cheatsheet.md
@@ -1,0 +1,198 @@
+# Membrane configuration cheatsheet
+
+Common, copy-adaptable patterns drawn from `distribution/tutorials`. These show
+idiom and shape — always confirm exact attribute names with
+`describe_element.py` and validate the result. Tutorials are the source of truth
+for style; the schema is the source of truth for what's allowed.
+
+## Skeleton
+
+Every YAML config starts with the schema header (gives editors autocompletion)
+and has exactly one top-level key per document:
+
+```yaml
+# yaml-language-server: $schema=https://www.membrane-api.io/v7.2.3.json
+api:
+  port: 2000
+  target:
+    url: https://api.predic8.de
+```
+
+Top-level keys (one per `---` document): `api`, `global`, `configuration`,
+`soapProxy`, `sslProxy`. `api` is by far the most common.
+
+## Multiple APIs on one port
+
+APIs are matched top-to-bottom; the first whose `path` matches wins. An API with
+no `path` matches everything remaining (put it last as a catch-all). Separate
+documents with a line containing only `---`.
+
+```yaml
+api:
+  port: 2000
+  path:
+    uri: /shop
+  target:
+    url: https://api.predic8.de
+---
+api:
+  port: 2000
+  target:                 # no path -> catch-all
+    url: https://httpbin.org
+```
+
+## The flow: request / response plugins
+
+`flow:` is an ordered list. A bare plugin runs in both directions; wrap it in
+`request:` or `response:` to scope it. Plugins execute in order on the way in,
+and in reverse on the way out.
+
+```yaml
+api:
+  port: 2000
+  flow:
+    - request:
+        - log: {}
+        - setHeader:
+            name: X-Trace
+            value: ${uuid()}
+    - response:
+        - setHeader:
+            name: X-Powered-By
+            value: Membrane
+  target:
+    url: https://api.predic8.de
+```
+
+## Conditionals
+
+`if` (single condition) and `choose`/`case`/`otherwise` (branching). Default
+expression language is `spel`; set `language:` (`groovy`, `jsonpath`, `xpath`)
+to switch. Available test variables include `header['X']`, `path`, `method`,
+`statusCode`, `body`.
+
+```yaml
+- if:
+    test: header['X-Id'] == null
+    flow:
+      - static:
+          src: Please set X-Id header
+      - return:
+          status: 400
+```
+
+```yaml
+- choose:
+    - case:
+        test: headers['X-Foo'] != null
+        flow:
+          - return:
+              status: 200
+    - otherwise:
+        - return:
+            status: 400
+```
+
+## Returning a response without a backend
+
+Omit `target:` and end the flow with `return`. Use `static` (or `template`,
+`setBody`) to set the body.
+
+```yaml
+api:
+  port: 2000
+  flow:
+    - static:
+        src: "Hello!"
+    - return:
+        status: 200
+```
+
+## Expressions & templating
+
+`${...}` interpolates inside string values. The language follows `language:` on
+the surrounding element (default `spel`). For request transformation, jsonpath
+reads the body, e.g. `${$.fieldName}`.
+
+```yaml
+target:
+  method: GET
+  url: https://api.predic8.de/shop/v2/products?sort=${$.sort}&limit=${$.limit}
+  language: jsonpath
+```
+
+## TLS termination
+
+```yaml
+api:
+  port: 8443
+  ssl:
+    key:
+      private:
+        location: membrane-key.pem
+      certificates:
+        - location: membrane.pem
+  target:
+    url: https://api.predic8.de
+```
+
+## Basic authentication
+
+```yaml
+- basicAuthentication:
+    users:
+      - username: alice
+        password: "qwertz"
+```
+
+## OpenAPI publish + validation
+
+```yaml
+api:
+  port: 2000
+  openapi:
+    - location: ../../conf/openapi/fruitshop-v2-2-0.oas.yml
+```
+
+## Rate limiting (global)
+
+`global:` applies plugins to every API in the config.
+
+```yaml
+global:
+  flow:
+    - rateLimiter:
+        requestLimit: 10
+        requestLimitDuration: PT1M   # ISO-8601 duration
+```
+
+---
+
+## XML format (proxies.xml) — only when explicitly requested
+
+Modern configs use YAML. The legacy Spring XML format is still supported. Same
+elements, camelCase tags, attributes instead of nested keys. The router/global
+wrapper is required:
+
+```xml
+<spring:beans xmlns="http://membrane-soa.org/proxies/1/"
+    xmlns:spring="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                        http://membrane-soa.org/proxies/1/ http://membrane-soa.org/schemas/proxies-1.xsd">
+  <router>
+    <global>
+      <rateLimiter requestLimit="10" requestLimitDuration="PT1M"/>
+    </global>
+    <api port="2000">
+      <path>/reset-pwd</path>
+      <static>Success</static>
+      <return/>
+    </api>
+  </router>
+</spring:beans>
+```
+
+Find XML examples under `distribution/examples/**/proxies.xml`. The
+`validate_config.py` script validates YAML only — for XML, ground every element
+in an existing `proxies.xml` example.

--- a/.claude/skills/membrane-config/references/expressions.md
+++ b/.claude/skills/membrane-config/references/expressions.md
@@ -1,0 +1,138 @@
+# Expressions, templating & built-in functions
+
+The schema tells you which elements exist; it does **not** tell you how their
+expression/template strings are evaluated. That's decided in code, and it's the
+main thing this skill would otherwise guess at. Three facts drive every snippet
+that contains a `${...}`, a `test:`, or a `value:`:
+
+1. **Which engine** evaluates the string (SpEL vs. Groovy vs. none).
+2. **How you call a built-in function** in that engine (`user()` vs. `fn.user()`).
+3. **Which variables** are in scope.
+
+Get any of these wrong and you get a 500 `Template execution error` or a silent
+empty value — not a schema error, so `validate_config.py` won't catch it.
+
+Source of truth (verify here if unsure, these can evolve):
+`core/.../lang/ScriptingUtils.java`, `core/.../lang/CommonBuiltInFunctions.java`,
+`core/.../lang/spel/functions/SpELBuiltInFunctions.java`,
+`core/.../lang/groovy/GroovyBuiltInFunctions.java`,
+`core/.../lang/ExchangeExpression.java`,
+`core/.../interceptor/lang/AbstractLanguageInterceptor.java` (default language),
+`core/.../interceptor/templating/TemplateInterceptor.java` (template engine).
+
+## Which engine does each element use?
+
+| Element | Engine | Interpolation | Default language | Call a function |
+|---|---|---|---|---|
+| `setHeader`, `setBody`, `setProperty`, … (anything with a `language` attribute — confirm the element name with `describe_element.py`) | `ExchangeExpression` | `${...}` inside the string | **SpEL** (`groovy` / `jsonpath` / `xpath` via `language:`) | `${user()}` — direct |
+| `if` `test`, `choose`/`case` `test` | `ExchangeExpression` | whole string is the expression (no `${}`) | **SpEL** | `user()` — direct |
+| `template` (`src`/`location`) | Groovy **StreamingTemplateEngine** (or **XmlTemplateEngine** when `contentType` is XML) | `${...}` is Groovy | Groovy (fixed — **no** `language` attribute) | `${fn.user()}` — via `fn` |
+| `static` (`src`) | none | **none** — text is emitted verbatim | — | not possible; use `template`/`setBody` |
+| `groovy` (script interceptor) | Groovy script | `${}` in Groovy strings | Groovy | functions available via the `fn` binding |
+
+The trap we keep hitting: **`template` is Groovy, `setBody`/`setHeader` default
+to SpEL.** Same-looking `${user()}` works in `setBody` (SpEL resolves the
+function directly) but throws `No signature of method ... .user()` in
+`template`, where it must be `${fn.user()}`. If you just need a function result
+in a response body, prefer `setBody` with SpEL — fewer surprises than `template`.
+
+```yaml
+# SpEL element — function called directly
+- setBody:
+    value: 'User: ${user()}, encoded: ${base64Encode("alice:secret")}'
+    # language: spel   # default, shown for clarity
+
+# Groovy template — function via fn., variables direct
+- template:
+    src: |
+      User: ${fn.user()}
+      Path: ${path}
+```
+
+## Calling built-in functions — the `fn.` rule
+
+All three engines expose the **same function set** (they delegate to
+`CommonBuiltInFunctions`). Only the call syntax differs:
+
+- **SpEL / jsonpath / xpath contexts** (`setHeader`, `setBody`, `if`, `choose`,
+  `target.url`, …): call the function **by name** — `user()`,
+  `base64Encode('a:b')`, `hasScope('admin')`. The evaluation context injects the
+  exchange argument; you pass only the visible parameters.
+- **Groovy `template`**: call it on the **`fn`** object — `fn.user()`,
+  `fn.base64Encode('a:b')`. `fn` is the binding key (`ScriptingUtils.BINDING`)
+  holding a `GroovyBuiltInFunctions`. Bare `user()` does **not** resolve.
+
+## Built-in function catalog
+
+Defined once in `CommonBuiltInFunctions`, surfaced in each language. Signatures
+below are the **caller-visible** ones (the exchange/context arg is implicit).
+
+| Function | Returns | Notes |
+|---|---|---|
+| `user()` | String | Authenticated username (from `basicAuthentication`, JWT, API-key, …). `null` if unauthenticated. |
+| `hasScope()` / `hasScope(scope)` / `hasScope(list)` | boolean | OAuth2/JWT scope checks. |
+| `scopes()` / `scopes(securityScheme)` | List\<String> | All scopes. |
+| `isBearerAuthorization()` | boolean | Is there a `Bearer` Authorization header. |
+| `isLoggedIn(beanName)` | boolean | Session check against a session manager bean. |
+| `getDefaultSessionLifetime(beanName)` | long | |
+| `base64Encode(s)` | String | UTF-8 → Base64. **There is no `base64Decode`.** To decode, drop to the host language: in **SpEL** `new String(T(java.util.Base64).getDecoder().decode(x))` (SpEL is a `StandardEvaluationContext`, so `T(...)` works); in a **Groovy** template `new String(java.util.Base64.decoder.decode(x))` (Groovy has no `T(...)`). |
+| `env(name)` | String | Environment variable — keep secrets out of the config file. |
+| `urlEncode(s)` / `pathEncode(segment)` | String | URL / path-segment encoding. |
+| `jsonPath(path)` | Object | Read a value from the JSON body. |
+| `xpath(expr)` / `xpath(expr, ctx)` | Object | Evaluate XPath against the (XML) body or a node. |
+| `toJSON(obj)` | String | Serialize to JSON. |
+| `isJSON()` / `isXML()` | boolean | Content-type / body sniffing. |
+| `weight(percent)` | boolean | True for ~`percent`% of calls — weighted routing / canary. |
+| `escape(obj)` *(Groovy only)* | Object | Content-type-aware escaping inside templates. |
+
+## Binding variables (in scope for expressions/templates)
+
+From `ScriptingUtils.createParameterBindings`. Many have singular+plural
+aliases — both work.
+
+| Variable | What |
+|---|---|
+| `exchange` / `exc` | The `Exchange`. |
+| `flow` | Current `Flow` (`REQUEST` / `RESPONSE` / `ABORT`). |
+| `message` | Current message (request or response per flow). |
+| `request` / `response` | The respective message (`response`/`statusCode` only in RESPONSE flow). |
+| `body` | Lazy body (string-decoded on use). |
+| `header` / `headers` | Header map — `header['Authorization']` or `header.Authorization`. |
+| `cookie` / `cookies` | Cookie map. |
+| `method` | HTTP method (REQUEST flow). |
+| `path` | Request URI/path. |
+| `param` / `params` | Query parameters (REQUEST flow). |
+| `pathParam` | Path parameters — `pathParam.id`. |
+| `statusCode` | Response status (RESPONSE flow). |
+| `property` / `props` | Exchange properties map. **In a Groovy `template`, use `property` — NOT `properties`** (`properties` collides with a built-in Groovy meta-property and returns the wrong thing; it works fine in SpEL and the Groovy script interceptor). |
+| `it` | Shortcut for the `it` exchange property (used by `for` loops). |
+| `json` | Parsed JSON body — present only when the template/script actually references `json`. |
+| `spring` / `registry` | Bean factory / registry (advanced). |
+| `fn` | The Groovy built-in functions object (see the `fn.` rule above). |
+
+## Quick worked example: read Basic-Auth username on the receiving side
+
+Two equivalent ways, depending on which element you use:
+
+```xml
+<!-- Preferred: let basicAuthentication validate, then read user() -->
+<basicAuthentication>
+    <user name="alice" password="secret"/>
+</basicAuthentication>
+<template>
+    <src>User: ${fn.user()}
+Path: ${path}</src>
+</template>
+
+<!-- Manual decode in a Groovy template (no base64Decode builtin, no T(...) in Groovy) -->
+<template>
+    <src>User: ${new String(java.util.Base64.decoder.decode(header['Authorization'].split(' ')[1])).split(':')[0]}</src>
+</template>
+
+<!-- Same decode but as a SpEL element (note T(...), which is SpEL-only) -->
+<setBody language="spel"
+         value="User: ${new String(T(java.util.Base64).getDecoder().decode(header['Authorization'].split(' ')[1])).split(':')[0]}"/>
+```
+
+Prefer the `basicAuthentication` + `fn.user()` form — it's unambiguous and
+sidesteps the SpEL-vs-Groovy `T(...)` difference entirely.

--- a/.claude/skills/membrane-config/scripts/describe_element.py
+++ b/.claude/skills/membrane-config/scripts/describe_element.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Look up a Membrane configuration element in membrane.schema.json.
+
+Every config element (api, target, setHeader, choose, rateLimiter, ...) is
+backed by a schema definition that lists its exact attributes, allowed enum
+values, and nested children. Guessing attribute names is the main way a
+generated config goes wrong, so use this to check the real names instead.
+
+Usage:
+    python3 describe_element.py <name>     # show one element's attributes
+    python3 describe_element.py --list     # list every known element id
+    python3 describe_element.py --grep foo # list element ids containing "foo"
+
+The schema is located the same way as validate_config.py: the locally built
+copy is preferred, otherwise the published schema is downloaded and cached.
+"""
+import json
+import os
+import sys
+import urllib.request
+
+PUBLISHED_SCHEMA_URL = "https://www.membrane-api.io/v7.2.3.json"
+LOCAL_SCHEMA_REL = "core/target/classes/com/predic8/membrane/core/config/json/membrane.schema.json"
+CACHE_DIR = os.path.join(os.path.expanduser("~"), ".cache", "membrane-config-skill")
+
+
+def find_local_schema():
+    starts = [os.getcwd(), os.path.dirname(os.path.abspath(__file__))]
+    seen = set()
+    for start in starts:
+        d = os.path.abspath(start)
+        while d and d not in seen:
+            seen.add(d)
+            cand = os.path.join(d, LOCAL_SCHEMA_REL)
+            if os.path.isfile(cand):
+                return cand
+            parent = os.path.dirname(d)
+            if parent == d:
+                break
+            d = parent
+    return None
+
+
+def load_schema():
+    path = find_local_schema()
+    if not path:
+        os.makedirs(CACHE_DIR, exist_ok=True)
+        path = os.path.join(CACHE_DIR, "v7.2.3.json")
+        if not os.path.isfile(path):
+            print(f"Downloading schema from {PUBLISHED_SCHEMA_URL} ...", file=sys.stderr)
+            urllib.request.urlretrieve(PUBLISHED_SCHEMA_URL, path)
+    with open(path) as f:
+        return json.load(f), path
+
+
+def id_map(schema):
+    """Map element id (the YAML key, e.g. 'setHeader') -> definition."""
+    out = {}
+    for key, d in schema.get("$defs", {}).items():
+        if isinstance(d, dict) and "id" in d:
+            out.setdefault(d["id"], (key, d))
+    return out
+
+
+def short_type(prop, defs):
+    if "$ref" in prop:
+        ref = prop["$ref"].split("/")[-1]
+        child = defs.get(ref, {})
+        return f"<{child.get('id', ref)}>"
+    if "enum" in prop:
+        return "enum(" + "|".join(map(str, prop["enum"])) + ")"
+    if "anyOf" in prop:
+        return " | ".join(short_type(p, defs) for p in prop["anyOf"])
+    if "items" in prop:
+        return f"[{short_type(prop['items'], defs)}]"
+    t = prop.get("type", "?")
+    return "/".join(t) if isinstance(t, list) else t
+
+
+def describe(name, schema):
+    defs = schema.get("$defs", {})
+    ids = id_map(schema)
+    if name not in ids:
+        matches = sorted(k for k in ids if name.lower() in k.lower())
+        print(f"No element named '{name}'.")
+        if matches:
+            print("Did you mean: " + ", ".join(matches))
+        else:
+            print("Use --list to see all element ids.")
+        return 1
+    key, d = ids[name]
+    print(f"# {name}")
+    props = d.get("properties", {})
+    if not props:
+        print("(no attributes)")
+    else:
+        print("attributes:")
+        for pname, p in props.items():
+            if pname == "$ref":
+                continue
+            print(f"  {pname}: {short_type(p, defs)}")
+    if d.get("additionalProperties", True):
+        print("(accepts additional/free-form properties)")
+    return 0
+
+
+def main():
+    args = sys.argv[1:]
+    if not args:
+        print(__doc__)
+        return 2
+    schema, path = load_schema()
+    if args[0] == "--list":
+        for k in sorted(id_map(schema)):
+            print(k)
+        return 0
+    if args[0] == "--grep":
+        needle = args[1].lower() if len(args) > 1 else ""
+        for k in sorted(id_map(schema)):
+            if needle in k.lower():
+                print(k)
+        return 0
+    return describe(args[0], schema)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/membrane-config/scripts/validate_config.py
+++ b/.claude/skills/membrane-config/scripts/validate_config.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Validate a Membrane YAML configuration against membrane.schema.json.
+
+Usage:
+    python3 validate_config.py path/to/apis.yaml [more.yaml ...]
+
+What it does
+------------
+- Finds the JSON schema. Prefers the locally built copy
+  (core/target/classes/com/predic8/membrane/core/config/json/membrane.schema.json),
+  searching upward from the config file and from this script. Falls back to the
+  published schema, downloaded once into a cache dir.
+- Each YAML file may contain several documents separated by `---`; Membrane
+  treats each as one proxy definition, and the schema requires exactly one
+  top-level key per document (api / global / configuration / ...). Every
+  document is validated independently.
+- Reports the JSON path of each violation so you can find it in the file.
+
+Dependencies (jsonschema, pyyaml) are bootstrapped into a private venv on first
+run, so the script works on a stock Python without touching system packages.
+"""
+import json
+import os
+import subprocess
+import sys
+import urllib.request
+
+PUBLISHED_SCHEMA_URL = "https://www.membrane-api.io/v7.2.3.json"
+LOCAL_SCHEMA_REL = "core/target/classes/com/predic8/membrane/core/config/json/membrane.schema.json"
+CACHE_DIR = os.path.join(os.path.expanduser("~"), ".cache", "membrane-config-skill")
+
+
+# --- dependency bootstrap -------------------------------------------------
+def ensure_deps():
+    try:
+        import jsonschema  # noqa: F401
+        import yaml  # noqa: F401
+        return
+    except ImportError:
+        pass
+    venv = os.path.join(CACHE_DIR, "venv")
+    py = os.path.join(venv, "bin", "python")
+    if not os.path.exists(py):
+        os.makedirs(CACHE_DIR, exist_ok=True)
+        print("Bootstrapping validation deps (one-time)...", file=sys.stderr)
+        subprocess.check_call([sys.executable, "-m", "venv", venv])
+        subprocess.check_call(
+            [py, "-m", "pip", "install", "--quiet", "jsonschema", "pyyaml"]
+        )
+    # re-exec inside the venv
+    os.execv(py, [py, os.path.abspath(__file__)] + sys.argv[1:])
+
+
+# --- schema location ------------------------------------------------------
+def find_local_schema(start_paths):
+    seen = set()
+    for start in start_paths:
+        d = os.path.abspath(start)
+        while d and d not in seen:
+            seen.add(d)
+            candidate = os.path.join(d, LOCAL_SCHEMA_REL)
+            if os.path.isfile(candidate):
+                return candidate
+            parent = os.path.dirname(d)
+            if parent == d:
+                break
+            d = parent
+    return None
+
+
+def download_schema():
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    cached = os.path.join(CACHE_DIR, "v7.2.3.json")
+    if not os.path.isfile(cached):
+        print(f"Downloading schema from {PUBLISHED_SCHEMA_URL} ...", file=sys.stderr)
+        urllib.request.urlretrieve(PUBLISHED_SCHEMA_URL, cached)
+    return cached
+
+
+def load_schema(config_paths):
+    starts = [os.path.dirname(p) for p in config_paths] + [
+        os.path.dirname(os.path.abspath(__file__)),
+        os.getcwd(),
+    ]
+    schema_path = find_local_schema(starts)
+    source = "local build"
+    if not schema_path:
+        schema_path = download_schema()
+        source = "published (v7.2.3)"
+    with open(schema_path) as f:
+        return json.load(f), schema_path, source
+
+
+# --- validation -----------------------------------------------------------
+def validate_file(path, schema):
+    import yaml
+    from jsonschema import Draft202012Validator
+
+    with open(path) as f:
+        try:
+            docs = list(yaml.safe_load_all(f))
+        except yaml.YAMLError as e:
+            return [f"YAML parse error: {e}"]
+
+    validator = Draft202012Validator(schema)
+    problems = []
+    real_docs = [d for d in docs if d is not None]
+    for i, doc in enumerate(real_docs):
+        prefix = f"document #{i + 1}: " if len(real_docs) > 1 else ""
+        for err in sorted(validator.iter_errors(doc), key=lambda e: list(e.path)):
+            loc = "/".join(str(p) for p in err.path) or "(root)"
+            problems.append(f"{prefix}{loc}: {err.message}")
+    return problems
+
+
+def main():
+    ensure_deps()
+    args = sys.argv[1:]
+    if not args:
+        print(__doc__)
+        sys.exit(2)
+
+    schema, schema_path, source = load_schema(args)
+    print(f"Schema: {schema_path} [{source}]\n")
+
+    total = 0
+    for path in args:
+        if not os.path.isfile(path):
+            print(f"✗ {path}: file not found")
+            total += 1
+            continue
+        problems = validate_file(path, schema)
+        if problems:
+            print(f"✗ {path}: {len(problems)} problem(s)")
+            for p in problems:
+                print(f"    - {p}")
+            total += len(problems)
+        else:
+            print(f"✓ {path}: valid")
+    print()
+    sys.exit(1 if total else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/review-branch/SKILL.md
+++ b/.claude/skills/review-branch/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: review-branch
+description: Review the current git branch against master — code quality, refactoring opportunities, regressions, correctness, and test coverage — and print a severity-grouped markdown report. Use whenever the user asks to review the branch, review their changes against master, do a pre-PR / pre-merge review, or asks "is this branch ready", "what's wrong with my changes", "review what I've done so far". Builds and runs the affected module's tests to catch real regressions. This is the whole-branch counterpart to the built-in /code-review (which only looks at the current diff).
+---
+
+# Review Branch
+
+Review everything that changed on the current branch relative to `master` and report what
+needs attention before the branch is merged. The goal is a review a senior engineer on this
+project would give: focused on real problems, grounded in the actual code, and ranked so the
+author knows what to fix first.
+
+## Scope of the review
+
+Review **committed changes on the branch plus any uncommitted working-tree changes**, all
+relative to the merge-base with `master`. Concretely:
+
+```bash
+BASE=$(git merge-base HEAD master)
+git diff --stat $BASE            # committed + uncommitted, names only
+git diff $BASE                   # the full diff to review
+```
+
+`git diff $BASE` (no `--cached`, no second ref) compares the working tree against the
+merge-base, so it already includes both committed and uncommitted changes — which is exactly
+the scope we want. Don't review changes that are also on `master`; the merge-base keeps those
+out.
+
+**Untracked (newly created, not yet `git add`-ed) files are out of scope** — `git diff` does
+not show them. This is deliberate: review what's in version control. If the author wants a brand
+new file reviewed, they should `git add` it first. If `git status --porcelain` shows untracked
+files that look relevant to the change, mention them in one line so the author can stage them and
+re-run — but don't review their contents.
+
+If the branch *is* `master`, or there is no diff, say so and stop — there is nothing to review.
+
+## How to work
+
+Review in four passes. Don't just walk the diff top to bottom — read enough of the surrounding
+code to understand what the change is *for*, then judge it. A diff hunk that looks fine in
+isolation can be a regression once you see its callers.
+
+1. **Understand the change.** Read the diff and the commit messages (`git log --oneline $BASE..HEAD`).
+   What is this branch trying to do? Hold that intent in mind — most findings are "this doesn't
+   actually achieve the intent" or "this achieves it but breaks something else".
+
+2. **Correctness & regressions.** This is the most important pass. For each change, ask what
+   existing behavior it could break: callers that relied on the old contract, edge cases
+   (null/empty/large input), changed defaults, altered exception or HTTP-status behavior,
+   thread-safety, resource leaks. When a public method's behavior changes, grep for its callers
+   rather than assuming the change is local. Then **build and run the affected tests** (see below)
+   — static reasoning finds the suspicious spots, the tests confirm them.
+
+3. **Code quality.** Apply the project's `code-conventions` skill
+   (`.claude/skills/code-conventions/SKILL.md`) — Java 21, `var`, no needless intermediate
+   variables, text blocks, `formatted` over concatenation, early returns, braces. Flag only real
+   deviations in the changed code, not pre-existing style elsewhere.
+
+4. **Refactoring & test coverage.** Look for duplication the change introduced or could now
+   remove, methods that got too long, abstractions that would simplify the change, and whether
+   new behavior is actually covered by a test. For a Membrane interceptor/plugin, check that new
+   config attributes are documented and tested the way the rest of the codebase does it; the
+   `find-interceptor-impl` and `find-example` skills help locate the conventions to match.
+
+## Building and running tests
+
+Regressions are confirmed by running tests, not by reading code alone. Run the tests for the
+**modules that actually changed**, not the whole build. The modules are `annot`, `core`,
+`distribution`, `war`, `test`.
+
+Map the changed files to a module from their path (`core/src/...` → `core`), then:
+
+```bash
+# Compile + run one module's tests under the English locale (this machine defaults to de/DE,
+# which makes locale-sensitive assertions fail spuriously).
+mvn -pl core test -Duser.language=en -Duser.country=US
+```
+
+Repo-specific gotchas that will otherwise waste time or produce misleading failures:
+
+- **`core`: `-Dtest=SomeClass` does not isolate a single class.** `core`'s `UnitTests` is a JUnit
+  Platform `@Suite` that runs the whole package regardless of the `-Dtest` filter. To run one
+  class in isolation, use the JUnit Platform launcher directly rather than the failsafe/surefire
+  filter. For a quick regression check it's usually fine (and simpler) to run the whole `core`
+  module suite.
+- **Don't use `-am` to pull in upstream modules.** It drags in the `annot` module, whose
+  annotation-processor test fails on a German-locale JVM and has nothing to do with the branch
+  under review. Build/test the changed module directly instead.
+- **Changes under `distribution/` (examples & tutorials)** are verified by integration tests that
+  unzip the *built* distribution, not the source tree. Use the `run-example-test` skill
+  (`.claude/skills/run-example-test/SKILL.md`) — it rebuilds the distribution when needed, runs a
+  single `*ExampleTest` / `*TutorialTest` fast, and already sets the English locale. Don't try to
+  run these with a plain `mvn test`.
+
+If a relevant test suite is too slow to run in full, run the most relevant classes and **say so in
+the report** — list the suites you ran and the ones you judged too expensive to run, so the author
+can finish the job. Never claim tests pass without having run them.
+
+## Report format
+
+Print the report as markdown in the conversation. Lead with a one-line verdict so the author
+immediately knows whether the branch is in good shape, then the findings ranked by severity.
+
+```markdown
+# Branch review: <branch> vs master
+
+**Verdict:** <one line — e.g. "Solid, two blockers to fix before merge" / "Ready to merge" / "Needs rework">
+
+<2–4 sentences: what the branch does and the overall shape of the change.>
+
+## Build & tests
+- `mvn -pl core test` → <pass/fail, counts>. <Anything notable.>
+- Not run: <suites skipped and why.>
+
+## Blockers
+Things that are wrong or will break — bugs, regressions, missing coverage for risky changes.
+- **`core/.../Foo.java:42` — <short title>.** <What's wrong and why it matters; the failing
+  case or broken caller.> *Fix:* <concrete suggestion.>
+
+## Improvements
+Should-fix-but-not-blocking — refactoring, quality, weaker test coverage.
+- **`core/.../Bar.java:88` — <short title>.** <What and why.> *Fix:* <suggestion.>
+
+## Nitpicks
+Minor style / convention points, grouped tersely. Skip this section if there's nothing real.
+```
+
+Rules that keep the report useful:
+
+- **Cite `file:line`** for every finding so the author can jump straight to it.
+- **Rank honestly.** A misplaced `var` is not a blocker; a regression is. If the branch is clean,
+  say "Ready to merge" and don't manufacture findings to fill sections — an empty Improvements
+  section is a fine outcome.
+- **Explain the why, propose a fix.** "This is wrong" is not actionable; "this NPEs when the
+  header is absent because `getFirst` returns null — guard with X" is.
+- **Stay in scope.** Review what the branch changed. Pre-existing problems in untouched code are
+  out of scope unless the change makes them materially worse or newly reachable.


### PR DESCRIPTION
Adds a Claude Code skill that generates Membrane API Gateway configuration examples and snippets, grounded in the project's tutorials and verified against membrane.schema.json.

- SKILL.md: workflow (ground in tutorials -> confirm attributes in schema -> write -> validate) and Membrane config conventions
- scripts/describe_element.py: looks up any element's exact attributes, enums, and children from the schema
- scripts/validate_config.py: validates apis.yaml against the schema, reporting the path of each violation
- references/cheatsheet.md: copy-adaptable patterns from the tutorials

Both scripts auto-locate the schema (local build, falling back to the published v7.2.3.json) and bootstrap their own dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Membrane YAML configuration validation tool that checks files against the Membrane JSON schema and reports detailed, per-problem errors.
  * Added an element inspector tool to discover configuration element ids and view their supported attributes.
  * Added expanded Membrane configuration documentation, including a cheatsheet and an expressions/template guide with worked examples and pattern coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->