### PR TITLE
fix: avoid NPE in YAML error report when parsing context is absent (#3041)

### DIFF
--- a/annot/src/main/java/com/predic8/membrane/annot/yaml/ConfigurationParsingException.java
+++ b/annot/src/main/java/com/predic8/membrane/annot/yaml/ConfigurationParsingException.java
@@ -50,8 +50,15 @@ public class ConfigurationParsingException extends RuntimeException {
 
     /**
      * Returns a complete formatted error report including highlighted YAML.
+     * <p>
+     * Many throw sites do not carry a {@link ParsingContext} (e.g. errors raised before the
+     * offending node is known). Without one there is nothing to highlight, so an empty report
+     * is returned rather than failing with a {@link NullPointerException} that would mask the
+     * actual error message.
      */
     public String getFormattedReport() throws JsonProcessingException {
+        if (parsingContext == null || parsingContext.getNode() == null)
+            return "";
         return renderErrorReport(this.parsingContext, sourceFile);
     }
 

--- a/annot/src/test/java/com/predic8/membrane/annot/yaml/ConfigurationParsingExceptionTest.java
+++ b/annot/src/test/java/com/predic8/membrane/annot/yaml/ConfigurationParsingExceptionTest.java
@@ -1,0 +1,41 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.annot.yaml;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ConfigurationParsingExceptionTest {
+
+    /**
+     * Many throw sites raise a {@link ConfigurationParsingException} without a
+     * {@link ParsingContext} (e.g. {@code SpelEvaluator}, {@code ObjectBinder}). Rendering the
+     * report must then return an empty string rather than throwing an NPE that would mask the
+     * real error message (see #3041).
+     */
+    @Test
+    void formattedReportWithoutParsingContextIsEmpty() {
+        var e = new ConfigurationParsingException("Invalid SpEL expression: boom");
+        assertEquals("", assertDoesNotThrow(e::getFormattedReport));
+    }
+
+    @Test
+    void formattedReportWithoutParsingContextIsEmptyForCauseConstructor() {
+        var e = new ConfigurationParsingException("Could not read file", new RuntimeException("io"), null);
+        assertEquals("", assertDoesNotThrow(e::getFormattedReport));
+    }
+}

--- a/core/src/main/java/com/predic8/membrane/core/cli/RouterCLI.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/RouterCLI.java
@@ -14,7 +14,6 @@
 
 package com.predic8.membrane.core.cli;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.predic8.membrane.annot.yaml.ConfigurationParsingException;
 import com.predic8.membrane.core.config.spring.TrackingFileSystemXmlApplicationContext;
 import com.predic8.membrane.core.exceptions.SpringConfigurationErrorHandler;
@@ -185,12 +184,16 @@ public class RouterCLI {
                 log.error("Fatal error: {}", errorMsg);
             }
         } catch (ConfigurationParsingException e) {
-            // Keep with one param to log otherwise first color code will be ignored!
+            // Render the highlighted YAML on a best-effort basis: a failure here must never
+            // mask the actual error message (see #3041).
+            String report = "";
             try {
-                log.error("{}", "%s%s%s\n%s".formatted(RED(), e.getMessage(), RESET(), e.getFormattedReport()));
-            } catch (JsonProcessingException ex) {
-                throw new RuntimeException(ex);
+                report = e.getFormattedReport();
+            } catch (Exception ex) {
+                log.debug("Could not render YAML error report.", ex);
             }
+            // Keep with one param to log otherwise first color code will be ignored!
+            log.error("{}", "%s%s%s\n%s".formatted(RED(), e.getMessage(), RESET(), report));
         } catch (ExitException ignored) {
             // do nothing
         } catch (Exception ex) {


### PR DESCRIPTION
## Problem

Fixes #3041.

`ConfigurationParsingException.getFormattedReport()` unconditionally called `LineYamlErrorRenderer.renderErrorReport(parsingContext, …)`, which dereferences the context on its first line (`pc.getNode()`). But many throw sites never set a `parsingContext` — they use the `(String)`, `(Throwable)`, or `(msg, cause, null)` constructors: `SpelEvaluator`, most of `ObjectBinder`, `CollectionBinder`, `ReferenceResolver`, and several `NodeValidationUtils` / `ScalarValueConverter` paths (the latter even passes `ctx == null ? null : …` explicitly).

When such an exception reached `RouterCLI.getRouter`, the NPE was thrown while building the `log.error(...)` arguments, and the surrounding `try` only caught `JsonProcessingException`. So the NPE escaped `main` and **replaced the real, useful error message with an opaque `NullPointerException`**:

```
Exception in thread "main" java.lang.NullPointerException: Cannot invoke
"com.predic8.membrane.annot.yaml.ParsingContext.getNode()" because "pc" is null
	at ...LineYamlErrorRenderer.renderErrorReport(LineYamlErrorRenderer.java:63)
	at ...ConfigurationParsingException.getFormattedReport(ConfigurationParsingException.java:55)
	at ...RouterCLI.getRouter(RouterCLI.java:197)
```

### Reproduction

Any context-less path, e.g. a malformed SpEL in `apis.yaml`:

```yaml
- api:
    port: "#{1 +}"
```

## Fix

- `getFormattedReport()` returns an empty report when there is no `parsingContext` (or node) to highlight, instead of throwing.
- `RouterCLI` now renders the highlighted YAML on a **best-effort** basis, so a rendering failure can never mask the actual error message. (Also removes the now-unused `JsonProcessingException` import.)

The highlighted-YAML output is unchanged whenever a context is present.

## Tests

- New `ConfigurationParsingExceptionTest`: a context-less exception yields an empty report and does not throw.
- Existing `YAMLParsingErrorTest` (10 tests, real-context rendering) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML error reporting so configuration failures no longer depend on report rendering succeeding.
  * When detailed context is unavailable, error reports now safely fall back to an empty message instead of failing.
  * Added coverage to confirm formatted reports remain empty and non-throwing when no parsing context is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->