### PR TITLE
fix: prevent request-less inflight exchange from leaking an NPE in LimitedMemoryExchangeStore

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/exchangestore/LimitedMemoryExchangeStore.java
+++ b/core/src/main/java/com/predic8/membrane/core/exchangestore/LimitedMemoryExchangeStore.java
@@ -208,12 +208,14 @@ public class LimitedMemoryExchangeStore extends AbstractExchangeStore {
 
 		for (AbstractExchange ex : inflight) {
 			// An inflight exchange whose request snapshot is not (yet) attached carries no usable data and
-			// would hand callers an exchange with a null request. Skip it rather than leak that NPE downstream.
-			if (ex.getRequest() == null)
+			// would hand callers an exchange with a null request. Read the request once so a concurrent
+			// reset between the guard and setRequest() can't slip a null through and leak that NPE downstream.
+			Request request = ex.getRequest();
+			if (request == null)
 				continue;
 			Exchange newEx = new Exchange(null);
 			newEx.setId(ex.getId());
-			newEx.setRequest(ex.getRequest());
+			newEx.setRequest(request);
 			newEx.setProxy(ex.getProxy());
 			newEx.setRemoteAddr(ex.getRemoteAddr());
 			newEx.setTime(ex.getTime());

--- a/core/src/main/java/com/predic8/membrane/core/exchangestore/LimitedMemoryExchangeStore.java
+++ b/core/src/main/java/com/predic8/membrane/core/exchangestore/LimitedMemoryExchangeStore.java
@@ -70,14 +70,22 @@ public class LimitedMemoryExchangeStore extends AbstractExchangeStore {
 			if (flow == REQUEST) {
 				AbstractExchange excCopy = snapInternal(exc, flow);
 
-				if (exc.getRequest() != null)
-					excCopy.setRequest(exc.getRequest().createSnapshot(() -> {
-						{
+				try {
+					if (exc.getRequest() != null)
+						excCopy.setRequest(exc.getRequest().createSnapshot(() -> {
 							currentSize.getAndAdd(- excCopy.resetHeapSizeEstimation() + excCopy.getHeapSizeEstimation());
 							log.debug("newSnap currentSize: " + currentSize);
 							modify();
-						}
-					}, bodyExceedingMaxSizeStrategy, maxBodySize));
+						}, bodyExceedingMaxSizeStrategy, maxBodySize));
+				} catch (Exception e) {
+					// Snapshotting the request failed after snapInternal() already enqueued the copy in
+					// 'inflight'. Drop it again so a half-initialised exchange with a null request can never
+					// surface in getAllExchangesAsList() (see the null-guard there) and contaminate later reads.
+					if (inflight.remove(excCopy))
+						currentSize.getAndAdd(- excCopy.getHeapSizeEstimation());
+					modify();
+					throw e;
+				}
 
 				exc.addExchangeViewerListener(new AbstractExchangeViewerListener() {
 					@Override
@@ -199,6 +207,10 @@ public class LimitedMemoryExchangeStore extends AbstractExchangeStore {
 		List<AbstractExchange> ret = new LinkedList<>();
 
 		for (AbstractExchange ex : inflight) {
+			// An inflight exchange whose request snapshot is not (yet) attached carries no usable data and
+			// would hand callers an exchange with a null request. Skip it rather than leak that NPE downstream.
+			if (ex.getRequest() == null)
+				continue;
 			Exchange newEx = new Exchange(null);
 			newEx.setId(ex.getId());
 			newEx.setRequest(ex.getRequest());

--- a/core/src/test/java/com/predic8/membrane/core/exchangestore/LimitedMemoryExchangeStoreTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/exchangestore/LimitedMemoryExchangeStoreTest.java
@@ -19,6 +19,8 @@ import com.predic8.membrane.core.http.*;
 import com.predic8.membrane.core.interceptor.Interceptor.*;
 import org.junit.jupiter.api.*;
 
+import java.util.*;
+
 import static com.predic8.membrane.core.http.Response.ok;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -52,6 +54,28 @@ public class LimitedMemoryExchangeStoreTest {
 		assertStore(0, "1");
 		assertStore(1, "2");
 
+	}
+
+	/**
+	 * Regression for the NPE in LimitedMemoryExchangeStoreIntegrationTest: an exchange can sit in the
+	 * 'inflight' queue before its request snapshot is attached (the brief window in newSnap(), or after a
+	 * failed request snapshot). getAllExchangesAsList() must skip such a request-less entry rather than
+	 * hand callers an exchange whose getRequest() is null.
+	 */
+	@Test
+	public void requestLessInflightExchangeIsSkipped() {
+		LimitedMemoryExchangeStore s = new LimitedMemoryExchangeStore();
+		s.setMaxSize(500000);
+
+		// snap() on the request flow enqueues a copy in 'inflight'; snapInternal() copies no request when the
+		// original has none, reproducing a request-less inflight entry deterministically.
+		s.snap(new Exchange(null), Flow.REQUEST);
+
+		List<AbstractExchange> all = s.getAllExchangesAsList();
+
+		assertTrue(all.stream().allMatch(e -> e.getRequest() != null),
+				"getAllExchangesAsList() must never return an exchange with a null request");
+		assertTrue(all.isEmpty(), "the request-less inflight ghost must be skipped");
 	}
 
 	private void assertStore(int pos, String value) {


### PR DESCRIPTION
## Problem

`LimitedMemoryExchangeStore.getAllExchangesAsList()` builds a view exchange for each `inflight` entry and copies its request **unconditionally**. In two situations that request is `null`:

- the brief window in `newSnap()` after `snapInternal()` has enqueued the copy in `inflight` but before the request snapshot is attached, and
- after a failed request snapshot leaves a half-initialised copy behind.

The returned exchange then hands callers a `null` `getRequest()`. Under load this surfaced as an **intermittent** NPE in `LimitedMemoryExchangeStoreIntegrationTest` at `getAllExchangesAsList().getFirst().getRequest()...`.

## Fix

- **`getAllExchangesAsList()`** — skip `inflight` entries whose request is `null` instead of leaking a request-less exchange downstream.
- **`newSnap()`** — if request snapshotting throws, remove the copy from `inflight` and correct `currentSize` before rethrowing, so no request-less ghost can persist (the pre-existing outer `catch` anticipated the failure but left the entry behind).

## Test

Adds `requestLessInflightExchangeIsSkipped`, a deterministic regression test that snaps a request-flow exchange with no request and asserts `getAllExchangesAsList()` skips it. Verified: it **fails without the guard** and **passes with it**.

The affected module's tests were run: the new unit test, `LimitedMemoryExchangeStoreTest`, `AbortExchangeTest` (the other `getAllExchangesAsList()` consumer), and the full `withoutinternet` integration suite (282 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented incomplete exchange requests from appearing in exchange listings by skipping inflight entries with missing request data.
  * Improved error handling for request snapshotting failures, ensuring inflight data is cleaned up and not left in a half-initialized state.
* **Tests**
  * Added a regression test to confirm request-less inflight exchanges are excluded from results and never returned with a null request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->