### PR TITLE
Add configurable PII masking for OpenAPI validation values

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/APIProxy.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/APIProxy.java
@@ -92,6 +92,8 @@ public class APIProxy extends ServiceProxy implements Polyglot, XMLSupport {
     public static final String RESPONSES = "responses";
     public static final String SECURITY = "security";
     public static final String VALIDATION_DETAILS = "details";
+    public static final String MASK_VALUES = "mask";
+    public static final String MASK_VALUES_LOG = "maskLog";
 
     private Language language = SPEL;
     private ExchangeExpression exchangeExpression;

--- a/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIInterceptor.java
@@ -132,9 +132,9 @@ public class OpenAPIInterceptor extends AbstractInterceptor {
             if (!errors.isEmpty()) {
                 log.info("OpenAPI request validation failed for {} {} against '{}': {}",
                         exc.getRequest().getMethod(), exc.getRequest().getUri(),
-                        rec.api.getInfo().getTitle(), errors);
+                        rec.api.getInfo().getTitle(), errors.toString(maskValues(rec.api, MASK_VALUES_LOG)));
                 apiProxy.statisticCollector.collect(errors);
-                createErrorResponse(exc, errors, ValidationErrors.Direction.REQUEST, validationDetails(rec.api));
+                createErrorResponse(exc, errors, ValidationErrors.Direction.REQUEST, validationDetails(rec.api), maskValues(rec.api, MASK_VALUES));
                 return RETURN;
             }
         } catch (OpenAPIParsingException e) {
@@ -188,10 +188,10 @@ public class OpenAPIInterceptor extends AbstractInterceptor {
             if (errors != null && errors.hasErrors()) {
                 log.info("OpenAPI response validation failed for {} {} against '{}': {}",
                         exc.getRequest().getMethod(), exc.getRequest().getUri(),
-                        rec.api.getInfo().getTitle(), errors);
+                        rec.api.getInfo().getTitle(), errors.toString(maskValues(rec.api, MASK_VALUES_LOG)));
                 exc.getResponse().setStatusCode(500); // A validation error in the response is a server error!
                 apiProxy.statisticCollector.collect(errors);
-                createErrorResponse(exc, errors, ValidationErrors.Direction.RESPONSE, validationDetails(rec.api));
+                createErrorResponse(exc, errors, ValidationErrors.Direction.RESPONSE, validationDetails(rec.api), maskValues(rec.api, MASK_VALUES));
                 return RETURN;
             }
         } catch (OpenAPIParsingException e) {
@@ -291,6 +291,14 @@ public class OpenAPIInterceptor extends AbstractInterceptor {
             return true;
 
         return validationDetails;
+    }
+
+    private static boolean maskValues(OpenAPI api, String key) {
+        if (api.getExtensions() == null)
+            return false;
+        @SuppressWarnings("unchecked")
+        Map<String, Object> xValidation = (Map<String, Object>) api.getExtensions().get(X_MEMBRANE_VALIDATION);
+        return xValidation != null && Boolean.TRUE.equals(xValidation.get(key));
     }
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
@@ -417,13 +425,13 @@ public class OpenAPIInterceptor extends AbstractInterceptor {
                 """.formatted(props.get("security"), props.get("requests"), props.get("responses"), props.get("details"));
     }
 
-    private void createErrorResponse(Exchange exc, ValidationErrors errors, ValidationErrors.Direction direction, boolean validationDetails) {
+    private void createErrorResponse(Exchange exc, ValidationErrors errors, ValidationErrors.Direction direction, boolean validationDetails, boolean maskValues) {
         user(router.getConfiguration().isProduction(), getDisplayName())
                 .title("OpenAPI message validation failed")
                 .addSubType("validation")
                 .status(errors.get(0).getContext().getStatusCode())
                 .flow(getFlowFromDirection(direction))
-                .topLevel("validation", getErrorMap(errors, direction, validationDetails))
+                .topLevel("validation", getErrorMap(errors, direction, validationDetails, maskValues))
                 .buildAndSetResponse(exc);
     }
 
@@ -434,9 +442,9 @@ public class OpenAPIInterceptor extends AbstractInterceptor {
         };
     }
 
-    private static Map<String, Object> getErrorMap(ValidationErrors errors, ValidationErrors.Direction direction, boolean validationDetails) {
+    private static Map<String, Object> getErrorMap(ValidationErrors errors, ValidationErrors.Direction direction, boolean validationDetails, boolean maskValues) {
         if (validationDetails) {
-            return errors.getErrorMessage(direction);
+            return errors.getErrorMessage(direction, maskValues);
         }
         Map<String, Object> m = new LinkedHashMap<>();
         m.put("error", "Message validation failed!");

--- a/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIRecordFactory.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIRecordFactory.java
@@ -41,6 +41,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static com.predic8.membrane.core.openapi.serviceproxy.APIProxy.*;
+import static com.predic8.membrane.core.openapi.serviceproxy.OpenAPISpec.MaskValues.*;
 import static com.predic8.membrane.core.openapi.serviceproxy.OpenAPISpec.YesNoOpenAPIOption.*;
 import static com.predic8.membrane.core.openapi.util.OpenAPIUtil.getIdFromAPI;
 import static com.predic8.membrane.core.openapi.util.OpenAPIUtil.isSwagger2;
@@ -289,6 +290,9 @@ public class OpenAPIRecordFactory {
 
         if (spec.validateSecurity != ASINOPENAPI)
             extension.put(SECURITY, toYesNo(spec.validateSecurity));
+
+        extension.put(MASK_VALUES, spec.maskValues == RESPONSE || spec.maskValues == BOTH);
+        extension.put(MASK_VALUES_LOG, spec.maskValues == LOG || spec.maskValues == BOTH);
 
         if (spec.validateSecurity == YES && spec.validateRequests == NO)
             log.warn("Automatically enabled request validation; which is required by security validation.");

--- a/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPISpec.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPISpec.java
@@ -66,6 +66,7 @@ public class OpenAPISpec implements Cloneable {
     public YesNoOpenAPIOption validateResponses = ASINOPENAPI;
     public YesNoOpenAPIOption validationDetails = ASINOPENAPI;
     public YesNoOpenAPIOption validateSecurity = ASINOPENAPI;
+    public MaskValues maskValues = MaskValues.NONE;
     private Rewrite rewrite = new Rewrite();
 
     @Override
@@ -170,6 +171,27 @@ public class OpenAPISpec implements Cloneable {
         return validationDetails;
     }
 
+    public MaskValues getMaskValues() {
+        return maskValues;
+    }
+
+    /**
+     * @description Where the actual submitted value is masked in validation error messages. A value
+     * that fails validation is replaced with <code>***</code> in the <code>message</code>
+     * (for example <code>*** is smaller than the minimum of 10</code>) so that potentially sensitive
+     * data is not echoed back. Constraint values from the OpenAPI document (such as the minimum) are
+     * never masked. Choose where masking applies: <code>none</code> (default), <code>response</code>
+     * (mask only in the HTTP response), <code>log</code> (mask only in the server log) or
+     * <code>both</code>. This lets you, for example, return <code>***</code> to the caller while
+     * keeping the real value in the log for debugging.
+     * @example response
+     * @default none
+     */
+    @MCAttribute
+    public void setMaskValues(MaskValues maskValues) {
+        this.maskValues = maskValues;
+    }
+
     @SuppressWarnings("unused")
     public YesNoOpenAPIOption getValidateSecurity() {
         return validateSecurity;
@@ -196,6 +218,13 @@ public class OpenAPISpec implements Cloneable {
         // To allow reading from YAML with yes and no without quotes
         TRUE,
         FALSE
+    }
+
+    public enum MaskValues {
+        NONE,
+        RESPONSE,
+        LOG,
+        BOTH
     }
 
     @Override

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/ArrayValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/ArrayValidator.java
@@ -24,6 +24,7 @@ import io.swagger.v3.oas.models.media.*;
 
 import java.util.*;
 
+import static com.predic8.membrane.core.openapi.validators.ValidationError.v;
 import static java.lang.String.*;
 
 
@@ -86,7 +87,7 @@ public class ArrayValidator implements JsonSchemaValidator {
             itemValues.add(node.get(i));
         }
         if (!moreThanOnce.isEmpty()) {
-            return ValidationErrors.error(ctx, format("Array with restriction uniqueItems contains non-unique values: %s.", Utils.joinByComma(moreThanOnce)));
+            return ValidationErrors.error(ctx, mask -> format("Array with restriction uniqueItems contains non-unique values: %s.", v(Utils.joinByComma(moreThanOnce), mask)));
         }
 
         return null;

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/BooleanValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/BooleanValidator.java
@@ -18,6 +18,7 @@ package com.predic8.membrane.core.openapi.validators;
 
 import com.fasterxml.jackson.databind.node.*;
 
+import static com.predic8.membrane.core.openapi.validators.ValidationError.v;
 import static java.util.Locale.*;
 
 public class BooleanValidator implements JsonSchemaValidator {
@@ -39,7 +40,7 @@ public class BooleanValidator implements JsonSchemaValidator {
         if (str.equals("true") || str.equals("false") || str.equals("yes") || str.equals("no"))
             return null;
 
-        return ValidationErrors.error(ctx.schemaType("boolean"), String.format("Value '%s' is not a boolean (true/false).", value));
+        return ValidationErrors.error(ctx.schemaType("boolean"), mask -> String.format("Value '%s' is not a boolean (true/false).", v(value, mask)));
     }
 
     private static String getStringValue(Object value) {

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/IntegerValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/IntegerValidator.java
@@ -21,6 +21,7 @@ import com.predic8.membrane.core.openapi.model.*;
 
 import java.math.*;
 
+import static com.predic8.membrane.core.openapi.validators.ValidationError.v;
 import static com.predic8.membrane.core.openapi.validators.ValidationErrors.error;
 
 public class IntegerValidator implements JsonSchemaValidator {
@@ -48,7 +49,7 @@ public class IntegerValidator implements JsonSchemaValidator {
         if (value instanceof JsonNode j) {
             return j.isIntegralNumber() ? null
                     : error(ctx.schemaType("integer"),
-                    String.format("%s is not an integer.", j.asText()));
+                    mask -> String.format("%s is not an integer.", v(j.asText(), mask)));
         }
         if (value instanceof String s) {
             try {
@@ -56,7 +57,7 @@ public class IntegerValidator implements JsonSchemaValidator {
                 return null;
             } catch (NumberFormatException e) {
                 return error(ctx.schemaType("integer"),
-                        String.format("%s is not an integer.", s));
+                        mask -> String.format("%s is not an integer.", v(s, mask)));
             }
         }
         if (value instanceof Body) {
@@ -67,7 +68,7 @@ public class IntegerValidator implements JsonSchemaValidator {
             return null;
         }
         if (value instanceof Number) {
-            return error(ctx.schemaType("integer"), "%s is not an integer.".formatted(value));
+            return error(ctx.schemaType("integer"), mask -> "%s is not an integer.".formatted(v(value, mask)));
         }
         if (value == null) {
             return error(ctx.schemaType("integer"), "null is not an integer.");

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/MaskableMessage.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/MaskableMessage.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2026 predic8 GmbH, www.predic8.com
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.predic8.membrane.core.openapi.validators;
+
+/**
+ * A validation message that is rendered lazily so submitted (potentially sensitive) values can be
+ * masked independently per output sink. The raw value is captured by the lambda and only turned
+ * into text when {@link #render(boolean)} is called - with {@code maskValues=true} it is replaced
+ * with {@link ValidationError#MASK}, otherwise it is shown in clear.
+ */
+@FunctionalInterface
+public interface MaskableMessage {
+    String render(boolean maskValues);
+}

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/NullValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/NullValidator.java
@@ -18,6 +18,8 @@ package com.predic8.membrane.core.openapi.validators;
 
 import com.fasterxml.jackson.databind.node.NullNode;
 
+import static com.predic8.membrane.core.openapi.validators.ValidationError.v;
+
 public class NullValidator implements JsonSchemaValidator {
 
     @Override
@@ -42,6 +44,6 @@ public class NullValidator implements JsonSchemaValidator {
         if (value instanceof NullNode) {
             return null;
         }
-        return ValidationErrors.error(ctx.schemaType(NULL), String.format("%s is not null.", value));
+        return ValidationErrors.error(ctx.schemaType(NULL), mask -> String.format("%s is not null.", v(value, mask)));
     }
 }

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/NumberRestrictionValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/NumberRestrictionValidator.java
@@ -22,6 +22,7 @@ import io.swagger.v3.oas.models.media.*;
 import java.math.*;
 
 import static com.predic8.membrane.core.openapi.util.Utils.*;
+import static com.predic8.membrane.core.openapi.validators.ValidationError.v;
 import static com.predic8.membrane.core.openapi.validators.ValidationErrors.*;
 import static java.lang.String.*;
 import static java.math.BigDecimal.*;
@@ -71,7 +72,7 @@ public class NumberRestrictionValidator {
         BigDecimal multiplesOf = schema.getMultipleOf();
         BigDecimal remainder = value.remainder(multiplesOf).stripTrailingZeros();
         if (remainder.compareTo(ZERO) != 0) {
-            return error(ctx, format("Value %s is not a multiple of %s.", value, multiplesOf));
+            return error(ctx, mask -> format("Value %s is not a multiple of %s.", v(value, mask), multiplesOf));
         }
 
         return null;
@@ -80,10 +81,10 @@ public class NumberRestrictionValidator {
     private ValidationErrors validateExclusiveMaximum(ValidationContext ctx, BigDecimal value) {
         if (schema.getExclusiveMaximumValue() != null) {
             if (schema.getExclusiveMaximumValue().compareTo(value) < 0) {
-                return error(ctx, value + " is greater than the maximum of " + schema.getExclusiveMaximumValue());
+                return error(ctx, mask -> v(value, mask) + " is greater than the maximum of " + schema.getExclusiveMaximumValue());
             }
             if (schema.getExclusiveMaximumValue().compareTo(value) == 0) {
-                return error(ctx, format("The value of %s should be less than the exclusive maximum %s.", value, schema.getExclusiveMaximumValue()));
+                return error(ctx, mask -> format("The value of %s should be less than the exclusive maximum %s.", v(value, mask), schema.getExclusiveMaximumValue()));
             }
         }
         return null;
@@ -92,10 +93,10 @@ public class NumberRestrictionValidator {
     private ValidationErrors validateMaximum(ValidationContext ctx, BigDecimal value) {
         if (schema.getMaximum() != null) {
             if (schema.getMaximum().compareTo(value) < 0) {
-                return error(ctx, value + " is greater than the maximum of " + schema.getMaximum());
+                return error(ctx, mask -> v(value, mask) + " is greater than the maximum of " + schema.getMaximum());
             }
             if (isExclusiveMaximum() && schema.getMaximum().compareTo(value) == 0) {
-                return error(ctx, format("The value of %s should be less than the exclusive maximum %s.", value, schema.getMaximum()));
+                return error(ctx, mask -> format("The value of %s should be less than the exclusive maximum %s.", v(value, mask), schema.getMaximum()));
             }
         }
         return null;
@@ -104,10 +105,10 @@ public class NumberRestrictionValidator {
     private ValidationErrors validateExclusiveMinimum(ValidationContext ctx, BigDecimal value) {
         if (schema.getExclusiveMinimumValue() != null) {
             if (schema.getExclusiveMinimumValue().compareTo(value) > 0) {
-                return error(ctx, value + " is smaller than the minimum of " + schema.getExclusiveMinimumValue());
+                return error(ctx, mask -> v(value, mask) + " is smaller than the minimum of " + schema.getExclusiveMinimumValue());
             }
             if (schema.getExclusiveMinimumValue().compareTo(value) == 0) {
-                return error(ctx, format("The value of %s should be greater than the exclusive minimum %s.", value, schema.getExclusiveMinimumValue()));
+                return error(ctx, mask -> format("The value of %s should be greater than the exclusive minimum %s.", v(value, mask), schema.getExclusiveMinimumValue()));
             }
         }
         return null;
@@ -116,10 +117,10 @@ public class NumberRestrictionValidator {
     private ValidationErrors validateMinimum(ValidationContext ctx, BigDecimal value) {
         if (schema.getMinimum() != null) {
             if (schema.getMinimum().compareTo(value) > 0) {
-                return error(ctx, value + " is smaller than the minimum of " + schema.getMinimum());
+                return error(ctx, mask -> v(value, mask) + " is smaller than the minimum of " + schema.getMinimum());
             }
             if (isExclusiveMinimum() && schema.getMinimum().compareTo(value) == 0) {
-                return error(ctx, format("The value of %s should be greater than the exclusive minimum %s.", value, schema.getMinimum()));
+                return error(ctx, mask -> format("The value of %s should be greater than the exclusive minimum %s.", v(value, mask), schema.getMinimum()));
             }
         }
         return null;

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/NumberValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/NumberValidator.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.databind.node.*;
 
 import java.math.*;
 
+import static com.predic8.membrane.core.openapi.validators.ValidationError.v;
+
 /**
  * When numbers appear in parameters, they enter as Strings (which is OK).
  * <p>
@@ -60,7 +62,7 @@ public class NumberValidator implements JsonSchemaValidator {
         }
         try {
             if (value instanceof TextNode) {
-                return ValidationErrors.error(ctx.schemaType(NUMBER), String.format("%s is not a number.", value));
+                return ValidationErrors.error(ctx.schemaType(NUMBER), mask -> String.format("%s is not a number.", v(value, mask)));
             }
             if (value instanceof JsonNode jn) {
                 // Not using double prevents from losing fractions
@@ -72,7 +74,7 @@ public class NumberValidator implements JsonSchemaValidator {
                 return null;
             }
         } catch (NumberFormatException ignored) {
-            return ValidationErrors.error(ctx.schemaType(NUMBER), String.format("%s is not a number.", value));
+            return ValidationErrors.error(ctx.schemaType(NUMBER), mask -> String.format("%s is not a number.", v(value, mask)));
         }
         throw new RuntimeException("Should never happen!");
     }

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/ObjectValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/ObjectValidator.java
@@ -28,6 +28,7 @@ import java.util.*;
 import java.util.regex.*;
 
 import static com.predic8.membrane.core.openapi.util.Utils.*;
+import static com.predic8.membrane.core.openapi.validators.ValidationError.v;
 import static com.predic8.membrane.core.openapi.validators.ValidationErrors.error;
 import static java.lang.String.*;
 import static java.util.Collections.*;
@@ -67,7 +68,7 @@ public class ObjectValidator implements JsonSchemaValidator {
         ctx = ctx.schemaType("object");
 
         if (canValidate(obj) == null || !(obj instanceof ObjectNode node)) {
-            return error(ctx.statusCode(400), format("Value %s is not an object.", obj));
+            return error(ctx.statusCode(400), mask -> format("Value %s is not an object.", v(obj, mask)));
         }
 
         ValidationErrors errors = validateRequiredProperties(ctx, node);
@@ -97,7 +98,8 @@ public class ObjectValidator implements JsonSchemaValidator {
 
         Schema<?> baseSchema = getBaseSchema(propertyValue);
         if (baseSchema == null) {
-            return error(ctx.statusCode(400), format("Discriminator value %s is not a valid type.", propertyValue));
+            String value = propertyValue;
+            return error(ctx.statusCode(400), mask -> format("Discriminator value %s is not a valid type.", v(value, mask)));
         }
         return new SchemaValidator(api, baseSchema).validate(ctx, node);
     }
@@ -311,7 +313,7 @@ public class ObjectValidator implements JsonSchemaValidator {
         if (node.get(propertyName) == null)
             return null;
 
-        return error(ctx.addJSONpointerSegment(propertyName), String.format("The property %s is read only. But the request contains the value %s for this field.", propertyName, node.get(propertyName)));
+        return error(ctx.addJSONpointerSegment(propertyName), mask -> String.format("The property %s is read only. But the request contains the value %s for this field.", propertyName, v(node.get(propertyName), mask)));
     }
 
     @SuppressWarnings("rawtypes")
@@ -326,7 +328,7 @@ public class ObjectValidator implements JsonSchemaValidator {
         if (node.get(propertyName) == null)
             return null;
 
-        return error(ctx.addJSONpointerSegment(propertyName), String.format("The property %s is write only. But the response contained the value %s.", propertyName, node.get(propertyName)));
+        return error(ctx.addJSONpointerSegment(propertyName), mask -> String.format("The property %s is write only. But the response contained the value %s.", propertyName, v(node.get(propertyName), mask)));
     }
 
     @SuppressWarnings("rawtypes")

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/SchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/SchemaValidator.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static com.predic8.membrane.core.openapi.util.SchemaUtil.getSchemaNameFromRef;
+import static com.predic8.membrane.core.openapi.validators.ValidationError.v;
 import static com.predic8.membrane.core.openapi.validators.ValidationContext.ValidatedEntityType.BODY;
 import static com.predic8.membrane.core.openapi.validators.ValidationContext.ValidatedEntityType.QUERY_PARAMETER;
 
@@ -224,7 +225,7 @@ public class SchemaValidator implements JsonSchemaValidator {
             }
         }
 
-        return ValidationErrors.error(ctx, "%s is of type %s which does not match any of %s".formatted(value, typeOfValue, types));
+        return ValidationErrors.error(ctx, mask -> "%s is of type %s which does not match any of %s".formatted(v(value, mask), typeOfValue, types));
     }
 
     /**
@@ -266,7 +267,7 @@ public class SchemaValidator implements JsonSchemaValidator {
                 default -> throw new RuntimeException("Should not happen! " + type);
             };
         } catch (Exception e) {
-            return ValidationErrors.error(ctx, "%s is not of %s format.".formatted(value, type));
+            return ValidationErrors.error(ctx, mask -> "%s is not of %s format.".formatted(v(value, mask), type));
         }
     }
 

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/StringRestrictionValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/StringRestrictionValidator.java
@@ -23,6 +23,7 @@ import org.slf4j.*;
 import java.util.regex.*;
 
 import static com.predic8.membrane.core.openapi.validators.JsonSchemaValidator.*;
+import static com.predic8.membrane.core.openapi.validators.ValidationError.v;
 import static java.lang.String.*;
 
 public class StringRestrictionValidator {
@@ -71,24 +72,24 @@ public class StringRestrictionValidator {
         }
 
         if (isMaxlenExceeded(str)) {
-            err.add(new ValidationError(ctx.schemaType(STRING), format("The string '%s' is %d characters long. MaxLength of %d is exceeded.", str, str.length(), schema.getMaxLength())));
+            err.add(new ValidationError(ctx.schemaType(STRING), mask -> format("The string '%s' is %d characters long. MaxLength of %d is exceeded.", v(str, mask), str.length(), schema.getMaxLength())));
         }
         if (isMinLenExceeded(str)) {
-            err.add(new ValidationError(ctx.schemaType(STRING), format("The string '%s' is %d characters long. The length of the string is shorter than the minLength of %d.", str, str.length(), schema.getMinLength())));
+            err.add(new ValidationError(ctx.schemaType(STRING), mask -> format("The string '%s' is %d characters long. The length of the string is shorter than the minLength of %d.", v(str, mask), str.length(), schema.getMinLength())));
         }
         if (isPatternViolated(str)) {
             err.add(new ValidationError(
                     ctx.schemaType(STRING),
-                    format("The string '%s' does not match the pattern %s.", str, schema.getPattern())
+                    mask -> format("The string '%s' does not match the pattern %s.", v(str, mask), schema.getPattern())
             ));
         }
         if (isEnumViolated(str)) {
             err.add(new ValidationError(ctx.schemaType(STRING),
-                    format("'%s' is not part of the enum %s.", str, schema.getEnum())));
+                    mask -> format("'%s' is not part of the enum %s.", v(str, mask), schema.getEnum())));
         }
         if (isConstViolated(str)) {
             err.add(new ValidationError(ctx.schemaType(STRING),
-                    format("The string '%s' must be equal to the constant value '%s'.", str, schema.getConst())));
+                    mask -> format("The string '%s' must be equal to the constant value '%s'.", v(str, mask), schema.getConst())));
         }
         return err;
     }

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/StringValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/StringValidator.java
@@ -25,6 +25,7 @@ import java.util.regex.*;
 
 import static com.predic8.membrane.core.openapi.util.Utils.*;
 import static com.predic8.membrane.core.openapi.validators.ValidationContext.ValidatedEntityType.*;
+import static com.predic8.membrane.core.openapi.validators.ValidationError.v;
 import static java.lang.String.*;
 
 @SuppressWarnings("rawtypes")
@@ -67,7 +68,7 @@ public class StringValidator implements JsonSchemaValidator {
             } else if (QUERY_PARAMETER.equals(ctx.getValidatedEntityType())) {
                 value = node.asText();
             } else {
-                errors.add(ctx, format("String expected but got %s of type %s", node, node.getNodeType()));
+                errors.add(ctx, mask -> format("String expected but got %s of type %s", v(node, mask), node.getNodeType()));
                 return errors;
             }
         } else if (obj instanceof String s) {
@@ -89,107 +90,107 @@ public class StringValidator implements JsonSchemaValidator {
         switch (schema.getFormat()) {
             case "uuid": {
                 if (!isValidUUID(value))
-                    return ValidationErrors.error(ctx, format("The string '%s' is not a valid UUID.", value));
+                    return ValidationErrors.error(ctx, mask -> format("The string '%s' is not a valid UUID.", v(value, mask)));
                 break;
             }
             case "email": {
                 if (!isValidEMail(value))
-                    return ValidationErrors.error(ctx, format("The string '%s' is not a valid E-Mail.", value));
+                    return ValidationErrors.error(ctx, mask -> format("The string '%s' is not a valid E-Mail.", v(value, mask)));
                 break;
             }
             case "uri": {
                 if (!isValidUri(value))
-                    return ValidationErrors.error(ctx, format("The string '%s' is not a valid URI.", value));
+                    return ValidationErrors.error(ctx, mask -> format("The string '%s' is not a valid URI.", v(value, mask)));
                 break;
             }
             case "date": {
                 if (!isValidDate(value))
-                    return ValidationErrors.error(ctx, format("The string '%s' is not a valid date of the pattern YYYY-MM-DD.", value));
+                    return ValidationErrors.error(ctx, mask -> format("The string '%s' is not a valid date of the pattern YYYY-MM-DD.", v(value, mask)));
                 break;
             }
             case "date-time": {
                 if (!isValidDateTime(value))
-                    return ValidationErrors.error(ctx, format("The string '%s' is not a valid date-time according to ISO 8601.", value));
+                    return ValidationErrors.error(ctx, mask -> format("The string '%s' is not a valid date-time according to ISO 8601.", v(value, mask)));
                 break;
             }
             case "duration": {
                 if (!isValidDuration(value))
-                    return ValidationErrors.error(ctx, format("The string '%s' is not a valid duration.", value));
+                    return ValidationErrors.error(ctx, mask -> format("The string '%s' is not a valid duration.", v(value, mask)));
                 break;
             }
             case "ip", "ipv4": {
                 if (!isValidIp(value))
-                    return ValidationErrors.error(ctx, format("The string '%s' is not a valid IPv4 address.", value));
+                    return ValidationErrors.error(ctx, mask -> format("The string '%s' is not a valid IPv4 address.", v(value, mask)));
                 break;
             }
             case "ipv6": {
                 if (!isValidIpV6(value))
-                    return ValidationErrors.error(ctx, format("The string '%s' is not a valid IPv6 address.", value));
+                    return ValidationErrors.error(ctx, mask -> format("The string '%s' is not a valid IPv6 address.", v(value, mask)));
                 break;
             }
             case "idn-email": {
                 if (!isValidEMail(value))
-                    return ValidationErrors.error(ctx, format("The string '%s' is not a valid E-Mail address.", value));
+                    return ValidationErrors.error(ctx, mask -> format("The string '%s' is not a valid E-Mail address.", v(value, mask)));
                 break;
             }
             case "uri-reference": {
                 if (!isValidUri(value))
-                    return ValidationErrors.error(ctx, format("The string '%s' is not a valid URI reference.", value));
+                    return ValidationErrors.error(ctx, mask -> format("The string '%s' is not a valid URI reference.", v(value, mask)));
                 break;
             }
             case "iri": {
                 if (!isValidUri(value))
-                    return ValidationErrors.error(ctx, format("The string '%s' is not a valid IRI.", value));
+                    return ValidationErrors.error(ctx, mask -> format("The string '%s' is not a valid IRI.", v(value, mask)));
                 break;
             }
             case "iri-reference": {
                 if (!isValidUri(value))
-                    return ValidationErrors.error(ctx, format("The string '%s' is not a valid IRI reference.", value));
+                    return ValidationErrors.error(ctx, mask -> format("The string '%s' is not a valid IRI reference.", v(value, mask)));
                 break;
             }
             case "hostname", "idn-hostname": {
                 if (!isValidHostname(value))
-                    return ValidationErrors.error(ctx, format("The string '%s' is not a valid hostname.", value));
+                    return ValidationErrors.error(ctx, mask -> format("The string '%s' is not a valid hostname.", v(value, mask)));
                 break;
             }
             case "json-pointer": {
                 if (!isValidJsonPointer(value))
-                    return ValidationErrors.error(ctx, format("The string '%s' is not a valid JSON pointer.", value));
+                    return ValidationErrors.error(ctx, mask -> format("The string '%s' is not a valid JSON pointer.", v(value, mask)));
                 break;
             }
             case "relative-json-pointer": {
                 if (!isValidRelativeJsonPointer(value))
-                    return ValidationErrors.error(ctx, format("The string '%s' is not a valid relative JSON pointer.", value));
+                    return ValidationErrors.error(ctx, mask -> format("The string '%s' is not a valid relative JSON pointer.", v(value, mask)));
                 break;
             }
             case "gtin-13": {
                 if (!isValidGlobalTradeItemNumber(value))
-                    return ValidationErrors.error(ctx, format("The string '%s' is not a valid GTIN-13 number.", value));
+                    return ValidationErrors.error(ctx, mask -> format("The string '%s' is not a valid GTIN-13 number.", v(value, mask)));
                 break;
             }
             case "iso-3166-alpha-2": {
                 if (!isValidIso3166Alpha2(value))
-                    return ValidationErrors.error(ctx, format("The string '%s' is not a valid ISO-3166-1-alpha-2 number.", value));
+                    return ValidationErrors.error(ctx, mask -> format("The string '%s' is not a valid ISO-3166-1-alpha-2 number.", v(value, mask)));
                 break;
             }
             case "iso-4217": {
                 if (!isValidIso4217(value))
-                    return ValidationErrors.error(ctx, format("The string '%s' is not a valid currency code according to ISO 4217.", value));
+                    return ValidationErrors.error(ctx, mask -> format("The string '%s' is not a valid currency code according to ISO 4217.", v(value, mask)));
                 break;
             }
             case "bcp47": {
                 if (!isValidBCP47(value))
-                    return ValidationErrors.error(ctx, format("The string '%s' is not a valid multi letter language tag according to BCP47.", value));
+                    return ValidationErrors.error(ctx, mask -> format("The string '%s' is not a valid multi letter language tag according to BCP47.", v(value, mask)));
                 break;
             }
             case "iso-639": {
                 if (!isValidIso639(value))
-                    return ValidationErrors.error(ctx, format("The string '%s' is not a valid language code according to ISO 639.", value));
+                    return ValidationErrors.error(ctx, mask -> format("The string '%s' is not a valid language code according to ISO 639.", v(value, mask)));
                 break;
             }
             case "iso-639-1": {
                 if (!isValidIso639_1(value))
-                    return ValidationErrors.error(ctx, format("The string '%s' is not a valid two letter language code according to ISO 639-1.", value));
+                    return ValidationErrors.error(ctx, mask -> format("The string '%s' is not a valid two letter language code according to ISO 639-1.", v(value, mask)));
                 break;
             }
             default:

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/ValidationContext.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/ValidationContext.java
@@ -201,7 +201,6 @@ public class ValidationContext {
         return ctx;
     }
 
-
     public String getPath() {
         return path;
     }

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/ValidationError.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/ValidationError.java
@@ -22,34 +22,66 @@ import static com.predic8.membrane.core.openapi.util.Utils.setFieldIfNotNull;
 
 public class ValidationError {
 
-    private final String message;
+    /**
+     * Replacement token for a submitted (potentially sensitive) value when a message is rendered
+     * with masking enabled.
+     */
+    public static final String MASK = "***";
+
+    private final MaskableMessage message;
     private final ValidationContext ctx;
 
     public ValidationError(String message) {
-        this.message = message;
-        this.ctx = null;
+        this(null, message);
     }
 
     public ValidationError(ValidationContext ctx, String message) {
+        this(ctx, maskValues -> message);
+    }
+
+    public ValidationError(ValidationContext ctx, MaskableMessage message) {
         this.message = message;
         this.ctx = ctx;
     }
 
+    /**
+     * Renders a submitted value for inclusion in a validation message: masked ({@link #MASK}) when
+     * {@code maskValues} is set, otherwise shown in clear. Kept out of the message string until
+     * render time so response body and log can be masked independently.
+     */
+    public static String v(Object value, boolean maskValues) {
+        return maskValues ? MASK : String.valueOf(value);
+    }
+
+    /**
+     * The message with submitted values shown in clear.
+     */
     public String getMessage() {
-        return message;
+        return message.render(false);
+    }
+
+    /**
+     * The message with submitted values either masked ({@link #MASK}) or shown in clear.
+     */
+    public String getMessage(boolean maskValues) {
+        return message.render(maskValues);
     }
 
     public ValidationContext getContext() {
         return ctx;
     }
 
+    public Map<String,Object> getContentMap() {
+        return getContentMap(false);
+    }
+
     /**
      * Takes out all fields with null values
      */
     @SuppressWarnings("ConstantConditions")
-    public Map<String,Object> getContentMap() {
+    public Map<String,Object> getContentMap(boolean maskValues) {
         Map<String,Object> fields = new LinkedHashMap<>();
-        setFieldIfNotNull(fields,"message", message);
+        setFieldIfNotNull(fields,"message", getMessage(maskValues));
         setFieldIfNotNull(fields,"complexType",ctx.getComplexType());
         setFieldIfNotNull(fields,"schemaType",ctx.getSchemaType());
 
@@ -58,8 +90,12 @@ public class ValidationError {
 
     @Override
     public String toString() {
+        return toString(false);
+    }
+
+    public String toString(boolean maskValues) {
         if (ctx == null)
-            return message;
-        return String.format("%s %s %s: %s",ctx.getMethod(), ctx.getPath(), ctx.getJSONpointer(), message);
+            return getMessage(maskValues);
+        return String.format("%s %s %s: %s",ctx.getMethod(), ctx.getPath(), ctx.getJSONpointer(), getMessage(maskValues));
     }
 }

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/ValidationErrors.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/ValidationErrors.java
@@ -34,6 +34,12 @@ public class ValidationErrors {
         return ve;
     }
 
+    public static ValidationErrors error(ValidationContext ctx, MaskableMessage message) {
+        ValidationErrors ve = new ValidationErrors();
+        ve.add(ctx, message);
+        return ve;
+    }
+
     public List<ValidationError> getErrors() {
         return errors;
     }
@@ -55,6 +61,11 @@ public class ValidationErrors {
     }
 
     public ValidationErrors add(ValidationContext ctx, String message) {
+        errors.add(new ValidationError(ctx, message));
+        return this;
+    }
+
+    public ValidationErrors add(ValidationContext ctx, MaskableMessage message) {
         errors.add(new ValidationError(ctx, message));
         return this;
     }
@@ -84,6 +95,10 @@ public class ValidationErrors {
     }
 
     public Map<String,Object> getErrorMessage(Direction direction) {
+        return getErrorMessage(direction, false);
+    }
+
+    public Map<String,Object> getErrorMessage(Direction direction, boolean maskValues) {
 
         var root = new LinkedHashMap<String, Object>();
 
@@ -92,7 +107,7 @@ public class ValidationErrors {
             return root;
         }
 
-        Map<String, List<Map<String, Object>>> m = getValidationErrorsGroupedByLocation(direction);
+        Map<String, List<Map<String, Object>>> m = getValidationErrorsGroupedByLocation(direction, maskValues);
         ValidationContext ctx = errors.getFirst().getContext();
         setFieldIfNotNull(root, "method", ctx.getMethod());
         setFieldIfNotNull(root, "uriTemplate", ctx.getUriTemplate());
@@ -103,11 +118,11 @@ public class ValidationErrors {
         return root;
     }
 
-    private Map<String, List<Map<String, Object>>> getValidationErrorsGroupedByLocation(Direction direction) {
+    private Map<String, List<Map<String, Object>>> getValidationErrorsGroupedByLocation(Direction direction, boolean maskValues) {
         Map<String, List<Map<String, Object>>> m = new HashMap<>();
         errors.forEach(ve -> {
             List<Map<String, Object>> ves = new ArrayList<>();
-            ves.add(ve.getContentMap());
+            ves.add(ve.getContentMap(maskValues));
             m.merge(getLocationFor(direction, ve), ves, (vesOld, vesNew) -> {
                 vesOld.addAll(vesNew);
                 return vesOld;
@@ -129,8 +144,12 @@ public class ValidationErrors {
 
     @Override
     public String toString() {
-        return "ValidationErrors{" +
-                "errors=" + errors +
-                '}';
+        return toString(false);
+    }
+
+    public String toString(boolean maskValues) {
+        StringJoiner joiner = new StringJoiner(", ", "[", "]");
+        errors.forEach(ve -> joiner.add(ve.toString(maskValues)));
+        return "ValidationErrors{errors=" + joiner + '}';
     }
 }

--- a/core/src/test/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIRecordFactoryTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/serviceproxy/OpenAPIRecordFactoryTest.java
@@ -52,6 +52,25 @@ class OpenAPIRecordFactoryTest {
     }
 
     @Test
+    void maskValuesEnumMapsToExtensionBooleans() {
+        assertMaskExtension(OpenAPISpec.MaskValues.NONE, false, false);
+        assertMaskExtension(OpenAPISpec.MaskValues.RESPONSE, true, false);
+        assertMaskExtension(OpenAPISpec.MaskValues.LOG, false, true);
+        assertMaskExtension(OpenAPISpec.MaskValues.BOTH, true, true);
+    }
+
+    private static void assertMaskExtension(OpenAPISpec.MaskValues maskValues, boolean maskResponse, boolean maskLog) {
+        OpenAPISpec spec = new OpenAPISpec();
+        spec.setLocation("customers.yml");
+        spec.setMaskValues(maskValues);
+        OpenAPIRecord rec = factory.create(singletonList(spec)).get("customers-api-v1-0");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> xValidation = (Map<String, Object>) rec.api.getExtensions().get(APIProxy.X_MEMBRANE_VALIDATION);
+        assertEquals(maskResponse, xValidation.get(APIProxy.MASK_VALUES));
+        assertEquals(maskLog, xValidation.get(APIProxy.MASK_VALUES_LOG));
+    }
+
+    @Test
     void readAndParseOpenAPI30() {
         OpenAPISpec spec = new OpenAPISpec();
         spec.setLocation("customers.yml");

--- a/core/src/test/java/com/predic8/membrane/core/openapi/validators/MaskValuesTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/validators/MaskValuesTest.java
@@ -1,0 +1,108 @@
+/*
+ *  Copyright 2026 predic8 GmbH, www.predic8.com
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.predic8.membrane.core.openapi.validators;
+
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.node.*;
+import com.predic8.membrane.core.openapi.*;
+import com.predic8.membrane.core.openapi.model.*;
+import com.predic8.membrane.core.openapi.serviceproxy.*;
+import com.predic8.membrane.core.util.*;
+import org.junit.jupiter.api.*;
+
+import java.math.*;
+import java.util.*;
+
+import static com.predic8.membrane.core.openapi.serviceproxy.APIProxy.*;
+import static com.predic8.membrane.core.openapi.util.OpenAPITestUtils.*;
+import static com.predic8.membrane.core.openapi.validators.ValidationError.MASK;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Masking is a render-time concern: the submitted value stays in the {@link ValidationError} and is
+ * only masked when a message is rendered. Response and log can therefore be masked independently.
+ */
+public class MaskValuesTest {
+
+    private static final ObjectMapper om = new ObjectMapper();
+
+    private OpenAPIValidator validator(String spec) {
+        OpenAPIValidator validator = new OpenAPIValidator(new URIFactory(),
+                new OpenAPIRecord(parseOpenAPI(getClass().getResourceAsStream(spec)), new OpenAPISpec()));
+        validator.getApi().setExtensions(new HashMap<>() {{
+            put(X_MEMBRANE_VALIDATION, new HashMap<>() {{
+                put(SECURITY, true);
+                put(REQUESTS, true);
+            }});
+        }});
+        return validator;
+    }
+
+    private static JsonNode object(String property, String value) {
+        ObjectNode root = om.createObjectNode();
+        root.put(property, value);
+        return root;
+    }
+
+    private static JsonNode object(String property, BigDecimal value) {
+        ObjectNode root = om.createObjectNode();
+        root.put(property, value);
+        return root;
+    }
+
+    @Test
+    void numberMinimumRawKeepsValueMaskedHidesIt() {
+        ValidationError e = validator("/openapi/specs/number.yml")
+                .validate(Request.post().path("/number").body(new JsonBody(object("minimum", new BigDecimal(3))))).get(0);
+
+        assertEquals("3 is smaller than the minimum of 5", e.getMessage());
+        assertEquals("3 is smaller than the minimum of 5", e.getMessage(false));
+        assertEquals(MASK + " is smaller than the minimum of 5", e.getMessage(true));
+    }
+
+    @Test
+    void contentMapMasksOnlyWhenRequested() {
+        ValidationError e = validator("/openapi/specs/number.yml")
+                .validate(Request.post().path("/number").body(new JsonBody(object("minimum", new BigDecimal(3))))).get(0);
+
+        assertEquals("3 is smaller than the minimum of 5", e.getContentMap(false).get("message"));
+        assertEquals(MASK + " is smaller than the minimum of 5", e.getContentMap(true).get("message"));
+    }
+
+    @Test
+    void stringValueIsNeverLeakedWhenMasked() {
+        ValidationError e = validator("/openapi/specs/strings.yml")
+                .validate(Request.post().path("/strings").body(new JsonBody(object("uuid", "B7AE38DD-7810-49E-B0BE-DF472F1343E0")))).get(0);
+
+        assertTrue(e.getMessage(false).contains("B7AE38DD"), e.getMessage(false));
+        String masked = e.getMessage(true);
+        assertTrue(masked.contains("'" + MASK + "'"), masked);
+        assertTrue(masked.contains("UUID"), masked);
+        assertFalse(masked.contains("B7AE38DD"), masked);
+    }
+
+    @Test
+    void sameErrorRendersBothWaysIndependently() {
+        ValidationError e = validator("/openapi/specs/number.yml")
+                .validate(Request.post().path("/number").body(new JsonBody(object("minimum", new BigDecimal(3))))).get(0);
+
+        // The raw value stays in the error: response and log can be masked independently from one instance.
+        assertEquals("3 is smaller than the minimum of 5", e.getMessage(false));
+        assertEquals(MASK + " is smaller than the minimum of 5", e.getMessage(true));
+        assertEquals("3 is smaller than the minimum of 5", e.getMessage(false));
+    }
+}


### PR DESCRIPTION
## What

Validation errors from the OpenAPI validator echo the submitted value back to the client (e.g. `5 is smaller than the minimum of 18`). For PII reasons that value can now be masked with `***`.

A new **opt-in** attribute on `<openapi>` controls it, with **response and log masked independently**:

```yaml
maskValues: none | response | log | both   # default: none (legacy behavior)
```

Typical use: real value in the server log for debugging, `***` in the response body.

## How

Masking is a **render-time** concern. The submitted value stays in the `ValidationError`, held by a lazy `MaskableMessage` (`String render(boolean maskValues)`) renderer, and is only turned into text when a message is rendered — so the response body and the log can diverge from a single error instance.

- New `MaskableMessage` functional interface; `ValidationError` holds one instead of a `String`. The `String` constructors still work (wrapped as a constant renderer), so literal-message call sites are untouched.
- `ValidationError.v(value, maskValues)` renders a submitted value (`***` or clear); the ~30 value-bearing call sites across the validators wrap their `format(...)` in `mask -> format(..., v(value, mask), ...)` with the format strings unchanged.
- The `maskValues` enum maps to two independent flags in `x-membrane-validation`, read live by `OpenAPIInterceptor` at the two render points (response body + log).

## Tests

- `MaskValuesTest` — raw vs. masked rendering and independent per-sink behavior from one error.
- `OpenAPIRecordFactoryTest` — enum → extension-flag mapping (`none→(F,F)`, `response→(T,F)`, `log→(F,T)`, `both→(T,T)`).
- Full `openapi.validators` package (441 tests) green: existing messages are unchanged because unmasked rendering reproduces the prior text verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable masking of submitted values in OpenAPI validation errors.
  * Masking can be enabled separately for error responses, logs, or both.
  * Supported validation error types now consistently protect sensitive values while retaining useful constraint details.

* **Bug Fixes**
  * Prevented sensitive request and response data from appearing in validation error messages when masking is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->