### PR TITLE
Enable debug logging for Maven deploy in GitHub Actions workflow

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -39,4 +39,5 @@ jobs:
             --batch-mode \
             -Pcentral \
             -DskipTests \
+            -X \
             deploy


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the Maven publishing workflow by enabling debug output during deployment, which can help diagnose release issues more easily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->