### PR TITLE
Improve reference docs for setHeader, AbstractSetterInterceptor, AbstractLanguageInterceptor

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/lang/AbstractLanguageInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/lang/AbstractLanguageInterceptor.java
@@ -34,9 +34,9 @@ public abstract class AbstractLanguageInterceptor extends AbstractInterceptor im
     }
 
     /**
-     * @description the language of the 'test' condition
+     * @description Scripting language used to evaluate the value expression.
      * @default SpEL
-     * @example SpEL, groovy, jsonpath, xpath
+     * @example SpEL | groovy | jsonpath | xpath
      */
     @MCAttribute
     public void setLanguage(Language language) {
@@ -44,8 +44,7 @@ public abstract class AbstractLanguageInterceptor extends AbstractInterceptor im
     }
 
     /**
-     * XML Configuration e.g. declaration of XML namespaces for XPath expressions, ...
-     * @param xmlConfig
+     * @description XML namespace declarations for XPath expressions in the value.
      */
     @Override
     @MCChildElement(allowForeign = true,order = 10)

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/lang/AbstractSetterInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/lang/AbstractSetterInterceptor.java
@@ -85,6 +85,11 @@ public abstract class AbstractSetterInterceptor extends AbstractExchangeExpressi
 
     protected abstract void setValue(Exchange exchange, Flow flow, Object evaluatedValue);
 
+    /**
+     * @description When true, only sets the field if it is not already present in the message.
+     * @default false
+     * @example true
+     */
     @MCAttribute
     public void setIfAbsent(boolean ifAbsent) {
         this.ifAbsent = ifAbsent;
@@ -94,6 +99,10 @@ public abstract class AbstractSetterInterceptor extends AbstractExchangeExpressi
         return ifAbsent;
     }
 
+    /**
+     * @description Name of the header field or exchange property key to set.
+     * @example X-Powered-By
+     */
     @MCAttribute(attributeName = "name")
     public void setFieldName(String fieldName) {
         this.fieldName = fieldName;
@@ -103,6 +112,11 @@ public abstract class AbstractSetterInterceptor extends AbstractExchangeExpressi
         return fieldName;
     }
 
+    /**
+     * @description Value to assign, evaluated as a SpEL template expression by default.
+     * Use the <code>language</code> attribute to switch to Groovy, JsonPath, or XPath.
+     * @example ${method}
+     */
     @MCAttribute
     public void setValue(String value) {
         this.expression = value;
@@ -117,10 +131,10 @@ public abstract class AbstractSetterInterceptor extends AbstractExchangeExpressi
     }
 
     /**
-     * Sets whether errors during value evaluation should be ignored or throw an exception.
-     *
-     * @param failOnError If true, an exception is raised on error. If false, errors are ignored.
+     * @description When true, aborts the request with a Problem Details error response if expression evaluation fails.
+     * When false, logs the error and the request continues unchanged.
      * @default true
+     * @example false
      */
     @MCAttribute
     public void setFailOnError(boolean failOnError) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/lang/AbstractSetterInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/lang/AbstractSetterInterceptor.java
@@ -14,18 +14,20 @@
 
 package com.predic8.membrane.core.interceptor.lang;
 
-import com.predic8.membrane.annot.*;
-import com.predic8.membrane.core.exceptions.*;
-import com.predic8.membrane.core.exchange.*;
-import com.predic8.membrane.core.interceptor.*;
-import com.predic8.membrane.core.lang.*;
-import com.predic8.membrane.core.util.*;
-import org.slf4j.*;
+import com.predic8.membrane.annot.MCAttribute;
+import com.predic8.membrane.core.exceptions.ProblemDetails;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.interceptor.Outcome;
+import com.predic8.membrane.core.lang.ExchangeExpressionException;
+import com.predic8.membrane.core.util.ExceptionUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import static com.predic8.membrane.core.exceptions.ProblemDetails.*;
-import static com.predic8.membrane.core.interceptor.Interceptor.Flow.*;
-import static com.predic8.membrane.core.interceptor.Outcome.*;
+import static com.predic8.membrane.core.exceptions.ProblemDetails.internal;
+import static com.predic8.membrane.core.interceptor.Interceptor.Flow.REQUEST;
+import static com.predic8.membrane.core.interceptor.Interceptor.Flow.RESPONSE;
 import static com.predic8.membrane.core.interceptor.Outcome.ABORT;
+import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
 
 public abstract class AbstractSetterInterceptor extends AbstractExchangeExpressionInterceptor {
 
@@ -131,8 +133,8 @@ public abstract class AbstractSetterInterceptor extends AbstractExchangeExpressi
     }
 
     /**
-     * @description When true, aborts the request with a Problem Details error response if expression evaluation fails.
-     * When false, logs the error and the request continues unchanged.
+     * @description When true, aborts processing if expression evaluation fails.
+     * When false, logs the error and continues unchanged.
      * @default true
      * @example false
      */

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/lang/SetHeaderInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/lang/SetHeaderInterceptor.java
@@ -21,11 +21,25 @@ import com.predic8.membrane.core.lang.TemplateExchangeExpression;
 import static com.predic8.membrane.core.util.text.SerializationFunction.HEADERVALUE_SERIALIZATION;
 
 /**
- * @description Set HTTP header on the current message.
+ * @description Sets an HTTP header field on the current message to a constant string or a computed value.
+ * SpEL template expressions are supported by default; Groovy, JsonPath, and XPath are also available.
+ * See tutorials/getting-started/60-SetHeader.yaml.
+ * @topic 2. Enterprise Integration Patterns
  * @yaml
- * setHeader:
- *   name: X-Foo
- *   value: 42
+ * <pre><code>
+ * api:
+ *   port: 2000
+ *   flow:
+ *     - response:
+ *         - setHeader:
+ *             name: X-Powered-By
+ *             value: Membrane
+ *         - setHeader:
+ *             name: X-Method
+ *             value: ${method}
+ *     - return:
+ *         status: 200
+ * </code></pre>
  */
 @MCElement(name = "setHeader")
 public class SetHeaderInterceptor extends AbstractSetterInterceptor {


### PR DESCRIPTION
## Summary

- **`SetHeaderInterceptor`**: add `@topic`, rewrite `@description` (constant vs computed value, supported languages, tutorial link), fix `@yaml` to use the proper `api:`/`flow:` context and show both a static (`Membrane`) and a computed (`${method}`) example side by side
- **`AbstractSetterInterceptor`**: add `@description`/`@default`/`@example` to all four `@MCAttribute` setters (`name`, `value`, `ifAbsent`, `failOnError`); replace the `@param`-based Javadoc on `failOnError` that was silently dropped by the renderer
- **`AbstractLanguageInterceptor`**: fix `@description` on `setLanguage` (was a copy-paste from `<if>` that said "test condition"); replace `@param` comment on `setXmlConfig` with a proper `@description` tag (previously invisible to the renderer)

## Test plan

- [ ] `mvn -q -o -pl core compile` passes with no warnings (verified locally)
- [ ] Check generated `docs.yaml` via `MEMBRANE_GENERATE_DOC_DIR=/tmp/docs mvn -q -o -pl core compile` — all four attributes of `setHeader` should have non-empty descriptions
- [ ] Confirm the `@yaml` example matches the tutorial at `distribution/tutorials/getting-started/60-SetHeader.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved public API documentation for language configuration, setter-related options, and header-setting behavior.
  * Added clearer Javadoc descriptions, including updated default values and examples for expression languages and configurable properties.
  * Expanded header-setting semantics with a refreshed YAML example, and clarified how expression evaluation failures are handled (abort vs. log-and-continue).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->