### PR TITLE
test: add validation for non-integer values in integer properties

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/ValidationErrors.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/ValidationErrors.java
@@ -17,10 +17,10 @@
 package com.predic8.membrane.core.openapi.validators;
 
 import java.util.*;
-import java.util.stream.*;
+import java.util.stream.Stream;
 
-import static com.predic8.membrane.core.openapi.util.Utils.*;
-import static com.predic8.membrane.core.openapi.validators.ValidationErrors.Direction.*;
+import static com.predic8.membrane.core.openapi.util.Utils.setFieldIfNotNull;
+import static com.predic8.membrane.core.openapi.validators.ValidationErrors.Direction.REQUEST;
 
 public class ValidationErrors {
 
@@ -73,6 +73,10 @@ public class ValidationErrors {
 
     public ValidationError get(int i) {
         return errors.get(i);
+    }
+
+    public ValidationError getFirst() {
+        return errors.getFirst();
     }
 
     public Stream<ValidationError> stream() {

--- a/core/src/test/java/com/predic8/membrane/core/openapi/validators/IntegerTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/validators/IntegerTest.java
@@ -16,15 +16,17 @@
 
 package com.predic8.membrane.core.openapi.validators;
 
-import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.databind.node.*;
-import com.predic8.membrane.core.openapi.model.*;
-import org.junit.jupiter.api.*;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.predic8.membrane.core.openapi.model.JsonBody;
+import com.predic8.membrane.core.openapi.model.Request;
+import org.junit.jupiter.api.Test;
 
-import java.math.*;
+import java.math.BigDecimal;
 
-import static com.predic8.membrane.core.openapi.validators.ValidationContext.ValidatedEntityType.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static com.predic8.membrane.core.openapi.validators.ValidationContext.ValidatedEntityType.QUERY_PARAMETER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class IntegerTest extends AbstractValidatorTest {
@@ -118,6 +120,15 @@ protected String getOpenAPIFileName() {
     public void validMaximumWithoutTypeInBody() {
         ValidationErrors errors = validator.validate(Request.post().path("/integer").body(new JsonBody(getNumbers("maximum-without-type",new BigDecimal(5)))));
         assertEquals(0,errors.size());
+    }
+
+    @Test
+    public void stringForIntegerPropertyInBodyIsRejected() {
+        var root = om.createObjectNode();
+        root.put("integer", "1"); // JSON string, not a number
+        var errors = validator.validate(Request.post().path("/integer").body(new JsonBody(root)));
+        assertEquals(1, errors.size());
+        assertTrue(errors.getFirst().getMessage().contains("not an integer"));
     }
 
     private JsonNode getNumbers(String name, BigDecimal n) {

--- a/core/src/test/resources/openapi/specs/integer.yml
+++ b/core/src/test/resources/openapi/specs/integer.yml
@@ -38,6 +38,8 @@ components:
     Numbers:
       type: object
       properties:
+        integer:
+          type: integer
         minimum:
           type: number
           minimum: 5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation so integer fields in request bodies are correctly rejected when sent as strings instead of numbers.
  * Added support for retrieving the first validation error more directly, helping surface the most relevant issue faster.

* **Tests**
  * Added coverage for invalid integer input to ensure the expected validation error is returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->