### PR TITLE
Tutorials: OpenTelemetry

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/opentelemetry/OpenTelemetryInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/opentelemetry/OpenTelemetryInterceptor.java
@@ -53,11 +53,39 @@ import static io.opentelemetry.api.trace.StatusCode.OK;
 import static io.opentelemetry.context.Context.current;
 
 /**
- * @description Creates an OpenTelemetry span for each HTTP request passing through. Sends the tracing data to the
- * speficied OpenTelemetry collector.
- *
- * See also examples/monitoring-tracing/opentelemetry for a demo, including screenshots.
+ * @description OpenTelemetry is an open observability standard for distributed tracing. It tracks
+ * a request as it travels across services by passing a <code>traceparent</code> header from hop
+ * to hop and collecting timing data (spans) in a central backend such as Jaeger or Zipkin.
+ * Membrane supports OpenTelemetry by creating one INTERNAL span per request: it extracts the
+ * incoming W3C trace context from request headers, opens the span, and injects the updated
+ * <code>traceparent</code> into the forwarded request so downstream services join the same trace.
+ * HTTP headers are recorded as <code>http.header.*</code> attributes, the response status as
+ * <code>http.status_code</code>, and for API proxies the OpenAPI title as <code>openapi.title</code>.
+ * The <code>traceId</code> and <code>spanId</code> are written into SLF4J MDC automatically so
+ * every log line carries them. Aborted exchanges are marked ERROR. Declare the plugin in
+ * <code>global:</code> to instrument all APIs at once.
+ * See tutorials/operation/40-OpenTelemetry.yaml for a runnable multi-hop example with Jaeger,
+ * and examples/monitoring-tracing/opentelemetry for screenshots.
+ * <pre>
+ * openTelemetry:
+ *   [ sampleRate: 0.0..1.0 ]        # default: 1.0
+ *   [ logBody: true | false ]        # default: false
+ *   [ otlpExporter: ... ]            # defaults to localhost:4317 over gRPC
+ *   [ customAttribute:
+ *       - name: key
+ *         value: val
+ *       ... ]
+ * </pre>
  * @topic 4. Monitoring, Logging and Statistics
+ * @yaml <pre><code>
+ * global:
+ *   - openTelemetry:
+ *       sampleRate: 1.0
+ *       otlpExporter:
+ *         host: localhost
+ *         port: 4317
+ *         transport: grpc
+ * </code></pre>
  */
 @MCElement(name = "openTelemetry")
 public class OpenTelemetryInterceptor extends AbstractInterceptor {
@@ -252,11 +280,20 @@ public class OpenTelemetryInterceptor extends AbstractInterceptor {
         return customAttributes;
     }
 
+    /**
+     * @description Static key-value pairs attached as attributes to every span.
+     * Useful for tagging traces with environment, region, or deployment metadata.
+     */
     @MCChildElement(order = 20)
     public void setCustomAttributes(List<CustomAttribute> customAttributes) {
         this.customAttributes.addAll(customAttributes);
     }
 
+    /**
+     * @description When <code>true</code>, records request and response bodies as span events.
+     * Reads the entire body into memory; avoid on large or streaming payloads.
+     * @default false
+     */
     @MCAttribute
     public void setLogBody(boolean logBody) {
         this.logBody = logBody;
@@ -266,6 +303,10 @@ public class OpenTelemetryInterceptor extends AbstractInterceptor {
         return logBody;
     }
 
+    /**
+     * @description The OTLP exporter that delivers spans to the collector.
+     * Defaults to <code>otlpExporter</code> targeting <code>localhost:4317</code> over gRPC.
+     */
     @MCChildElement(order = 10)
     public void setExporter(OtelExporter exporter) {
         this.exporter = exporter;
@@ -275,6 +316,10 @@ public class OpenTelemetryInterceptor extends AbstractInterceptor {
         return exporter;
     }
 
+    /**
+     * @description Fraction of requests to sample, between 0.0 (none) and 1.0 (all).
+     * @default 1.0
+     */
     @MCAttribute
     public void setSampleRate(double sampleRate) {
         this.sampleRate = sampleRate;
@@ -290,6 +335,9 @@ public class OpenTelemetryInterceptor extends AbstractInterceptor {
         private String name;
         private String value;
 
+        /**
+         * @description Attribute key written to the span.
+         */
         @MCAttribute
         public void setName(String name) {
             this.name = name;
@@ -299,6 +347,9 @@ public class OpenTelemetryInterceptor extends AbstractInterceptor {
             return name;
         }
 
+        /**
+         * @description Attribute value written to the span.
+         */
         @MCAttribute
         public void setValue(String value) {
             this.value = value;

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/opentelemetry/exporter/OtlpExporter.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/opentelemetry/exporter/OtlpExporter.java
@@ -62,9 +62,8 @@ public class OtlpExporter implements OtelExporter {
         return format("%s://%s:%d%s", isSecured() ? "https" : "http", host, getProtocolPort(port, transport), getPathExtension());
     }
 
-    @SuppressWarnings("StringEquality")
     private String getPathExtension() {
-        if (path == "" && transport == HTTP) {
+        if (path.isEmpty() && transport == HTTP) {
             return "/v1/traces";
         }
         return path;
@@ -137,7 +136,8 @@ public class OtlpExporter implements OtelExporter {
     }
 
     /**
-     * @description Whether to use HTTPS instead of HTTP. Does not affect gRPC TLS configuration.
+     * @description Whether to use a secure (TLS) connection. When <code>true</code>, the endpoint URL
+     * scheme is set to <code>https</code> for HTTP transport and causes the gRPC client to use TLS as well.
      * @default false
      */
     @SuppressWarnings("unused")

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/opentelemetry/exporter/OtlpExporter.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/opentelemetry/exporter/OtlpExporter.java
@@ -27,11 +27,24 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.predic8.membrane.core.interceptor.opentelemetry.exporter.OtlpExporter.OtlpType.*;
+import static com.predic8.membrane.core.interceptor.opentelemetry.exporter.OtlpExporter.OtlpType.GRPC;
+import static com.predic8.membrane.core.interceptor.opentelemetry.exporter.OtlpExporter.OtlpType.HTTP;
 import static java.lang.String.format;
 
-/*
- * Otlp Implementation for the OpenTelemetry protocol
+/**
+ * @description Exports spans to an OpenTelemetry collector using the OTLP protocol over gRPC or HTTP.
+ * Defaults to gRPC on <code>localhost:4317</code>. Switch to HTTP by setting
+ * <code>transport: http</code> (default port 4318, default path <code>/v1/traces</code>).
+ * Set <code>secured: true</code> to use HTTPS. Custom request headers can be added for
+ * hosted collectors that require authorization.
+ * @yaml <pre><code>
+ * global:
+ *   - openTelemetry:
+ *       otlpExporter:
+ *         host: localhost
+ *         port: 4317
+ *         transport: grpc
+ * </code></pre>
  */
 @MCElement(name = "otlpExporter", component = false)
 public class OtlpExporter implements OtelExporter {
@@ -103,30 +116,58 @@ public class OtlpExporter implements OtelExporter {
         return builder.build();
     }
 
+    /**
+     * @description HTTP headers sent with every span export request. Only effective when
+     * <code>transport</code> is <code>http</code>. Useful for authorization headers required
+     * by hosted collectors.
+     */
     @MCChildElement
     public void setHeaders(List<addHeader> headers) {
         this.headers.addAll(headers);
     }
 
+    /**
+     * @description Wire protocol for delivering spans: <code>grpc</code> or <code>http</code>.
+     * @default grpc
+     * @example http
+     */
     @MCAttribute
     public void setTransport(String transport) {
         this.transport = OtlpType.fromString(transport);
     }
 
+    /**
+     * @description Whether to use HTTPS instead of HTTP. Does not affect gRPC TLS configuration.
+     * @default false
+     */
     @SuppressWarnings("unused")
     @MCAttribute
     public void setSecured(boolean secured) {
         this.secured = secured;
     }
 
+    /**
+     * @description URL path appended to the collector endpoint. For HTTP transport defaults to
+     * <code>/v1/traces</code> when left empty.
+     * @default (empty)
+     */
     @MCAttribute
     public void setPath(String path) { this.path = path; }
 
+    /**
+     * @description Hostname or IP address of the OTLP collector.
+     * @default localhost
+     * @example collector.example.com
+     */
     @MCAttribute
     public void setHost(String host) {
         this.host = host;
     }
 
+    /**
+     * @description Port of the OTLP collector. When omitted, defaults to 4317 for gRPC and 4318 for HTTP.
+     * @example 4317
+     */
     @MCAttribute
     public void setPort(int port) {
         this.port = port;

--- a/distribution/src/test/java/com/predic8/membrane/tutorials/operation/OpenTelemetryTutorialTest.java
+++ b/distribution/src/test/java/com/predic8/membrane/tutorials/operation/OpenTelemetryTutorialTest.java
@@ -1,0 +1,71 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.tutorials.operation;
+
+import com.predic8.membrane.examples.util.SubstringWaitableConsoleEvent;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+
+/**
+ * Verifies tutorial step 40-OpenTelemetry.yaml: a three-hop chain
+ * (Gateway → Microservice A → Microservice B) with an explicit Jaeger
+ * OTLP/gRPC endpoint. Requests succeed even when Jaeger is not running —
+ * the exporter silently drops unreachable spans. The openTelemetry plugin
+ * writes traceId and spanId into the SLF4J MDC for every request, and each
+ * API logs the propagated traceparent header.
+ */
+public class OpenTelemetryTutorialTest extends AbstractOperationTutorialTest {
+
+    @Override
+    protected String getTutorialYaml() {
+        return "40-OpenTelemetry.yaml";
+    }
+
+    @Test
+    void requestSucceeds() {
+        given()
+        .when()
+            .get("http://localhost:2000")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    void traceIdIsWrittenToMdc() throws Exception {
+        var traceInMdc = new SubstringWaitableConsoleEvent(process, "traceId=");
+
+        given()
+        .when()
+            .get("http://localhost:2000")
+        .then()
+            .statusCode(200);
+
+        traceInMdc.waitFor(5000);
+    }
+
+    @Test
+    void traceparentIsPropagatedToBackend() throws Exception {
+        var traceparent = new SubstringWaitableConsoleEvent(process, "traceparent: 00-");
+
+        given()
+        .when()
+            .get("http://localhost:2000")
+        .then()
+            .statusCode(200);
+
+        traceparent.waitFor(5000);
+    }
+}

--- a/distribution/src/test/java/com/predic8/membrane/tutorials/operation/OpenTelemetryTutorialTest.java
+++ b/distribution/src/test/java/com/predic8/membrane/tutorials/operation/OpenTelemetryTutorialTest.java
@@ -14,10 +14,18 @@
 
 package com.predic8.membrane.tutorials.operation;
 
+import com.predic8.membrane.examples.util.BufferLogger;
 import com.predic8.membrane.examples.util.SubstringWaitableConsoleEvent;
+import com.predic8.membrane.examples.withoutinternet.opentelemetry.Traceparent;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.util.List;
+
+import static com.predic8.membrane.examples.withoutinternet.opentelemetry.Traceparent.parse;
 import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Verifies tutorial step 40-OpenTelemetry.yaml: a three-hop chain
@@ -29,9 +37,17 @@ import static io.restassured.RestAssured.given;
  */
 public class OpenTelemetryTutorialTest extends AbstractOperationTutorialTest {
 
+    private BufferLogger logger;
+
     @Override
     protected String getTutorialYaml() {
         return "40-OpenTelemetry.yaml";
+    }
+
+    @BeforeEach
+    void startMembrane() throws IOException, InterruptedException {
+        logger = new BufferLogger();
+        process = startServiceProxyScript(logger);
     }
 
     @Test
@@ -58,7 +74,8 @@ public class OpenTelemetryTutorialTest extends AbstractOperationTutorialTest {
 
     @Test
     void traceparentIsPropagatedToBackend() throws Exception {
-        var traceparent = new SubstringWaitableConsoleEvent(process, "traceparent: 00-");
+        // Wait until at least one downstream hop logs a real traceparent.
+        var firstHopWithTraceparent = new SubstringWaitableConsoleEvent(process, "traceparent: 00-");
 
         given()
         .when()
@@ -66,6 +83,14 @@ public class OpenTelemetryTutorialTest extends AbstractOperationTutorialTest {
         .then()
             .statusCode(200);
 
-        traceparent.waitFor(5000);
+        firstHopWithTraceparent.waitFor(5000);
+
+        // Gateway logs "traceparent: null" (no incoming header from the test client),
+        // so parse() finds exactly the two downstream hops (Microservice A and B).
+        List<Traceparent> traceparents = parse(logger.toString());
+        assertTrue(traceparents.size() >= 2,
+            "Expected traceparent logged by at least 2 downstream hops, got: " + traceparents.size());
+        assertTrue(traceparents.get(0).sameTraceId(traceparents.get(1)),
+            "Trace ID must be identical across all hops — W3C traceparent propagation is broken");
     }
 }

--- a/distribution/tutorials/operation/40-OpenTelemetry.yaml
+++ b/distribution/tutorials/operation/40-OpenTelemetry.yaml
@@ -1,0 +1,93 @@
+# yaml-language-server: $schema=https://www.membrane-api.io/v7.2.4.json
+#
+# Tutorial: OpenTelemetry
+#
+# 1.) Start Jaeger (Docker required):
+#       docker run -d --name jaeger \
+#         -e COLLECTOR_OTLP_ENABLED=true \
+#         -p 16686:16686 \
+#         -p 4317:4317 \
+#         jaegertracing/all-in-one:latest
+#
+# 2.) Start Membrane:
+#       Linux/Mac:  ./membrane.sh -c 40-OpenTelemetry.yaml
+#       Windows:    membrane.cmd  -c 40-OpenTelemetry.yaml
+#
+# 3.) Send a few requests:
+#       curl http://localhost:2000
+#
+# 4.) Open http://localhost:16686, select 'Membrane' and click 'Find Traces'.
+
+global:
+  - openTelemetry:
+      sampleRate: 1.0
+      otlpExporter:
+        host: localhost
+        port: 4317
+        transport: grpc
+
+---
+api:
+  name: Gateway
+  port: 2000
+  flow:
+    - request:
+        - log:
+            message: "traceparent: ${header.traceparent}"
+  target:
+    url: http://localhost:2001
+
+---
+api:
+  name: Microservice A
+  port: 2001
+  flow:
+    - request:
+        - log:
+            message: "traceparent: ${header.traceparent}"
+  target:
+    url: http://localhost:2002
+
+---
+api:
+  name: Microservice B
+  port: 2002
+  flow:
+    - request:
+        - log:
+            message: "traceparent: ${header.traceparent}"
+    - static:
+        src: Greetings from the backend!
+    - return:
+        status: 200
+
+# ---------------------------------------------------------------------------
+# How it works
+# ---------------------------------------------------------------------------
+#
+# Each request travels through three APIs: Gateway → Microservice A → Microservice B.
+# The openTelemetry plugin (declared once in global:) runs on every hop and adds
+# a W3C traceparent header to the request before it is forwarded.
+#
+# The traceparent header has four fields separated by dashes:
+#
+#   00 - a3ce929d0e0e47368efb39bb0c10f469 - 674ad14c4ca87b49 - 01
+#   │    │                                   │                   └─ flags (01 = sampled)
+#   │    │                                   └─ parent-id: ID of the current span
+#   │    └─ trace-id: one ID shared by the entire request across all services
+#   └─ version (always 00)
+#
+# Look at the log output: the trace-id stays the same at every hop.
+# The parent-id changes, because each service adds its own span to the trace.
+# That is exactly what you see as the call chain in the Jaeger UI.
+#
+# The microservices can run on different computers. As long as each one has
+# the openTelemetry plugin configured, the trace will be stitched together
+# correctly in Jaeger from spans that originated on different machines.
+#
+# The trace-id and span-id are also written into the log context (MDC)
+# automatically, so every log line carries them without extra code:
+#
+#   INFO {api=Microservice B, spanId=674ad14c4ca87b49, traceId=a3ce929d...}
+#
+# Reference: https://www.membrane-api.io/docs/current/openTelemetry.html


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end OpenTelemetry tutorial demonstrating trace propagation across a gateway and backend services.
  * Included a complete OTLP-based tutorial configuration with full sampling for the example setup.
* **Documentation**
  * Expanded OpenTelemetry interceptor and OTLP exporter configuration documentation, including clearer YAML examples and attribute descriptions.
* **Bug Fixes**
  * Improved OTLP exporter handling for an empty `path` value (more reliable HTTP endpoint path resolution).
* **Tests**
  * Added tutorial tests to verify successful requests and confirm trace information in logs, including consistent `traceparent` hop behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->