### PR TITLE
Tutorial: Prometheus

### DIFF
--- a/distribution/src/test/java/com/predic8/membrane/tutorials/operation/GrafanaTutorialTest.java
+++ b/distribution/src/test/java/com/predic8/membrane/tutorials/operation/GrafanaTutorialTest.java
@@ -1,0 +1,50 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.tutorials.operation;
+
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+
+/**
+ * Verifies tutorial step 60-Grafana.yaml: the Membrane metrics endpoint is reachable
+ * so Prometheus (and in turn Grafana) can scrape it.
+ */
+public class GrafanaTutorialTest extends AbstractOperationTutorialTest {
+
+    @Override
+    protected String getTutorialYaml() {
+        return "60-Grafana.yaml";
+    }
+
+    @Test
+    void metricsEndpointReachableForScraping() {
+        // @formatter:off
+        given()
+        .when()
+            .get("http://localhost:2001")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("http://localhost:2000/metrics")
+        .then()
+            .statusCode(200)
+            .body(containsString("membrane_count"));
+        // @formatter:on
+    }
+}

--- a/distribution/src/test/java/com/predic8/membrane/tutorials/operation/PrometheusTutorialTest.java
+++ b/distribution/src/test/java/com/predic8/membrane/tutorials/operation/PrometheusTutorialTest.java
@@ -21,7 +21,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 
 /**
  * Verifies tutorial step 50-Prometheus.yaml: the prometheus plugin exposes
- * membrane_count metrics at /actuator/prometheus after traffic hits the backends.
+ * membrane_count metrics at /metrics after traffic hits the backends.
  */
 public class PrometheusTutorialTest extends AbstractOperationTutorialTest {
 

--- a/distribution/src/test/java/com/predic8/membrane/tutorials/operation/PrometheusTutorialTest.java
+++ b/distribution/src/test/java/com/predic8/membrane/tutorials/operation/PrometheusTutorialTest.java
@@ -1,0 +1,50 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.tutorials.operation;
+
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+
+/**
+ * Verifies tutorial step 50-Prometheus.yaml: the prometheus plugin exposes
+ * membrane_count metrics at /actuator/prometheus after traffic hits the backends.
+ */
+public class PrometheusTutorialTest extends AbstractOperationTutorialTest {
+
+    @Override
+    protected String getTutorialYaml() {
+        return "50-Prometheus.yaml";
+    }
+
+    @Test
+    void metricsEndpointReturnsPrometheusFormat() {
+        // @formatter:off
+        given()
+        .when()
+            .get("http://localhost:2001")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("http://localhost:2000/metrics")
+        .then()
+            .statusCode(200)
+            .body(containsString("membrane_count"));
+        // @formatter:on
+    }
+}

--- a/distribution/tutorials/operation/50-Prometheus.yaml
+++ b/distribution/tutorials/operation/50-Prometheus.yaml
@@ -23,8 +23,12 @@
 # 4.) To connect a real Prometheus server use the scrape config in
 #     prometheus/prometheus.yml.  With Docker:
 #       docker run -p 9090:9090 \
+#         --add-host=host.docker.internal:host-gateway \
 #         -v $(pwd)/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml \
 #         prom/prometheus
+#
+#     --add-host is required on Linux so host.docker.internal resolves to the host;
+#     on macOS and Windows it is provided automatically.
 #
 #     Open http://localhost:9090 and search for 'membrane_count'.
 

--- a/distribution/tutorials/operation/50-Prometheus.yaml
+++ b/distribution/tutorials/operation/50-Prometheus.yaml
@@ -1,0 +1,53 @@
+# yaml-language-server: $schema=https://www.membrane-api.io/v7.2.4.json
+#
+# Tutorial: Prometheus Metrics
+#
+# The prometheus plugin exposes all Membrane metrics in Prometheus format
+# at /metrics so any Prometheus server can scrape them.
+#
+# 1.) Start Membrane:
+#       Linux/Mac:  ./membrane.sh -c 50-Prometheus.yaml
+#       Windows:    membrane.cmd  -c 50-Prometheus.yaml
+#
+# 2.) Generate traffic on the two backend APIs:
+#       curl http://localhost:2001
+#       curl http://localhost:2002
+#
+# 3.) Scrape the metrics endpoint:
+#       curl http://localhost:2000/metrics | grep membrane_count
+#
+#     You should see one counter per API/status combination, e.g.:
+#       membrane_count{api="Backend A",method="GET",statusCode="200",...} 1.0
+#       membrane_count{api="Backend B",method="GET",statusCode="404",...} 1.0
+#
+# 4.) To connect a real Prometheus server use the scrape config in
+#     prometheus/prometheus.yml.  With Docker:
+#       docker run -p 9090:9090 \
+#         -v $(pwd)/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml \
+#         prom/prometheus
+#
+#     Open http://localhost:9090 and search for 'membrane_count'.
+
+api:
+  name: Metrics Endpoint for Scraping
+  port: 2000
+  path:
+    uri: /metrics
+  flow:
+    - prometheus: {}
+
+---
+api:
+  name: Backend A
+  port: 2001
+  flow:
+    - return:
+        status: 200
+
+---
+api:
+  name: Backend B
+  port: 2002
+  flow:
+    - return:
+        status: 404

--- a/distribution/tutorials/operation/60-Grafana.yaml
+++ b/distribution/tutorials/operation/60-Grafana.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://www.membrane-api.io/v7.2.4.json
+#
+# Tutorial: Grafana Dashboard for Membrane Metrics
+#
+# This tutorial extends the Prometheus tutorial. If you haven't done it yet,
+# start there: tutorials/operation/50-Prometheus.yaml
+#
+# 1.) Start Membrane:
+#       Linux/Mac:  ./membrane.sh -c 60-Grafana.yaml
+#       Windows:    membrane.cmd  -c 60-Grafana.yaml
+#
+# 2.) Start Prometheus and Grafana:
+#       docker compose -f grafana/docker-compose.yml up -d
+#
+# 3.) Generate traffic on the two backend APIs:
+#       curl http://localhost:2001
+#       curl http://localhost:2002
+#
+# 4.) Open Grafana at http://localhost:3000
+#     Log in with admin / admin
+#
+# 5.) Open the pre-provisioned dashboard:
+#     Dashboards → Membrane Minimal
+#
+#     You should see live panels for requests per minute, incoming traffic,
+#     status code distribution, and average response time.
+
+api:
+  name: Metrics Endpoint for Scraping
+  port: 2000
+  path:
+    uri: /metrics
+  flow:
+    - prometheus: {}
+
+---
+api:
+  name: Backend A
+  port: 2001
+  flow:
+    - return:
+        status: 200
+
+---
+api:
+  name: Backend B
+  port: 2002
+  flow:
+    - return:
+        status: 404

--- a/distribution/tutorials/operation/grafana/dashboards/membrane.json
+++ b/distribution/tutorials/operation/grafana/dashboards/membrane.json
@@ -1,0 +1,352 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 3,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "valueSize": 70
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "sum(rate(membrane_count{rule!=\"predic8_de_prometheus\"}[1m])) *60",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests per Minute",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 11,
+        "x": 4,
+        "y": 0
+      },
+      "id": 8,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "Bps"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "RdYlBu",
+          "steps": 128
+        },
+        "exemplars": {
+          "color": "red"
+        },
+        "filterValues": {
+          "le": 0
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "show": true,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "right",
+          "reverse": true,
+          "unit": "KBs"
+        }
+      },
+      "pluginVersion": "9.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(membrane_good_bytes_req_body[1m])) by (rule)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Incoming Traffic",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [],
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 0,
+        "y": 7
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "value"
+          ]
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by(code) (delta(membrane_count{rule!=\"predic8_de_prometheus\"}[$__interval])) > 0",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Status Codes",
+      "transformations": [],
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 11,
+        "x": 4,
+        "y": 7
+      },
+      "id": 4,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "ms"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "RdYlGn",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "show": true,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "right",
+          "reverse": true
+        }
+      },
+      "pluginVersion": "9.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "avg(rate(membrane_good_time{rule=~\".+\"}[1m])) by (rule)>0",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Average Response Time",
+      "type": "heatmap"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "filters": [],
+        "hide": 0,
+        "name": "Filters",
+        "skipUrlSync": false,
+        "type": "adhoc"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Membrane Minimal",
+  "uid": "cb6d4a5f3",
+  "version": 1,
+  "weekStart": ""
+}

--- a/distribution/tutorials/operation/grafana/docker-compose.yml
+++ b/distribution/tutorials/operation/grafana/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  prometheus:
+    image: prom/prometheus:v2.44.0
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+
+  grafana:
+    image: grafana/grafana:9.5.2
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    restart: unless-stopped
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - ./provisioning/datasources:/etc/grafana/provisioning/datasources
+      - ./provisioning/dashboards:/etc/grafana/provisioning/dashboards
+      - ./dashboards:/var/lib/grafana/dashboards

--- a/distribution/tutorials/operation/grafana/docker-compose.yml
+++ b/distribution/tutorials/operation/grafana/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     container_name: prometheus
     ports:
       - "9090:9090"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
 

--- a/distribution/tutorials/operation/grafana/prometheus/prometheus.yml
+++ b/distribution/tutorials/operation/grafana/prometheus/prometheus.yml
@@ -1,0 +1,8 @@
+scrape_configs:
+  - job_name: 'MembraneMetrics'
+    metrics_path: '/metrics'
+    scrape_interval: 3s
+    static_configs:
+      - targets: ['host.docker.internal:2000']
+        labels:
+          application: 'Membrane'

--- a/distribution/tutorials/operation/grafana/provisioning/dashboards/dashboards.yml
+++ b/distribution/tutorials/operation/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+providers:
+  - name: 'Membrane'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/distribution/tutorials/operation/grafana/provisioning/datasources/datasource.yml
+++ b/distribution/tutorials/operation/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/distribution/tutorials/operation/grafana/provisioning/datasources/datasource.yml
+++ b/distribution/tutorials/operation/grafana/provisioning/datasources/datasource.yml
@@ -2,6 +2,7 @@ apiVersion: 1
 datasources:
   - name: Prometheus
     type: prometheus
+    uid: PBFA97CFB590B2093
     access: proxy
     url: http://prometheus:9090
     isDefault: true

--- a/distribution/tutorials/operation/prometheus/prometheus.yml
+++ b/distribution/tutorials/operation/prometheus/prometheus.yml
@@ -1,0 +1,8 @@
+scrape_configs:
+  - job_name: 'MembraneMetrics'
+    metrics_path: '/metrics'
+    scrape_interval: 3s
+    static_configs:
+      - targets: ['host.docker.internal:2000']
+        labels:
+          application: 'Membrane'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Prometheus tutorial step with a `/metrics` scraping example and backend traffic to produce observable counters.
  * Added a Grafana tutorial step with Docker Compose setup, including Prometheus scraping and a pre-provisioned “Membrane Minimal” dashboard.
* **Tests**
  * Added integration tests verifying the metrics endpoint is reachable and returns Prometheus-formatted output including `membrane_count`.
* **Documentation**
  * Introduced tutorial YAMLs and Grafana/Prometheus configuration snippets to guide scraping and dashboard visualization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->