### PR TITLE
Allow `/api-docs` and related paths in `APIProxyKey.matchesPath` even when a custom path is configured.

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/APIProxyKey.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/APIProxyKey.java
@@ -25,6 +25,8 @@ import org.slf4j.*;
 import java.util.*;
 
 import static com.predic8.membrane.core.interceptor.Interceptor.Flow.*;
+import static com.predic8.membrane.core.openapi.serviceproxy.OpenAPIPublisherInterceptor.PATH;
+import static com.predic8.membrane.core.openapi.serviceproxy.OpenAPIPublisherInterceptor.PATH_UI;
 import static com.predic8.membrane.core.openapi.util.UriTemplateMatcher.matchTemplate;
 import static java.util.Optional.*;
 
@@ -62,8 +64,8 @@ public class APIProxyKey extends ServiceProxyKey {
             return;
 
         // Add basePaths of OpenAPIPublisherInterceptor to accept them also
-        basePaths.add(OpenAPIPublisherInterceptor.PATH);    // new path
-        basePaths.add(OpenAPIPublisherInterceptor.PATH_UI); // "
+        basePaths.add(PATH);    // new path
+        basePaths.add(PATH_UI); // "
         basePaths.add("/api-doc");                          // old to stay compatible
         basePaths.add("/api-doc/ui");                       // "
     }
@@ -133,6 +135,10 @@ public class APIProxyKey extends ServiceProxyKey {
 
     @Override
     public boolean matchesPath(String path) {
+        for (String basePath : basePaths) {
+            if (path.startsWith(basePath))
+                return true;
+        }
         try {
             matchTemplate(getPath(), path); // ignore result
             return true;

--- a/core/src/test/java/com/predic8/membrane/core/openapi/serviceproxy/APIProxyKeyComplexMatchTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/serviceproxy/APIProxyKeyComplexMatchTest.java
@@ -94,6 +94,17 @@ class APIProxyKeyComplexMatchTest {
         assertFalse(key.complexMatch(new Builder().get("/foobar").buildExchange()));
     }
 
+    @Test
+    @DisplayName("matchesPath allows /api-docs even when a path is configured")
+    void matchesPathAllowsApiDocsWhenPathIsConfigured() {
+        var key = new APIProxyKey("", "", 80, "/cities", "*", null, true);
+        assertTrue(key.matchesPath("/api-docs"));
+        assertTrue(key.matchesPath("/api-docs/ui"));
+        assertTrue(key.matchesPath("/api-doc"));
+        assertTrue(key.matchesPath("/api-doc/ui"));
+        assertFalse(key.matchesPath("/other"));
+    }
+
     private static Stream<Arguments> urls() {
         return Stream.of(
                 of("/api-docs",true),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API proxy path matching to reliably recognize configured paths and API documentation endpoints.
  * Prevented unrelated paths from being incorrectly matched.

* **Tests**
  * Added coverage for API documentation paths and unrelated path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->