### PR TITLE
Tutorial: demonstrate dynamic XSLT parameters (date, UUID)

### DIFF
--- a/distribution/src/test/java/com/predic8/membrane/tutorials/xml/XsltParameterTutorialTest.java
+++ b/distribution/src/test/java/com/predic8/membrane/tutorials/xml/XsltParameterTutorialTest.java
@@ -22,6 +22,7 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.XML;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.matchesPattern;
 
 public class XsltParameterTutorialTest extends AbstractXmlTutorialTest {
     @Override
@@ -41,6 +42,9 @@ public class XsltParameterTutorialTest extends AbstractXmlTutorialTest {
             .statusCode(200)
             .contentType(XML)
             .body("books.@library", equalTo("predic8"))
+            // Dynamic, gateway-computed values XSLT 1.0 cannot produce itself
+            .body("books.@generated", matchesPattern("\\d{4}-\\d{2}-\\d{2}"))
+            .body("books.@requestId", matchesPattern("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"))
             .body("books.book.size()", greaterThan(0));
         // @formatter:on
     }

--- a/distribution/tutorials/xml/41-XSLT-Parameter.yaml
+++ b/distribution/tutorials/xml/41-XSLT-Parameter.yaml
@@ -2,12 +2,19 @@
 #
 # Tutorial: XSLT Parameter
 #
-# Exchange properties are passed to the stylesheet as XSLT parameters of the same name.
+# Exchange properties of type string are passed to the stylesheet as XSLT parameters of the same name.
+#
+# This is handy for values XSLT 1.0 cannot produce on its own: it has no
+# date/time function and no way to generate a unique id. The gateway computes them at
+# request time with SpEL and hands them to the stylesheet as parameters.
+#
+# Note the trailing .toString(): only String-valued properties are passed to XSLT, so the
+# expression must yield a String (a bare LocalDate/UUID object would be silently dropped).
 #
 # Try:
 #   curl -d @books.xml -H "Content-Type: text/xml" localhost:2000
 #
-#   <books library="predic8">
+#   <books library="predic8" generated="2026-07-11" requestId="1f3c...">
 #     ...
 #   </books>
 
@@ -16,8 +23,14 @@ api:
   flow:
     - request:
         - setProperty:
-            name: library
+            name: library         # a static value
             value: predic8
+        - setProperty:
+            name: generated       # the current date
+            value: ${T(java.time.LocalDate).now().toString()}
+        - setProperty:
+            name: requestId       # a fresh UUID
+            value: ${T(java.util.UUID).randomUUID().toString()}
         - transform:
             xslt: add-library.xsl
     - return:

--- a/distribution/tutorials/xml/add-library.xsl
+++ b/distribution/tutorials/xml/add-library.xsl
@@ -4,11 +4,13 @@
 
     <xsl:output method="xml" indent="yes"/>
 
-    <!-- Set from the "library" exchange property -->
+    <!-- Each param is set from the exchange property of the same name -->
     <xsl:param name="library"/>
+    <xsl:param name="generated"/>
+    <xsl:param name="requestId"/>
 
     <xsl:template match="/books">
-        <books library="{$library}">
+        <books library="{$library}" generated="{$generated}" requestId="{$requestId}">
             <xsl:copy-of select="book"/>
         </books>
     </xsl:template>


### PR DESCRIPTION
## What

Makes the XSLT Parameter tutorial (`distribution/tutorials/xml/41-XSLT-Parameter.yaml`) more practical. It previously only showed a **static** value (`library: predic8`), which doesn't motivate *why* passing exchange properties to a stylesheet is useful.

XSLT 1.0 has no date/time or UUID functions at all — you literally cannot produce the current date or a unique id inside a stylesheet. This PR adds two gateway-computed parameters alongside the static one, so the output shows a static value and two runtime values side by side:

- `generated` — current date, `${T(java.time.LocalDate).now().toString()}`
- `requestId` — fresh UUID, `${T(java.util.UUID).randomUUID().toString()}`

Response root becomes e.g. `<books library="predic8" generated="2026-07-11" requestId="1f3c...">`.

## Note on `.toString()`

Only **String-valued** exchange properties are passed to XSLT (`Exchange.getStringProperties()` filters to `instanceof String`). A bare `${T(java.time.LocalDate).now()}` would store a `LocalDate` object and be silently dropped, leaving the param empty. The trailing `.toString()` is therefore required, and this is called out in the tutorial header comment.

## Changes

- `41-XSLT-Parameter.yaml` — two extra `setProperty` steps + header comment explaining the motivation and the `.toString()` requirement.
- `add-library.xsl` — declares the `generated`/`requestId` params and emits them as attributes on `<books>`.
- `XsltParameterTutorialTest.java` — asserts the two new attributes match a date pattern and a UUID pattern (kept the existing `library` assertion).

## Verification

`XsltParameterTutorialTest` passes against the freshly built distribution (gateway boots the config, response carries all three well-formed attributes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the XML/XSLT tutorial to demonstrate passing multiple dynamically generated values into an XSLT transformation.
  * Updated the example output to include `generated` and `requestId` attributes alongside `library`.
  * Clarified that only string-valued exchange properties should be provided to XSLT, requiring conversion to strings.

* **Tests**
  * Strengthened assertions to verify `generated` matches a `YYYY-MM-DD` pattern and `requestId` matches a UUID-like hexadecimal format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->