### PR TITLE
fix: rebuild HttpClient when setHttpClientConfig() is called after init()

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/HTTPClientInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/HTTPClientInterceptor.java
@@ -234,5 +234,6 @@ public class HTTPClientInterceptor extends AbstractInterceptor {
     @MCChildElement
     public void setHttpClientConfig(HttpClientConfiguration httpClientConfig) {
         this.httpClientConfig = httpClientConfig;
+        this.httpClient = null;
     }
 }

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/HTTPClientInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/HTTPClientInterceptor.java
@@ -234,6 +234,7 @@ public class HTTPClientInterceptor extends AbstractInterceptor {
     @MCChildElement
     public void setHttpClientConfig(HttpClientConfiguration httpClientConfig) {
         this.httpClientConfig = httpClientConfig;
+        // Force init() to rebuild httpClient from the new config instead of keeping a stale one.
         this.httpClient = null;
     }
 }


### PR DESCRIPTION
## Problem

`HTTPClientInterceptor.setHttpClientConfig()` only updated the stored
`httpClientConfig` field but left a previously-built `httpClient` in
place. Since `init()` only builds `httpClient` when it is still `null`,
calling `setHttpClientConfig()` after `init()` has already run once had
no effect — the interceptor kept using the stale client built from the
old config.

`updateHttpClientConfig()` (test-only helper) already null'd `httpClient`
before setting the new config, but `setHttpClientConfig()` (the
`@MCChildElement` setter) did not, which is inconsistent.

This was surfaced by `LargeBodyTest`: the test builds a router (which
runs `init()` once via `Transport.init()` with the router's default
`HttpClientConfiguration`, `retries=2`), then calls
`setHttpClientConfig(hcc)` with `retries=1` before calling `init()`
again — but the stale `httpClient` (bound to `retries=2`) was still
used. With `retries > 1`, `Http1ProtocolHandler` buffers the whole
request body into memory before sending (so it can be safely retried),
which then throws `BodyTooLargeException` for bodies ≥ ~2 GiB instead
of streaming them.

## Fix

`setHttpClientConfig()` now also nulls out the cached `httpClient`, so
the next `init()` rebuilds it from the newly-assigned config — matching
the behavior `updateHttpClientConfig()` already had.

## Testing

- `core.interceptor.HTTPClientInterceptorTest` — all 13 tests pass.
- `core.integration.withinternet.LargeBodyTest` — both `large()` and
  `largeChunked()` now pass (previously failed with
  `BodyTooLargeException` / `wasStreamed() == false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated HTTP client settings now take effect correctly without requiring an application restart.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->