### PR TITLE
Maven central deploy gpg expires

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Check GPG key expiry
         run: |
           EXPIRY=$(gpg --list-secret-keys --keyid-format LONG \
-            | grep -oP '(?<=expires: )\S+' | head -1 || true)
+            | grep -oP '(?<=expires: )\d{4}-\d{2}-\d{2}' | head -1 || true)
           if [ -z "$EXPIRY" ]; then
             echo "GPG key has no expiry date set."
           else

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -39,4 +39,5 @@ jobs:
             --batch-mode \
             -Pcentral \
             -DskipTests \
+            -X \
             deploy

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -30,7 +30,7 @@ jobs:
           if [ -z "$EXPIRY" ]; then
             echo "GPG key has no expiry date set."
           else
-            EXPIRY_TS=$(date -d "$EXPIRY" +%s 2>/dev/null || date -j -f "%Y-%m-%d" "$EXPIRY" +%s)
+            EXPIRY_TS=$(date -d "$EXPIRY" +%s)
             NOW_TS=$(date +%s)
             if [ "$EXPIRY_TS" -lt "$NOW_TS" ]; then
               echo "ERROR: GPG key expired on $EXPIRY" >&2

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Check GPG key expiry
         run: |
           EXPIRY=$(gpg --list-secret-keys --keyid-format LONG \
-            | grep -oP '(?<=expires: )\S+' | head -1)
+            | grep -oP '(?<=expires: )\S+' | head -1 || true)
           if [ -z "$EXPIRY" ]; then
             echo "GPG key has no expiry date set."
           else

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -21,10 +21,25 @@ jobs:
       - id: install-secret-key
         name: Install gpg secret key
         run: |
-          # Install gpg secret key
           cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import
-          # Verify gpg secret key
           gpg --list-secret-keys --keyid-format LONG
+      - name: Check GPG key expiry
+        run: |
+          EXPIRY=$(gpg --list-secret-keys --keyid-format LONG \
+            | grep -oP '(?<=expires: )\S+' | head -1)
+          if [ -z "$EXPIRY" ]; then
+            echo "GPG key has no expiry date set."
+          else
+            EXPIRY_TS=$(date -d "$EXPIRY" +%s 2>/dev/null || date -j -f "%Y-%m-%d" "$EXPIRY" +%s)
+            NOW_TS=$(date +%s)
+            if [ "$EXPIRY_TS" -lt "$NOW_TS" ]; then
+              echo "ERROR: GPG key expired on $EXPIRY" >&2
+              exit 1
+            else
+              DAYS=$(( (EXPIRY_TS - NOW_TS) / 86400 ))
+              echo "GPG key valid. Expires: $EXPIRY (in $DAYS days)"
+            fi
+          fi
       - id: publish-to-central
         name: Publish to Central Repository
         env:
@@ -39,5 +54,4 @@ jobs:
             --batch-mode \
             -Pcentral \
             -DskipTests \
-            -X \
             deploy


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release publishing workflow with a GPG key expiry check.
  * The publish process now reports remaining key validity and fails early if the signing key has expired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->