### PR TITLE
WSDL Validation: Resolution of embedded schemas, ns aware filter of soap elements…

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/AbstractXMLSchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/AbstractXMLSchemaValidator.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
+import org.w3c.dom.ls.LSResourceResolver;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
@@ -110,7 +111,9 @@ public abstract class AbstractXMLSchemaValidator extends AbstractMessageValidato
         } else {
             exceptions.add(new Exception(preliminaryError));
         }
+        // Reached only when the message matched none of the (possibly several) embedded schemas.
         var errorMsg = getErrorMsg(exceptions); // Errors als simple String
+        log.info("{} message did not validate against any schema of {}: {}", flow, location, errorMsg);
         if (failureHandler != null) {
             failureHandler.handleFailure(errorMsg, exc);
         }
@@ -123,7 +126,7 @@ public abstract class AbstractXMLSchemaValidator extends AbstractMessageValidato
 
     protected List<Validator> createValidators() {
         var sf = SchemaFactory.newInstance(XSD_NS);
-        sf.setResourceResolver(resolver.toLSResourceResolver());
+        sf.setResourceResolver(getResourceResolver());
         var validators = new ArrayList<Validator>();
         var schemas = getSchemas();
         for (int i = 0; i < schemas.size(); i++) {
@@ -132,6 +135,15 @@ public abstract class AbstractXMLSchemaValidator extends AbstractMessageValidato
             validators.add(createValidator(schema, sf));
         }
         return validators;
+    }
+
+    /**
+     * Resolver used while compiling the schemas. Subclasses may override to resolve references
+     * that the default location-based {@link ResolverMap} resolver cannot handle, e.g. a
+     * namespace-only {@code <xsd:import>} between two schemas embedded in the same WSDL.
+     */
+    protected LSResourceResolver getResourceResolver() {
+        return resolver.toLSResourceResolver();
     }
 
     private @NotNull Validator createValidator(Element schema, SchemaFactory sf) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/SOAPXMLFilter.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/SOAPXMLFilter.java
@@ -18,6 +18,14 @@ import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.XMLFilterImpl;
 
