### PR TITLE
HTTP/2: ignore unknown frame types instead of killing the connection

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/transport/http2/Http2Logic.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/http2/Http2Logic.java
@@ -149,9 +149,10 @@ public class Http2Logic {
                 handleFrame(frame.asGoaway());
                 break;
             case TYPE_PUSH_PROMISE:
+                throw new FatalConnectionException(ERROR_PROTOCOL_ERROR);
             default:
-                // TODO
-                throw new NotImplementedException("frame type " + frame.getType());
+                log.debug("ignoring frame of unknown type {}", frame.getType());
+                break;
         }
 
     }


### PR DESCRIPTION
## Problem

In `Http2Logic.handleFrame`, the `default` case (any frame type not explicitly handled) threw an uncaught `NotImplementedException`. RFC 9113 §4.1 requires implementations to **ignore and discard** frames of unknown type. As written, any peer sending an HTTP/2 extension frame — or GREASE-style probing — would tear down the connection without a GOAWAY.

`PUSH_PROMISE` (a defined type) was lumped into the same `default` branch, so it also failed with a `RuntimeException` rather than a proper protocol error.

## Fix

- **Unknown frame types** → discarded and logged at debug. This is safe because `Frame.read()` already consumes the full payload before dispatch, leaving the stream positioned at the next frame boundary.
- **`PUSH_PROMISE`** → now a `FatalConnectionException(ERROR_PROTOCOL_ERROR)` (RFC 9113 §6.6): a server must never receive it, and we never enable server push as a client.

## Notes

This is one of several robustness issues in the HTTP/2 server path; it's scoped intentionally narrow. Not addressed here (potential follow-ups): CONTINUATION-flood bounds, `MAX_CONCURRENT_STREAMS` enforcement / stream-map eviction, and GOAWAY handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP/2 connections now fail immediately with a protocol error when a push promise frame is received, improving standards compliance.
  * Unknown HTTP/2 frame types are now ignored with a debug message instead of interrupting normal processing, helping avoid unnecessary errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->