### PR TITLE
OAuth2 Session: Use `ConcurrentHashMap` 

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2client/rf/token/AccessTokenRefresher.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2client/rf/token/AccessTokenRefresher.java
@@ -34,7 +34,8 @@ import static com.predic8.membrane.core.interceptor.oauth2client.OAuth2Resource2
 public class AccessTokenRefresher {
     private static final Logger log = LoggerFactory.getLogger(AccessTokenRefresher.class);
 
-    private final Cache<String, Object> synchronizers = CacheBuilder.newBuilder()
+    private final Cache<Session, Object> synchronizers = CacheBuilder.newBuilder()
+            .weakKeys()
             .expireAfterAccess(1, TimeUnit.MINUTES)
             .build();
 
@@ -107,12 +108,8 @@ public class AccessTokenRefresher {
     }
 
     private Object getTokenSynchronizer(Session session) {
-        var refreshToken = session.getOAuth2AnswerParameters().getRefreshToken();
-
         try {
-            return refreshToken == null
-                    ? new Object()
-                    : synchronizers.get(refreshToken, Object::new);
+            return synchronizers.get(session, Object::new);
         } catch (ExecutionException e) {
             throw new RuntimeException(e);
         }

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2client/rf/token/AccessTokenRefresher.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2client/rf/token/AccessTokenRefresher.java
@@ -56,6 +56,11 @@ public class AccessTokenRefresher {
         }
 
         synchronized (getTokenSynchronizer(session)) {
+            // a concurrent caller may have already refreshed the token
+            // while this thread waited for the monitor.
+            if (!refreshingOfAccessTokenIsNeeded(session, wantedScope)) {
+                return;
+            }
             try {
                 exc.setProperty(OAUTH2, refreshAccessToken(session, wantedScope));
             } catch (Exception e) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2client/rf/token/AccessTokenRefresher.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2client/rf/token/AccessTokenRefresher.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 
 import static com.predic8.membrane.core.exchange.Exchange.OAUTH2;
 import static com.predic8.membrane.core.interceptor.oauth2client.OAuth2Resource2Interceptor.WANTED_SCOPE;
@@ -34,9 +33,12 @@ import static com.predic8.membrane.core.interceptor.oauth2client.OAuth2Resource2
 public class AccessTokenRefresher {
     private static final Logger log = LoggerFactory.getLogger(AccessTokenRefresher.class);
 
+    // weakKeys() ties the entry lifetime to the Session object: the entry is evicted only
+    // when the Session is GC'd, which cannot happen while any thread holds a reference to it.
+    // No expireAfterAccess: time-based eviction could replace a monitor while a slow
+    // refreshTokenRequest holds it, letting a second thread acquire a different lock object.
     private final Cache<Session, Object> synchronizers = CacheBuilder.newBuilder()
             .weakKeys()
-            .expireAfterAccess(1, TimeUnit.MINUTES)
             .build();
 
     private AuthorizationService auth;

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/session/Session.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/session/Session.java
@@ -241,12 +241,10 @@ public class Session {
     }
 
     public void setContent(Map<String, Object> content) {
-        // ConcurrentHashMap never holds null keys/values, so an existing ConcurrentHashMap is
-        // already safe to use directly. Any other Map (e.g. from Jackson deserialization) is
-        // copied with nulls filtered out.
-        this.content = content instanceof ConcurrentHashMap<?,?>
-                ? (ConcurrentHashMap<String, Object>) content
-                : withoutNullEntries(content);
+        // Always make a defensive copy so the Session owns its map exclusively.
+        // External mutations to the source map and sharing between Session instances
+        // cannot then bypass put() or dirty().
+        this.content = withoutNullEntries(content);
     }
 
     private static ConcurrentHashMap<String, Object> withoutNullEntries(Map<String, Object> source) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/session/Session.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/session/Session.java
@@ -18,6 +18,7 @@ import com.predic8.membrane.core.interceptor.oauth2.OAuth2AnswerParameters;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import static com.predic8.membrane.core.interceptor.oauth2.ParamNames.ACCESS_TOKEN;
@@ -44,19 +45,21 @@ public class Session {
     protected final static String AUTHORIZATION_LEVEL = "auth_level";
 
     private String usernameKeyName;
-    Map<String, Object> content;
+    ConcurrentHashMap<String, Object> content;
 
     boolean isDirty;
 
     public Session(String usernameKeyName, Map<String, Object> content) {
         this.usernameKeyName = usernameKeyName;
-        this.content = content;
+        this.content = new ConcurrentHashMap<>(content);
         if(getInternal(AUTHORIZATION_LEVEL) == null)
             setAuthorization(AuthorizationLevel.ANONYMOUS);
         isDirty = false;
     }
 
-    public Session(){};
+    public Session() {
+        this.content = new ConcurrentHashMap<>();
+    }
 
     public Session(Map<String, Object> content) {
         this("username",content);
@@ -80,12 +83,7 @@ public class Session {
     }
 
     public void remove(String... keys) {
-        Set<String> keysUnique = new HashSet<>(Arrays.asList(keys));
-        content = content
-                .entrySet()
-                .stream()
-                .filter(entry -> !keysUnique.contains(entry.getKey()))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        Arrays.stream(keys).forEach(content::remove);
         dirty();
     }
 
@@ -233,7 +231,9 @@ public class Session {
     }
 
     public void setContent(Map<String, Object> content) {
-        this.content = content;
+        this.content = content instanceof ConcurrentHashMap<?,?>
+                ? (ConcurrentHashMap<String, Object>) content
+                : new ConcurrentHashMap<>(content);
     }
 
     public String getUsernameKeyName() {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/session/Session.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/session/Session.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 
 import static com.predic8.membrane.core.interceptor.oauth2.ParamNames.ACCESS_TOKEN;
 import static com.predic8.membrane.core.interceptor.oauth2client.temp.OAuth2Constants.OAUTH2_ANSWER;
+import static java.util.Collections.unmodifiableMap;
 
 public class Session {
     @JsonIgnore  // we don't want this utility method to show up in JSON representations
@@ -107,7 +108,7 @@ public class Session {
     }
 
     public Map<String, Object> get() {
-        return content;
+        return unmodifiableMap(content);
     }
 
     public void clear() {
@@ -237,7 +238,7 @@ public class Session {
     }
 
     public Map<String, Object> getContent() {
-        return content;
+        return unmodifiableMap(content);
     }
 
     public void setContent(Map<String, Object> content) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/session/Session.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/session/Session.java
@@ -45,9 +45,9 @@ public class Session {
     protected final static String AUTHORIZATION_LEVEL = "auth_level";
 
     private String usernameKeyName;
-    ConcurrentHashMap<String, Object> content;
+    volatile ConcurrentHashMap<String, Object> content;
 
-    boolean isDirty;
+    volatile boolean isDirty;
 
     public Session(String usernameKeyName, Map<String, Object> content) {
         this.usernameKeyName = usernameKeyName;

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/session/Session.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/session/Session.java
@@ -51,7 +51,7 @@ public class Session {
 
     public Session(String usernameKeyName, Map<String, Object> content) {
         this.usernameKeyName = usernameKeyName;
-        this.content = new ConcurrentHashMap<>(content);
+        this.content = withoutNullEntries(content);
         if(getInternal(AUTHORIZATION_LEVEL) == null)
             setAuthorization(AuthorizationLevel.ANONYMOUS);
         isDirty = false;
@@ -70,6 +70,8 @@ public class Session {
     }
 
     public <T> void put(String key, T value) {
+        if (key == null) throw new IllegalArgumentException("Session key must not be null");
+        if (value == null) return; // null value = absent; treat as no-op
         put(Collections.singletonMap(key, value));
     }
 
@@ -83,12 +85,20 @@ public class Session {
     }
 
     public void remove(String... keys) {
+        for (String key : keys)
+            if (key == null) throw new IllegalArgumentException("Session key must not be null");
         Arrays.stream(keys).forEach(content::remove);
         dirty();
     }
 
     public void put(Map<String, Object> map) {
-        content.putAll(map);
+        // ConcurrentHashMap rejects null keys and values. Filter them here so that batch
+        // operations and Jackson deserialization (which may produce null values from JSON null)
+        // remain backward compatible. Null keys are still a programming error when passed to
+        // the single-entry put(String, T), which throws explicitly.
+        map.forEach((k, v) -> {
+            if (k != null && v != null) content.put(k, v);
+        });
         dirty();
     }
 
@@ -231,9 +241,18 @@ public class Session {
     }
 
     public void setContent(Map<String, Object> content) {
+        // ConcurrentHashMap never holds null keys/values, so an existing ConcurrentHashMap is
+        // already safe to use directly. Any other Map (e.g. from Jackson deserialization) is
+        // copied with nulls filtered out.
         this.content = content instanceof ConcurrentHashMap<?,?>
                 ? (ConcurrentHashMap<String, Object>) content
-                : new ConcurrentHashMap<>(content);
+                : withoutNullEntries(content);
+    }
+
+    private static ConcurrentHashMap<String, Object> withoutNullEntries(Map<String, Object> source) {
+        ConcurrentHashMap<String, Object> result = new ConcurrentHashMap<>();
+        source.forEach((k, v) -> { if (k != null && v != null) result.put(k, v); });
+        return result;
     }
 
     public String getUsernameKeyName() {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/b2c/B2CMembrane.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/b2c/B2CMembrane.java
@@ -92,12 +92,10 @@ public class B2CMembrane {
         oauth2Resource.add(sp3_flowInitiator_noLogout);
         oauth2Resource.add(sp2_flowInitiator_logoutBeforeFlow);
         oauth2Resource.add(sp1_oauth2resource2);
-        oauth2Resource.start();
-
-        oauth2Resource.getTransport().setConcurrentConnectionLimitPerIp(10000);
         oauth2Resource.getTransport().setBacklog(10000);
         oauth2Resource.getTransport().setSocketTimeout(10000);
         oauth2Resource.getTransport().setConcurrentConnectionLimitPerIp(tc.limit * 100);
+        oauth2Resource.start();
 
     }
 

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/b2c/MockAuthorizationServer.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/b2c/MockAuthorizationServer.java
@@ -81,10 +81,10 @@ public class MockAuthorizationServer {
         mockAuthServer.add(getMockAuthServiceProxy(SERVER_PORT, tc.susiFlowId));
         mockAuthServer.add(getMockAuthServiceProxy(SERVER_PORT, tc.peFlowId));
         mockAuthServer.add(getMockAuthServiceProxy(SERVER_PORT, tc.pe2FlowId));
-        mockAuthServer.start();
         mockAuthServer.getTransport().setBacklog(10000);
         mockAuthServer.getTransport().setSocketTimeout(10000);
         mockAuthServer.getTransport().setConcurrentConnectionLimitPerIp(tc.limit * 100);
+        mockAuthServer.start();
     }
 
     public void stop() {

--- a/core/src/test/java/com/predic8/membrane/integration/withoutinternet/MassivelyParallelTest.java
+++ b/core/src/test/java/com/predic8/membrane/integration/withoutinternet/MassivelyParallelTest.java
@@ -55,10 +55,10 @@ class MassivelyParallelTest {
         client = new HttpClient();
         server = new TestRouter();
         server.add(createServiceProxy());
-        server.start();
         server.getTransport().setConcurrentConnectionLimitPerIp(CONCURRENT_THREADS);
         server.getTransport().setBacklog(CONCURRENT_THREADS);
         server.getTransport().setSocketTimeout(10000);
+        server.start();
     }
 
     private static ServiceProxy createServiceProxy() {


### PR DESCRIPTION
AccessTokenRefresher used the refresh token string as its per-session lock key. Because the refresh token changes with every refresh, a thread that evaluated the key after another thread had already refreshed would get a different lock object and bypass the intended serialization, allowing concurrent writes to the same Session. On Windows this happened consistently due to coarser thread scheduling (~15 ms quanta vs ~1 ms on Linux).                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
  The concurrent writes hit Session.content, which was a plain HashMap, causing ConcurrentModificationException. That exception was caught and triggered session.clearAuthentication(), wiping the session and making all remaining threads fail.                                                                                                                                                                                                                                                                                                    
                                                            
  Two fixes:
  - AccessTokenRefresher: use the Session object identity (via Guava weakKeys()) as the lock key instead of the refresh token string, so the lock stays stable across refreshes.
  - Session: replace HashMap with ConcurrentHashMap and rewrite remove() to mutate in place rather than reassigning the field, so concurrent access is safe even outside the refresher's lock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved OAuth2 access-token refresh reliability during simultaneous operations within the same session.
* Prevented duplicate token refreshes from concurrent requests.
* Improved consistency when session data is accessed or modified concurrently.
* Added safer handling for missing or incomplete session values.
* Prevented unexpected changes through exposed session-data views.
* Improved reliability of connection and transport settings during server startup and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->