+import static com.predic8.membrane.annot.Constants.SOAP11_NS;
+import static com.predic8.membrane.annot.Constants.SOAP12_NS;
+
+/**
+ * Strips the SOAP envelope so that only the payload below {@code <soap:Body>} is passed on.
+ * The {@code Body} boundary is matched by namespace, not just local name: a domain element
+ * that happens to be named {@code Body} in another namespace is left untouched and forwarded.
+ */
 public class SOAPXMLFilter extends XMLFilterImpl {
 
 
@@ -27,11 +35,15 @@ public class SOAPXMLFilter extends XMLFilterImpl {
 		super(reader);
 	}
 
+	private static boolean isSoapBody(String uri, String localName) {
+		return localName.equals("Body") && (SOAP11_NS.equals(uri) || SOAP12_NS.equals(uri));
+	}
+
 	@Override
 	public void startElement(String uri, String localName, String qName,
 			Attributes atts) throws SAXException {
 
-		if (localName.equals("Body")) {
+		if (isSoapBody(uri, localName)) {
 			body = true;
 			return;
 		}
@@ -47,7 +59,7 @@ public class SOAPXMLFilter extends XMLFilterImpl {
 	public void endElement(String uri, String localName, String qName)
 			throws SAXException {
 
-		if (localName.equals("Body")) {
+		if (isSoapBody(uri, localName)) {
 			body = false;
 			return;
 		}

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/SchemaValidatorErrorHandler.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/SchemaValidatorErrorHandler.java
@@ -13,8 +13,10 @@
    limitations under the License. */
 package com.predic8.membrane.core.interceptor.schemavalidation;
 
-import org.slf4j.*;
-import org.xml.sax.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXParseException;
 
 public class SchemaValidatorErrorHandler implements ErrorHandler {
 
@@ -22,18 +24,19 @@ public class SchemaValidatorErrorHandler implements ErrorHandler {
 
 	private Exception exception;
 
+	// Errors are collected here and only reported by AbstractXMLSchemaValidator once the message
+	// has failed *all* embedded schemas. Logging here would emit spurious "Error:" lines for a
+	// perfectly valid message that simply matches a different embedded schema of the same WSDL.
 	public void error(SAXParseException e) {
 		exception = e;
-		log.info("Error: {}", e.getMessage());
 	}
 
 	public void fatalError(SAXParseException e) {
 		exception = e;
-		log.info("Fatal Error: {}", e.getMessage());
 	}
 
 	public void warning(SAXParseException e) {
-		log.info("Warning: {}", e.getMessage());
+		log.debug("Warning: {}", e.getMessage());
 	}
 
 	public Exception getException() {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidator.java
@@ -22,14 +22,18 @@ import com.predic8.membrane.core.multipart.XOPReconstitutor;
 import com.predic8.membrane.core.resolver.ResolverMap;
 import com.predic8.membrane.core.resolver.ResourceRetrievalException;
 import com.predic8.membrane.core.util.ConfigurationException;
+import com.predic8.membrane.core.util.LSInputImpl;
 import com.predic8.membrane.core.util.MessageUtil;
 import com.predic8.membrane.core.util.wsdl.parser.Definitions.SOAPVersion;
+import com.predic8.membrane.core.util.xml.XMLUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
+import org.w3c.dom.ls.LSResourceResolver;
 
 import javax.xml.namespace.QName;
 import javax.xml.transform.Source;
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +50,7 @@ import static com.predic8.membrane.core.util.SOAPUtil.FaultCode.Client;
 import static com.predic8.membrane.core.util.SOAPUtil.*;
 import static com.predic8.membrane.core.util.wsdl.parser.Definitions.SOAPVersion.SOAP_11;
 import static com.predic8.membrane.core.util.wsdl.parser.Definitions.SOAPVersion.SOAP_12;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class WSDLValidator extends AbstractXMLSchemaValidator {
 
@@ -156,6 +161,34 @@ public class WSDLValidator extends AbstractXMLSchemaValidator {
     @Override
     protected List<Element> getSchemas() {
         return definitions.getSchemaElements();
+    }
+
+    /**
+     * Each schema embedded in the WSDL is compiled into its own validator. A schema that
+     * references a type from another embedded schema via a namespace-only {@code <xsd:import>}
+     * (no {@code schemaLocation}) would otherwise fail to resolve, because the default
+     * location-based resolver has no systemId to work with. This resolver serves such imports
+     * from the WSDL's own embedded schemas, delegating everything else to the default resolver.
+     */
+    @Override
+    protected LSResourceResolver getResourceResolver() {
+        LSResourceResolver delegate = super.getResourceResolver();
+        return (type, namespaceURI, publicId, systemId, baseURI) -> {
+            if (systemId == null && namespaceURI != null) {
+                var embedded = definitions.getEmbeddedSchema(namespaceURI);
+                if (embedded.isPresent()) {
+                    try {
+                        String xsd = XMLUtil.xmlNode2String(embedded.get().getSchemaElement());
+                        return new LSInputImpl(publicId, location, new ByteArrayInputStream(xsd.getBytes(UTF_8)));
+                    } catch (Exception e) {
+                        throw new ConfigurationException(
+                                "Could not resolve embedded schema for namespace %s in WSDL at %s."
+                                        .formatted(namespaceURI, location), e);
+                    }
+                }
+            }
+            return delegate.resolveResource(type, namespaceURI, publicId, systemId, baseURI);
+        };
     }
 
     @Override

--- a/core/src/main/java/com/predic8/membrane/core/util/SOAPUtil.java
+++ b/core/src/main/java/com/predic8/membrane/core/util/SOAPUtil.java
@@ -14,23 +14,33 @@
 
 package com.predic8.membrane.core.util;
 
-import com.predic8.membrane.core.http.*;
-import com.predic8.membrane.core.multipart.*;
-import com.predic8.xml.beautifier.*;
-import org.slf4j.*;
-import org.w3c.dom.*;
+import com.predic8.membrane.core.http.Message;
+import com.predic8.membrane.core.http.ReadingBodyException;
+import com.predic8.membrane.core.http.Response;
+import com.predic8.membrane.core.multipart.XOPReconstitutor;
+import com.predic8.xml.beautifier.XMLInputFactoryFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
-import javax.xml.namespace.*;
-import javax.xml.parsers.*;
-import javax.xml.stream.*;
-import javax.xml.stream.events.*;
-import java.util.*;
+import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.StartElement;
+import javax.xml.stream.events.XMLEvent;
+import java.util.Map;
 
 import static com.predic8.membrane.annot.Constants.*;
-import static com.predic8.membrane.core.http.MimeType.*;
-import static com.predic8.membrane.core.http.Response.*;
-import static com.predic8.membrane.core.util.xml.XMLUtil.*;
-import static javax.xml.stream.XMLInputFactory.*;
+import static com.predic8.membrane.core.http.MimeType.TEXT_XML_UTF8;
+import static com.predic8.membrane.core.http.Response.ok;
+import static com.predic8.membrane.core.util.xml.XMLUtil.mapToXml;
+import static com.predic8.membrane.core.util.xml.XMLUtil.xmlNode2String;
+import static javax.xml.stream.XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES;
+import static javax.xml.stream.XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES;
 
 public class SOAPUtil {
 
@@ -168,9 +178,11 @@ public class SOAPUtil {
                     return NO_SOAP_RESULT;
             }
         } catch (Exception e) {
-            log.warn("Ignoring exception: ", e);
+            log.info("Error parsing SOAP message: {}", e.getMessage());
+            log.debug("Ignoring exception: ", e);
+            return NO_SOAP_RESULT;
         }
-        log.debug("No SOAP Element found.");
+        log.info("No SOAP Element found.");
         return NO_SOAP_RESULT;
     }
 

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/MultiSchemaValidationLoggingTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/MultiSchemaValidationLoggingTest.java
@@ -1,0 +1,98 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+package com.predic8.membrane.core.interceptor.schemavalidation;
+
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.http.Request;
+import com.predic8.membrane.core.resolver.ResolverMap;
+import com.predic8.membrane.test.TestAppender;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.predic8.membrane.core.http.MimeType.TEXT_XML;
+import static com.predic8.membrane.core.interceptor.Interceptor.Flow.REQUEST;
+import static com.predic8.membrane.core.interceptor.Outcome.ABORT;
+import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The WSDL embeds two schemas and the request element is declared in the SECOND one, so the first
+ * schema's validator is tried (and fails) before the matching one succeeds. These tests pin the
+ * logging contract: per-schema errors from the schema that did not match must NOT be logged for a
+ * message that validates against another schema; a genuine failure (no schema matches) must be
+ * logged once, with all collected errors.
+ */
+public class MultiSchemaValidationLoggingTest {
+
+    private static final String EMBEDDED_WSDL = "src/test/resources/ws/import/second-schema-match.wsdl";
+
+    private Logger root;
+    private TestAppender appender;
+
+    @BeforeEach
+    void attachAppender() {
+        root = (Logger) LogManager.getRootLogger();
+        appender = new TestAppender("MultiSchemaValidationLoggingTest");
+        appender.start();
+        root.addAppender(appender);
+    }
+
+    @AfterEach
+    void detachAppender() {
+        root.removeAppender(appender);
+        appender.stop();
+    }
+
+    @Test
+    void validMessageDoesNotLogErrorsFromNonMatchingSchemas() throws Exception {
+        var exc = requestExchange("""
+                <b:Req xmlns:b="http://example.com/b"><b:value>hello</b:value></b:Req>
+                """);
+
+        assertEquals(CONTINUE, validator().validateMessage(exc, REQUEST));
+        assertFalse(appender.contains("cvc-elt"), "non-matching schemas must not log: " + appender.getMessages());
+        assertFalse(appender.contains("did not validate"), appender.getMessages().toString());
+    }
+
+    @Test
+    void invalidMessageLogsConsolidatedErrorOnce() throws Exception {
+        var exc = requestExchange("""
+                <b:Req xmlns:b="http://example.com/b"/>
+                """);
+
+        assertEquals(ABORT, validator().validateMessage(exc, REQUEST));
+        assertTrue(appender.contains("did not validate against any schema"), appender.getMessages().toString());
+    }
+
+    private static WSDLValidator validator() {
+        var v = new WSDLValidator(new ResolverMap(), EMBEDDED_WSDL, "Svc", null, false);
+        v.init();
+        return v;
+    }
+
+    private static Exchange requestExchange(String payload) {
+        try {
+            return Request.post("/x").body("""
+                    <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+                        <s:Body>%s</s:Body>
+                    </s:Envelope>
+                    """.formatted(payload)).contentType(TEXT_XML).buildExchange();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/SOAPXMLFilterTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/SOAPXMLFilterTest.java
@@ -1,0 +1,79 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+package com.predic8.membrane.core.interceptor.schemavalidation;
+
+import com.predic8.membrane.core.util.MessageUtil;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamResult;
+import java.io.ByteArrayInputStream;
+import java.io.StringWriter;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SOAPXMLFilterTest {
+
+    /**
+     * The SOAP {@code <Body>} wrapper must be stripped, but a domain element that is itself
+     * named {@code Body} (in a non-SOAP namespace) must be preserved — otherwise schema
+     * validation of the extracted payload fails with cvc-complex-type.2.4.a.
+     */
+    @Test
+    void keepsDomainBodyElement() throws Exception {
+        String out = filterSoapBody("""
+                <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+                  <soapenv:Body>
+                    <req:Request xmlns:req="http://example.com/svc">
+                      <req:Body>
+                        <req:SearchCriteria>abc</req:SearchCriteria>
+                      </req:Body>
+                    </req:Request>
+                  </soapenv:Body>
+                </soapenv:Envelope>
+                """);
+
+        assertFalse(out.contains("Envelope"), out);
+        assertTrue(out.contains("Request"), out);
+        assertTrue(out.contains("Body"), out);          // the domain Body survived
+        assertTrue(out.contains("SearchCriteria"), out);
+    }
+
+    @Test
+    void keepsDomainBodyElementSoap12() throws Exception {
+        String out = filterSoapBody("""
+                <soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope">
+                  <soapenv:Body>
+                    <req:Request xmlns:req="http://example.com/svc">
+                      <req:Body><req:SearchCriteria>x</req:SearchCriteria></req:Body>
+                    </req:Request>
+                  </soapenv:Body>
+                </soapenv:Envelope>
+                """);
+
+        assertFalse(out.contains("Envelope"), out);
+        assertTrue(out.contains("Body"), out);
+        assertTrue(out.contains("SearchCriteria"), out);
+    }
+
+    private static String filterSoapBody(String soap) throws Exception {
+        Transformer t = TransformerFactory.newInstance().newTransformer();
+        StringWriter sw = new StringWriter();
+        t.transform(MessageUtil.getSOAPBody(new ByteArrayInputStream(soap.getBytes(UTF_8))), new StreamResult(sw));
+        return sw.toString();
+    }
+}

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/SOAPXMLFilterTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/SOAPXMLFilterTest.java
@@ -71,7 +71,9 @@ class SOAPXMLFilterTest {
     }
 
     private static String filterSoapBody(String soap) throws Exception {
-        Transformer t = TransformerFactory.newInstance().newTransformer();
+        TransformerFactory tf = TransformerFactory.newInstance();
+        tf.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        Transformer t = tf.newTransformer();
         StringWriter sw = new StringWriter();
         t.transform(MessageUtil.getSOAPBody(new ByteArrayInputStream(soap.getBytes(UTF_8))), new StreamResult(sw));
         return sw.toString();

--- a/core/src/test/java/com/predic8/membrane/core/ws/WSDLIncludeImportTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/ws/WSDLIncludeImportTest.java
@@ -14,17 +14,20 @@
 
 package com.predic8.membrane.core.ws;
 
-import com.predic8.membrane.core.interceptor.schemavalidation.*;
-import com.predic8.membrane.core.resolver.*;
-import com.predic8.membrane.core.util.wsdl.parser.*;
-import com.predic8.membrane.core.util.wsdl.parser.schema.*;
-import org.jetbrains.annotations.*;
-import org.junit.jupiter.api.*;
-import org.slf4j.*;
+import com.predic8.membrane.core.interceptor.schemavalidation.WSDLValidator;
+import com.predic8.membrane.core.resolver.ResolverMap;
+import com.predic8.membrane.core.util.wsdl.parser.Definitions;
+import com.predic8.membrane.core.util.wsdl.parser.WSDLElement;
+import com.predic8.membrane.core.util.wsdl.parser.schema.SchemaElement;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class WSDLIncludeImportTest {
 
@@ -104,6 +107,20 @@ public class WSDLIncludeImportTest {
                 "TestService",
                 (msg, exc) -> log.info("Validation failure: {}", msg), true);
         validator.init();
+    }
+
+    /**
+     * The service schema references types from two other embedded schemas via namespace-only
+     * {@code <xsd:import>} (no schemaLocation). Compiling that schema must resolve those types
+     * from the WSDL's own embedded schemas instead of failing with src-resolve.
+     */
+    @Test
+    void validatorResolvesCrossEmbeddedSchemaImports() {
+        var validator = new WSDLValidator(new ResolverMap(),
+                WSDLIncludeImportTest.class.getResource("/ws/import/embedded.wsdl").toString(),
+                "CustomerService",
+                (msg, exc) -> log.info("Validation failure: {}", msg), true);
+        assertDoesNotThrow(validator::init);
     }
 
     private static @NotNull List<String> getElementNames(List<SchemaElement> schemaElements) {

--- a/core/src/test/resources/ws/import/second-schema-match.wsdl
+++ b/core/src/test/resources/ws/import/second-schema-match.wsdl
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Synthetic fixture: the request element is declared in the SECOND embedded schema, so the
+     first schema's validator is tried (and fails) before the matching one succeeds. Used to pin
+     the logging behaviour of AbstractXMLSchemaValidator for multi-schema WSDLs. -->
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns:tns="http://example.com/b"
+             xmlns:xs="http://www.w3.org/2001/XMLSchema"
+             targetNamespace="http://example.com/b" name="SecondSchemaMatch">
+
+  <types>
+    <!-- Schema A: first embedded schema; does NOT declare the request element -->
+    <xs:schema targetNamespace="http://example.com/a" elementFormDefault="qualified">
+      <xs:element name="somethingElse" type="xs:string"/>
+    </xs:schema>
+
+    <!-- Schema B: second embedded schema; declares the request element -->
+    <xs:schema targetNamespace="http://example.com/b" elementFormDefault="qualified">
+      <xs:element name="Req">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="value" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+  </types>
+
+  <message name="ReqMsg">
+    <part name="p" element="tns:Req"/>
+  </message>
+
+  <portType name="PT">
+    <operation name="Op">
+      <input message="tns:ReqMsg"/>
+    </operation>
+  </portType>
+
+  <binding name="B" type="tns:PT">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="Op">
+      <soap:operation soapAction="op"/>
+      <input><soap:body use="literal"/></input>
+    </operation>
+  </binding>
+
+  <service name="Svc">
+    <port name="P" binding="tns:B">
+      <soap:address location="http://example.com/b"/>
+    </port>
+  </service>
+
+</definitions>

--- a/distribution/release-notes/7.3.1.md
+++ b/distribution/release-notes/7.3.1.md
@@ -1,0 +1,12 @@
+# 7.3.1
+
+7.3.1 is a maintenance release that fixes SOAP/WSDL schema validation for WSDLs whose payloads span multiple embedded schemas.
+
+## Improvements
+- SOAP/WSDL schema validation no longer logs spurious per-schema errors for a message that is valid against another schema embedded in the same WSDL; a genuine failure is now logged once with all collected errors [#TBD](https://github.com/membrane/api-gateway/pull/TBD)
+
+## Fixes
+- WSDL validation now resolves namespace-only `<xsd:import>` references between schemas embedded in the same WSDL, fixing a startup failure (`Cannot read schema … src-resolve: Cannot resolve the name …`) [#TBD](https://github.com/membrane/api-gateway/pull/TBD)
+- SOAP message validation now strips only the SOAP envelope's `<Body>`, preserving domain elements named `Body` in other namespaces that were previously dropped and caused false `cvc-complex-type` validation errors [#TBD](https://github.com/membrane/api-gateway/pull/TBD)
+
+**Full changelog:** [v7.3.0...v7.3.1](https://github.com/membrane/api-gateway/compare/v7.3.0...v7.3.1)


### PR DESCRIPTION
…, logging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved spurious schema-validation errors when a SOAP request matches one of multiple embedded schemas, with failure reported once only when none match.
  * Improved SOAP body extraction to match the `<Body>` element by SOAP namespace (preserving non-SOAP elements named `Body`).
  * Fixed embedded WSDL/XSD schema resolution, including namespace-only `<xsd:import>` across embedded schemas.
* **Improvements**
  * Validation logging is more structured and less noisy (collects errors and logs debug details only as needed).
* **Tests**
  * Added coverage for multi-schema logging behavior, SOAP body filtering, and cross-embedded schema import resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->