### PR TITLE
Add OpenAPI tutorial: validating x-www-form-urlencoded messages

### DIFF
--- a/distribution/src/test/java/com/predic8/membrane/tutorials/openapi/AbstractOpenAPITutorialTest.java
+++ b/distribution/src/test/java/com/predic8/membrane/tutorials/openapi/AbstractOpenAPITutorialTest.java
@@ -1,0 +1,26 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.tutorials.openapi;
+
+import com.predic8.membrane.tutorials.AbstractMembraneTutorialTest;
+
+public abstract class AbstractOpenAPITutorialTest extends AbstractMembraneTutorialTest {
+
+    @Override
+    protected String getTutorialDir() {
+        return "openapi";
+    }
+
+}

--- a/distribution/src/test/java/com/predic8/membrane/tutorials/openapi/FormUrlEncodedTutorialTest.java
+++ b/distribution/src/test/java/com/predic8/membrane/tutorials/openapi/FormUrlEncodedTutorialTest.java
@@ -1,0 +1,56 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.tutorials.openapi;
+
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+
+public class FormUrlEncodedTutorialTest extends AbstractOpenAPITutorialTest {
+
+    @Override
+    protected String getTutorialYaml() {
+        return "50-Form-URL-Encoded.apis.yaml";
+    }
+
+    @Test
+    void validFormPostIsForwarded() {
+        // @formatter:off
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .body("product=Shoes&quantity=5")
+        .when()
+            .post("http://localhost:2000/orders")
+        .then()
+            .statusCode(200)
+            .body(containsString("accepted"));
+        // @formatter:on
+    }
+
+    @Test
+    void formWithNegativeQuantityIsRejected() {
+        // @formatter:off
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .body("product=Shoes&quantity=-5")
+        .when()
+            .post("http://localhost:2000/orders")
+        .then()
+            .statusCode(400)
+            .body(containsString("minimum"));
+        // @formatter:on
+    }
+}

--- a/distribution/tutorials/README.md
+++ b/distribution/tutorials/README.md
@@ -47,7 +47,7 @@ If you need to integrate legacy SOAP Web Services, this tutorial provides exampl
 
 ## [OpenAPI](openapi)
 
-Validate requests against an OpenAPI description - including `application/x-www-form-urlencoded` form posts - and learn the features added in OpenAPI 3.2, such as the QUERY method.
+Validate requests against an OpenAPI description and learn the features added in OpenAPI 3.2, such as the QUERY method.
 
 ---
 

--- a/distribution/tutorials/README.md
+++ b/distribution/tutorials/README.md
@@ -45,9 +45,9 @@ Issue signed JSON Web Tokens and protect an API by validating them. Covers the O
 If you need to integrate legacy SOAP Web Services, this tutorial provides examples and practical guidance.
 
 
-## [OpenAPI 3.2](openapi/v32)
+## [OpenAPI](openapi)
 
-Learn the features added in OpenAPI 3.2 - such as the QUERY method - and how Membrane validates requests against them.
+Validate requests against an OpenAPI description - including `application/x-www-form-urlencoded` form posts - and learn the features added in OpenAPI 3.2, such as the QUERY method.
 
 ---
 

--- a/distribution/tutorials/openapi/50-Form-URL-Encoded.apis.yaml
+++ b/distribution/tutorials/openapi/50-Form-URL-Encoded.apis.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://www.membrane-api.io/v7.3.1.json
+#
+# Tutorial: Validating application/x-www-form-urlencoded messages with OpenAPI
+#
+# HTML forms post their fields as application/x-www-form-urlencoded.
+# When the OpenAPI description declares that media type, Membrane can validate the form fields
+# against its schema.
+#
+# 1.) Start Membrane:
+#     ./membrane.sh -c 50-Form-URL-Encoded.apis.yaml
+#
+# 2.) Send a valid form post (curl uses application/x-www-form-urlencoded by default for -d):
+#     curl localhost:2000/orders -v -d 'product=Shoes&quantity=5'
+#
+#     The request passes to the backend.
+#
+# 3.) Order a negative quantity:
+#     curl localhost:2000/orders -v -d 'product=Shoes&quantity=-5'
+#
+#     Rejected with status 400: "quantity" is below the minimum of 1.
+
+api:
+  port: 2000
+  openapi:
+    - location: form-validation.oas.yaml
+      validateRequests: true
+
+---
+# Mock backend
+# Requests that pass validation are forwarded here.
+api:
+  port: 3000
+  path:
+    uri: /orders
+  flow:
+    - static:
+        contentType: application/json
+        src: '{ "status": "accepted" }'
+    - return:
+        status: 200

