### PR TITLE
fix: configure transport before starting routers in OAuth2ResourceTest

### DIFF
--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/OAuth2ResourceTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/OAuth2ResourceTest.java
@@ -68,17 +68,17 @@ public abstract class OAuth2ResourceTest {
     public void init() throws IOException {
         mockAuthServer = new TestRouter();
         mockAuthServer.add(getMockAuthServiceProxy());
-        mockAuthServer.start();
         mockAuthServer.getTransport().setBacklog(10000);
         mockAuthServer.getTransport().setSocketTimeout(10000);
         mockAuthServer.getTransport().setConcurrentConnectionLimitPerIp(limit + 1);
+        mockAuthServer.start();
 
         oauth2Resource = new TestRouter();
         oauth2Resource.add(getConfiguredOAuth2Resource());
-        oauth2Resource.start();
         oauth2Resource.getTransport().setBacklog(10000);
         oauth2Resource.getTransport().setSocketTimeout(10000);
         oauth2Resource.getTransport().setConcurrentConnectionLimitPerIp(limit + 1);
+        oauth2Resource.start();
     }
 
     @AfterEach


### PR DESCRIPTION
setBacklog() and setSocketTimeout() were called after Router.start(). HttpEndpointListener reads the backlog when it constructs the ServerSocket, so both listeners were created with HttpTransport's default backlog of 50 instead of the intended 10000.

testUseRefreshTokenOnTokenExpiration opens 100 concurrent connections, overflowing that queue. Linux and macOS silently drop the excess SYNs and the client retries, so the test passes there; Windows answers with an RST, the requesting threads die on ConnectException, and the collected token set ends up short (observed 52-68 of 100).

Moving the transport configuration before start() makes the settings take effect and the test pass on Windows too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OAuth2 resource test setup so router connection and timeout settings are applied before startup, ensuring more reliable networking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->