### PR TITLE
Extract GitLab website-pipeline trigger into its own workflow

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -18,6 +18,8 @@ jobs:
   build-release:
     if: github.event.pull_request.merged && startsWith(github.event.pull_request.title, 'Release ')
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.VERSION }}
     steps:
       - name: Get version
         id: get_version
@@ -99,19 +101,9 @@ jobs:
           artifacts: "core/target/classes/com/predic8/membrane/core/config/json/membrane.schema.json,distribution/target/membrane-api-gateway-${{ steps.get_version.outputs.VERSION }}.zip,distribution/target/membrane-api-gateway-${{ steps.get_version.outputs.VERSION }}.zip.asc"
           token: ${{ github.token }}
 
-      - name: Trigger website pipeline on GitLab
-        shell: bash
-        env:
-          GITLAB_TRIGGER_TOKEN: ${{ secrets.GITLAB_TRIGGER_TOKEN }}
-          VERSION: ${{ steps.get_version.outputs.VERSION }}
-        run: |
-          set -euo pipefail
-          curl --fail --silent --show-error \
-            --connect-timeout 10 \
-            --max-time 10 \
-            --request POST \
-            --form-string "token=${GITLAB_TRIGGER_TOKEN}" \
-            --form-string "ref=main" \
-            --form-string "variables[PIPELINE]=release" \
-            --form-string "variables[MEMBRANE_VERSION]=${VERSION}" \
-            "https://gitlab.predic8.de/api/v4/projects/94/trigger/pipeline"
+  trigger-website:
+    needs: build-release
+    uses: ./.github/workflows/trigger-website-pipeline.yml
+    with:
+      version: ${{ needs.build-release.outputs.version }}
+    secrets: inherit

--- a/.github/workflows/trigger-website-pipeline.yml
+++ b/.github/workflows/trigger-website-pipeline.yml
@@ -1,0 +1,38 @@
+name: Trigger Website Pipeline
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Membrane version to publish on the website (e.g. 7.1.0)"
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+    secrets:
+      GITLAB_TRIGGER_TOKEN:
+        required: true
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger website pipeline on GitLab
+        shell: bash
+        env:
+          GITLAB_TRIGGER_TOKEN: ${{ secrets.GITLAB_TRIGGER_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error \
+            --connect-timeout 10 \
+            --max-time 10 \
+            --request POST \
+            --form-string "token=${GITLAB_TRIGGER_TOKEN}" \
+            --form-string "ref=main" \
+            --form-string "variables[PIPELINE]=release" \
+            --form-string "variables[MEMBRANE_VERSION]=${VERSION}" \
+            "https://gitlab.predic8.de/api/v4/projects/94/trigger/pipeline"


### PR DESCRIPTION
## Context

`release-build.yml` ended with an inline **"Trigger website pipeline on GitLab"** step that `curl`s a GitLab pipeline trigger with the release version. Baked into the release job, it could only ever run as the tail of a full release build — there was no way to re-fire the website pipeline on its own (e.g. if the GitLab call failed, or to re-publish a given version).

## Change

- **New `.github/workflows/trigger-website-pipeline.yml`** — a reusable + manually-dispatchable workflow holding the GitLab trigger logic:
  - `workflow_dispatch` with a `version` input (the manual **Run workflow** form, styled like `update-docker-latest.yml`).
  - `workflow_call` with the same `version` input and a declared `GITLAB_TRIGGER_TOKEN` secret so callers can pass it.
  - The GitLab `curl` step is carried over verbatim, sourcing the version from `inputs.version`.
- **`release-build.yml`**
  - Removed the inline GitLab step.
  - Exposed `version` as a `build-release` job output (from the existing `get_version` step — derivation unchanged).
  - Added a `trigger-website` job that `needs: build-release`, calls the new workflow with the version, and forwards the secret via `secrets: inherit`.

No behavior change at release time: the GitLab pipeline still fires automatically at the end of a successful release, just via a called job instead of an inline step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation by automatically triggering the website release pipeline after a successful build.
  * Added support for manually starting a website pipeline with a specified release version.
  * Added clearer failure handling and timeouts for pipeline requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->