--- a/distribution/tutorials/openapi/README.md
+++ b/distribution/tutorials/openapi/README.md
@@ -1,0 +1,15 @@
+# Membrane API Gateway Tutorial - OpenAPI
+
+Learn how Membrane validates incoming requests against an OpenAPI description.
+
+This tutorial shows how Membrane validates `application/x-www-form-urlencoded` messages - the format
+HTML forms post - against the schema declared in an OpenAPI description: required fields, types and
+constraints, just like for JSON.
+
+To begin, open [50-Form-URL-Encoded.apis.yaml](50-Form-URL-Encoded.apis.yaml) and follow the
+instructions in the file.
+
+## More
+
+- [OpenAPI 3.2](v32) - the features added in OpenAPI 3.2 (the `QUERY` method, `itemSchema`,
+  `in: querystring`, `xml.nodeType`) and how Membrane validates requests against them.

--- a/distribution/tutorials/openapi/form-validation.oas.yaml
+++ b/distribution/tutorials/openapi/form-validation.oas.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.3
+info:
+  title: Form API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3000
+paths:
+  /orders:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required: [product]
+              properties:
+                product:
+                  type: string
+                quantity:
+                  type: integer
+                  minimum: 1
+      responses:
+        '200':
+          description: Order accepted

--- a/distribution/tutorials/openapi/membrane.cmd
+++ b/distribution/tutorials/openapi/membrane.cmd
@@ -1,0 +1,24 @@
+@echo off
+setlocal EnableExtensions
+
+set "SCRIPT_DIR=%~dp0"
+if "%SCRIPT_DIR:~-1%"=="\" set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
+
+set "dir=%SCRIPT_DIR%"
+
+:search_up
+if exist "%dir%\LICENSE.txt" if exist "%dir%\scripts\run-membrane.cmd" goto found
+for %%A in ("%dir%\..") do set "next=%%~fA"
+if /I "%next%"=="%dir%" goto notfound
+set "dir=%next%"
+goto search_up
+
+:found
+set "MEMBRANE_HOME=%dir%"
+set "MEMBRANE_CALLER_DIR=%SCRIPT_DIR%"
+call "%MEMBRANE_HOME%\scripts\run-membrane.cmd" %*
+exit /b %ERRORLEVEL%
+
+:notfound
+>&2 echo Could not locate Membrane root. Ensure directory structure is correct.
+exit /b 1

--- a/distribution/tutorials/openapi/membrane.sh
+++ b/distribution/tutorials/openapi/membrane.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Default: ./proxies.xml (next to this script); fallback -> $MEMBRANE_HOME/conf/proxies.xml
+# JAVA_OPTS: relative -D paths are auto-resolved against $MEMBRANE_HOME (absolute/URI unchanged).
+# Examples:
+#   export JAVA_OPTS='-Dlog4j.configurationFile=examples/logging/access/log4j2_access.xml'
+#   export JAVA_OPTS='-Dlog4j.configurationFile=/abs/path/log4j2.xml'
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+
+dir="$SCRIPT_DIR"
+while [ "$dir" != "/" ]; do
+  if [ -f "$dir/LICENSE.txt" ] && [ -f "$dir/scripts/run-membrane.sh" ]; then
+    export MEMBRANE_HOME="$dir"
+    export MEMBRANE_CALLER_DIR="$SCRIPT_DIR"
+    exec sh "$dir/scripts/run-membrane.sh" "$@"
+  fi
+  dir=$(dirname "$dir")
+done
+
+echo "Could not locate Membrane root. Ensure directory structure is correct." >&2
+exit 1


### PR DESCRIPTION
## What

A minimal, self-teaching tutorial under `distribution/tutorials/openapi/` demonstrating how Membrane validates `application/x-www-form-urlencoded` request bodies against an OpenAPI schema.

The tutorial walks through:
1. Starting Membrane with the config
2. A valid form post (`product=Shoes&quantity=5`) — forwarded to the backend
3. A negative quantity (`quantity=-5`) — rejected with `400` against the schema's `minimum`

## Files

- `50-Form-URL-Encoded.apis.yaml` — self-teaching step (front API with `validateRequests: true` + mock backend)
- `form-validation.oas.yaml` — minimal OpenAPI 3.0.3 spec declaring the form-encoded body
- `README.md` — intro linking to the step and onward to the existing `v32/` tutorial
- `membrane.sh` / `membrane.cmd` — launcher scripts
- `AbstractOpenAPITutorialTest` + `FormUrlEncodedTutorialTest` — auto-discovered integration test (valid post → 200, negative quantity → 400)
- `tutorials/README.md` — OpenAPI section retargeted to the `openapi` category

The `50-` prefix leaves room for more basic OpenAPI tutorials to be added later.

## Testing

Integration test passes against the built distribution: 2 tests, both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenAPI tutorial demonstrating request validation for `application/x-www-form-urlencoded` order submissions.
  * Enforces required `product` and a minimum `quantity` of 1.
  * Added runnable startup scripts for the tutorial (Windows and Unix-like systems).
* **Documentation**
  * Added a tutorial README and updated the OpenAPI section to point to the generic OpenAPI anchor.
* **Tests**
  * Added automated test coverage for valid requests and rejection of invalid form data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->