### PR TITLE
Wsdl validation fault elements

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/AbstractXMLSchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/AbstractXMLSchemaValidator.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 
 import static com.predic8.membrane.annot.Constants.XSD_NS;
 import static com.predic8.membrane.core.http.Header.VALIDATION_ERROR_SOURCE;
@@ -87,30 +88,15 @@ public abstract class AbstractXMLSchemaValidator extends AbstractMessageValidato
         var msg = exc.getMessage(flow);
         var exceptions = new ArrayList<Exception>();
         var preliminaryError = getPreliminaryError(xopr, msg);
+        boolean isValid = false;
         if (preliminaryError == null) {
-            var vals = validators.take();
-            try {
-                // the message must be valid for one schema embedded into WSDL
-                for (var validator : vals) {
-                    var handler = (SchemaValidatorErrorHandler) validator.getErrorHandler();
-                    try {
-                        validator.validate(getMessageBody(xopr.reconstituteIfNecessary(msg)));
-                        if (handler.noErrors()) {
-                            valid.incrementAndGet();
-                            return CONTINUE;
-                        }
-                        exceptions.add(handler.getException());
-                    } finally {
-                        handler.reset();
-                    }
-                }
-            } catch (Exception e) {
-                exceptions.add(e);
-            } finally {
-                validators.put(vals);
-            }
+            isValid = validateAgainstSchemas(() -> getMessageBody(xopr.reconstituteIfNecessary(msg)), exceptions);
         } else {
             exceptions.add(new Exception(preliminaryError));
+        }
+        if (isValid) {
+            valid.incrementAndGet();
+            return CONTINUE;
         }
         // Reached only when the message matched none of the (possibly several) embedded schemas.
         var errorMsg = getErrorMsg(exceptions); // Errors als simple String
@@ -123,6 +109,43 @@ public abstract class AbstractXMLSchemaValidator extends AbstractMessageValidato
         exc.getResponse().getHeader().add(VALIDATION_ERROR_SOURCE, flow.name());
         invalid.incrementAndGet();
         return ABORT;
+    }
+
+    /**
+     * Validates a {@link Source} against every schema embedded in the WSDL, succeeding if it
+     * matches any one of them. Exposed as {@code protected} so subclasses can run schema
+     * validation against a narrower source than the whole message body (e.g. {@link WSDLValidator}
+     * validates a SOAP fault's {@code detail} content this way).
+     * <p>
+     * Takes a {@link Supplier} rather than a single {@link Source} because a {@code Source}
+     * backed by a stream is consumed after one {@code validate()} call - a fresh one is needed
+     * for each of the (possibly several) embedded schemas tried.
+     *
+     * @param exceptions collects one exception per schema the source failed against
+     * @return {@code true} if the source matched at least one embedded schema
+     */
+    protected boolean validateAgainstSchemas(Supplier<Source> source, List<Exception> exceptions) throws Exception {
+        var vals = validators.take();
+        try {
+            // the message must be valid for one schema embedded into WSDL
+            for (var validator : vals) {
+                var handler = (SchemaValidatorErrorHandler) validator.getErrorHandler();
+                try {
+                    validator.validate(source.get());
+                    if (handler.noErrors()) {
+                        return true;
+                    }
+                    exceptions.add(handler.getException());
+                } finally {
+                    handler.reset();
+                }
+            }
+        } catch (Exception e) {
+            exceptions.add(e);
+        } finally {
+            validators.put(vals);
+        }
+        return false;
     }
 
     protected List<Validator> createValidators() {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/AbstractXMLSchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/AbstractXMLSchemaValidator.java
@@ -99,13 +99,40 @@ public abstract class AbstractXMLSchemaValidator extends AbstractMessageValidato
             return CONTINUE;
         }
         // Reached only when the message matched none of the (possibly several) embedded schemas.
+        return abort(exc, flow, exceptions);
+    }
+
+    /**
+     * Rejects a message that matched none of the schemas, reporting the errors collected per
+     * schema.
+     */
+    protected Outcome abort(Exchange exc, Interceptor.Flow flow, List<Exception> exceptions) {
         var errorMsg = getErrorMsg(exceptions); // Errors als simple String
-        log.info("{} message did not validate against any schema of {}: {}", flow, location, errorMsg);
+        setErrorResponse(exc, flow, exceptions);
+        return finishAbort(exc, flow, "message did not validate against any schema of %s: %s".formatted(location, errorMsg), errorMsg);
+    }
+
+    /**
+     * Rejects a message for a reason other than schema validation - because it is not SOAP at all,
+     * say, or carries an element the WSDL does not describe.
+     */
+    protected Outcome abort(Exchange exc, Interceptor.Flow flow, String message) {
+        setErrorResponse(exc, message);
+        return finishAbort(exc, flow, "message rejected: " + message, message);
+    }
+
+    /**
+     * The steps every rejection takes, whatever was wrong with the message: log it, notify the
+     * configured failure handler, expose the reason on the exchange, mark the response with the
+     * flow the message was rejected in and count it as invalid. Rejections must go through
+     * {@link #abort} so that none of this is left out.
+     */
+    private Outcome finishAbort(Exchange exc, Interceptor.Flow flow, String logMessage, String errorMsg) {
+        log.info("{} {}", flow, logMessage);
         if (failureHandler != null) {
             failureHandler.handleFailure(errorMsg, exc);
         }
         exc.setProperty("error", errorMsg); // TODO Search for usage. If it is used rename property. See properties in class Exchange
-        setErrorResponse(exc, flow, exceptions);
         exc.getResponse().getHeader().add(VALIDATION_ERROR_SOURCE, flow.name());
         invalid.incrementAndGet();
         return ABORT;
@@ -123,8 +150,11 @@ public abstract class AbstractXMLSchemaValidator extends AbstractMessageValidato
      *
      * @param exceptions collects one exception per schema the source failed against
      * @return {@code true} if the source matched at least one embedded schema
+     * @throws InterruptedException if interrupted while waiting for a validator from the pool.
+     *                             Validation failures are collected in {@code exceptions} instead
+     *                             of being thrown.
      */
-    protected boolean validateAgainstSchemas(Supplier<Source> source, List<Exception> exceptions) throws Exception {
+    protected boolean validateAgainstSchemas(Supplier<Source> source, List<Exception> exceptions) throws InterruptedException {
         var vals = validators.take();
         try {
             // the message must be valid for one schema embedded into WSDL

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/AbstractXMLSchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/AbstractXMLSchemaValidator.java
@@ -34,12 +34,14 @@ import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
@@ -78,10 +80,18 @@ public abstract class AbstractXMLSchemaValidator extends AbstractMessageValidato
 
     public void init() {
         super.init();
-        int concurrency = Runtime.getRuntime().availableProcessors() * 2;
+        int concurrency = poolConcurrency();
         validators = new ArrayBlockingQueue<>(concurrency);
         for (int i = 0; i < concurrency; i++)
             validators.add(createValidators());
+    }
+
+    /**
+     * Size of a validator pool. Exposed so subclasses that keep an additional pool of their own
+     * (e.g. {@link WSDLValidator}'s SOAP fault structure validators) size it identically.
+     */
+    protected static int poolConcurrency() {
+        return Runtime.getRuntime().availableProcessors() * 2;
     }
 
     public Outcome validateMessage(Exchange exc, Interceptor.Flow flow) throws Exception {
@@ -159,15 +169,8 @@ public abstract class AbstractXMLSchemaValidator extends AbstractMessageValidato
         try {
             // the message must be valid for one schema embedded into WSDL
             for (var validator : vals) {
-                var handler = (SchemaValidatorErrorHandler) validator.getErrorHandler();
-                try {
-                    validator.validate(source.get());
-                    if (handler.noErrors()) {
-                        return true;
-                    }
-                    exceptions.add(handler.getException());
-                } finally {
-                    handler.reset();
+                if (validateOnce(validator, source.get(), exceptions)) {
+                    return true;
                 }
             }
         } catch (Exception e) {
@@ -176,6 +179,48 @@ public abstract class AbstractXMLSchemaValidator extends AbstractMessageValidato
             validators.put(vals);
         }
         return false;
+    }
+
+    /**
+     * Validates a {@link Source} against the single schema a borrowed validator was compiled for.
+     * For pools whose validators are not interchangeable alternatives but are each the one right
+     * validator for a given kind of message - e.g. {@link WSDLValidator}'s SOAP fault structure
+     * schemas, one per SOAP version.
+     *
+     * @param exceptions collects the validation error if the source did not validate
+     * @return {@code true} if the source validated
+     * @throws InterruptedException if interrupted while waiting for a validator from the pool.
+     *                             Validation failures are collected in {@code exceptions} instead
+     *                             of being thrown.
+     */
+    protected boolean validateWith(BlockingQueue<Validator> pool, Source source, List<Exception> exceptions) throws InterruptedException {
+        var validator = pool.take();
+        try {
+            return validateOnce(validator, source, exceptions);
+        } catch (Exception e) {
+            exceptions.add(e);
+            return false;
+        } finally {
+            pool.put(validator);
+        }
+    }
+
+    /**
+     * Runs one validator over one source and resets its error handler afterwards, so that the
+     * validator can be returned to its pool ready for the next use.
+     */
+    private boolean validateOnce(Validator validator, Source source, List<Exception> exceptions) throws IOException, SAXException {
+        var handler = (SchemaValidatorErrorHandler) validator.getErrorHandler();
+        try {
+            validator.validate(source);
+            if (handler.noErrors()) {
+                return true;
+            }
+            exceptions.add(handler.getException());
+            return false;
+        } finally {
+            handler.reset();
+        }
     }
 
     protected List<Validator> createValidators() {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/FaultDetailXMLFilter.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/FaultDetailXMLFilter.java
@@ -1,0 +1,69 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+package com.predic8.membrane.core.interceptor.schemavalidation;
+
+import com.predic8.membrane.annot.Constants.SoapVersion;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.XMLFilterImpl;
+
+import static com.predic8.membrane.annot.Constants.SOAP12_NS;
+
+/**
+ * Strips a SOAP fault message down to the content of its {@code detail} (SOAP 1.1, unqualified)
+ * or {@code Detail} (SOAP 1.2, {@link com.predic8.membrane.annot.Constants#SOAP12_NS}) element, so
+ * that only the WSDL-typed fault payload is passed on. Mirrors {@link SOAPXMLFilter}, which does
+ * the same for {@code soap:Body}.
+ */
+public class FaultDetailXMLFilter extends XMLFilterImpl {
+
+    private final SoapVersion version;
+    private boolean inDetail;
+
+    public FaultDetailXMLFilter(XMLReader reader, SoapVersion version) {
+        super(reader);
+        this.version = version;
+    }
+
+    private boolean isDetail(String uri, String localName) {
+        return switch (version) {
+            case SOAP11 -> "detail".equals(localName) && uri.isEmpty();
+            case SOAP12 -> "Detail".equals(localName) && SOAP12_NS.equals(uri);
+            default -> false;
+        };
+    }
+
+    @Override
+    public void startElement(String uri, String localName, String qName, Attributes atts) throws SAXException {
+        if (isDetail(uri, localName)) {
+            inDetail = true;
+            return;
+        }
+        if (!inDetail)
+            return;
+        super.startElement(uri, localName, qName, atts);
+    }
+
+    @Override
+    public void endElement(String uri, String localName, String qName) throws SAXException {
+        if (isDetail(uri, localName)) {
+            inDetail = false;
+            return;
+        }
+        if (!inDetail)
+            return;
+        super.endElement(uri, localName, qName);
+    }
+}

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/FaultDetailXMLFilter.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/FaultDetailXMLFilter.java
@@ -26,11 +26,22 @@ import static com.predic8.membrane.annot.Constants.SOAP12_NS;
  * or {@code Detail} (SOAP 1.2, {@link com.predic8.membrane.annot.Constants#SOAP12_NS}) element, so
  * that only the WSDL-typed fault payload is passed on. Mirrors {@link SOAPXMLFilter}, which does
  * the same for {@code soap:Body}.
+ * <p>
+ * Unlike {@link SOAPXMLFilter}, the boundary is tracked by element depth, not by matching the
+ * name a second time on the closing tag: a fault payload may well contain an element of its own
+ * named {@code detail} (fault schemas usually leave {@code elementFormDefault} at its
+ * {@code unqualified} default), which would otherwise end the payload halfway through and emit
+ * an unbalanced document.
  */
 public class FaultDetailXMLFilter extends XMLFilterImpl {
 
     private final SoapVersion version;
-    private boolean inDetail;
+
+    /**
+     * {@code -1} outside the detail element, {@code 0} on the detail element itself, {@code n}
+     * when {@code n} levels deep inside its content.
+     */
+    private int depth = -1;
 
     public FaultDetailXMLFilter(XMLReader reader, SoapVersion version) {
         super(reader);
@@ -47,23 +58,38 @@ public class FaultDetailXMLFilter extends XMLFilterImpl {
 
     @Override
     public void startElement(String uri, String localName, String qName, Attributes atts) throws SAXException {
-        if (isDetail(uri, localName)) {
-            inDetail = true;
+        if (depth < 0) {
+            if (isDetail(uri, localName))
+                depth = 0;
             return;
         }
-        if (!inDetail)
-            return;
+        depth++;
         super.startElement(uri, localName, qName, atts);
     }
 
     @Override
     public void endElement(String uri, String localName, String qName) throws SAXException {
-        if (isDetail(uri, localName)) {
-            inDetail = false;
+        if (depth < 0)
+            return;
+        if (depth == 0) {
+            depth = -1; // the detail element itself: consumed, not forwarded
             return;
         }
-        if (!inDetail)
-            return;
+        depth--;
         super.endElement(uri, localName, qName);
+    }
+
+    @Override
+    public void characters(char[] ch, int start, int length) throws SAXException {
+        if (depth <= 0)
+            return; // envelope text (faultcode/faultstring, whitespace) must not leak into the prolog
+        super.characters(ch, start, length);
+    }
+
+    @Override
+    public void ignorableWhitespace(char[] ch, int start, int length) throws SAXException {
+        if (depth <= 0)
+            return;
+        super.ignorableWhitespace(ch, start, length);
     }
 }

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLMessageElementExtractor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLMessageElementExtractor.java
@@ -14,13 +14,15 @@
 
 package com.predic8.membrane.core.interceptor.schemavalidation;
 
+import com.predic8.membrane.core.util.ConfigurationException;
 import com.predic8.membrane.core.util.wsdl.parser.*;
 import com.predic8.membrane.core.util.wsdl.parser.Operation.Direction;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.xml.namespace.QName;
 import java.util.*;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.predic8.membrane.core.util.wsdl.parser.Binding.Style.RPC;
@@ -28,6 +30,8 @@ import static com.predic8.membrane.core.util.wsdl.parser.Operation.Direction.*;
 import static java.util.stream.Collectors.toSet;
 
 public class WSDLMessageElementExtractor {
+
+    private static final Logger log = LoggerFactory.getLogger(WSDLMessageElementExtractor.class.getName());
 
     public static Set<QName> getPossibleRequestElements(Definitions definitions, String serviceName) {
         return getPossibleElements(definitions, INPUT, serviceName);
@@ -41,9 +45,58 @@ public class WSDLMessageElementExtractor {
      * Elements that may legitimately appear as the payload of a SOAP fault's
      * {@code detail}/{@code Detail}, as declared via {@code wsdl:fault} on the service's
      * operations.
+     * <p>
+     * Unlike request and response elements, fault elements are read from the fault message's part
+     * for RPC and document bindings alike: a {@code soap:fault} is never RPC-wrapped (WSDL 1.1
+     * &sect;3.6), so there is no operation-named wrapper element to derive.
+     *
+     * @throws ConfigurationException if the WSDL declares a fault whose detail element cannot be
+     *         determined - a fault message without a part, or with a part naming a type instead of
+     *         an element. Such a fault is not validatable, and dropping it silently would leave an
+     *         empty result indistinguishable from a WSDL that declares no faults at all, so fault
+     *         validation would look active while doing nothing.
      */
     public static Set<QName> getPossibleFaultDetailElements(Definitions definitions, String serviceName) {
-        return getPossibleElements(definitions, FAULT, serviceName);
+        var result = new HashSet<QName>();
+        for (var portType : getAllPortTypes(getTypesByStyle(definitions, serviceName))) {
+            for (var operation : portType.getOperations()) {
+                for (var message : operation.getMessagesByDirection(FAULT)) {
+                    result.add(getFaultDetailElement(operation, message));
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * The element a {@code wsdl:fault}'s message declares as its detail payload.
+     */
+    private static QName getFaultDetailElement(Operation operation, Message message) {
+        var parts = message.getParts();
+        if (parts.isEmpty()) {
+            throw new ConfigurationException("Fault message %s of operation %s has no part, so the fault's detail content cannot be validated. A wsdl:fault must reference a message with a single part naming an element."
+                    .formatted(message.getName(), operation.getName()));
+        }
+        // A wsdl:fault message has exactly one part (WSDL 1.1 3.6), and only one detail entry is
+        // validated at runtime. Extra parts are silently unused, so warn once here at startup
+        // rather than letting the WSDL look fully covered while most of it is ignored. Not a
+        // ConfigurationException: the first part still describes a validatable fault detail, so
+        // refusing to start would be harsher than the defect warrants.
+        if (parts.size() > 1) {
+            log.warn("Fault message {} of operation {} declares {} parts, but a wsdl:fault must have a single part. Only the first one ({}) is used to validate the fault detail; the others are ignored.",
+                    message.getName(), operation.getName(), parts.size(), parts.getFirst().getName());
+        }
+        var part = parts.getFirst();
+        var element = part.getElementQName();
+        if (element == null) {
+            throw new ConfigurationException("Part %s of fault message %s (operation %s) names a type instead of an element, so the fault's detail content cannot be validated. A wsdl:fault's part must use part/@element, not part/@type."
+                    .formatted(part.getName(), message.getName(), operation.getName()));
+        }
+        return element;
+    }
+
+    private static @NotNull List<PortType> getAllPortTypes(PortTypesByStyle portTypes) {
+        return Stream.concat(portTypes.portTypesDocument().stream(), portTypes.portTypesRPC().stream()).toList();
     }
 
     public static Set<QName> getPossibleElements(Definitions definitions, Direction direction, String serviceName) {
@@ -65,7 +118,7 @@ public class WSDLMessageElementExtractor {
         return getParts(direction, portTypes.portTypesDocument())
                 .map(Part::getElementQName)
                 .filter(Objects::nonNull)
-                .collect(Collectors.toSet());
+                .collect(toSet());
     }
 
     private static @NotNull PortTypesByStyle getTypesByStyle(Definitions definitions, String serviceName) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLMessageElementExtractor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLMessageElementExtractor.java
@@ -24,8 +24,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.predic8.membrane.core.util.wsdl.parser.Binding.Style.RPC;
-import static com.predic8.membrane.core.util.wsdl.parser.Operation.Direction.INPUT;
-import static com.predic8.membrane.core.util.wsdl.parser.Operation.Direction.OUTPUT;
+import static com.predic8.membrane.core.util.wsdl.parser.Operation.Direction.*;
 import static java.util.stream.Collectors.toSet;
 
 public class WSDLMessageElementExtractor {
@@ -36,6 +35,15 @@ public class WSDLMessageElementExtractor {
 
     public static Set<QName> getPossibleResponseElements(Definitions definitions, String serviceName) {
         return getPossibleElements(definitions, OUTPUT, serviceName);
+    }
+
+    /**
+     * Elements that may legitimately appear as the payload of a SOAP fault's
+     * {@code detail}/{@code Detail}, as declared via {@code wsdl:fault} on the service's
+     * operations.
+     */
+    public static Set<QName> getPossibleFaultDetailElements(Definitions definitions, String serviceName) {
+        return getPossibleElements(definitions, FAULT, serviceName);
     }
 
     public static Set<QName> getPossibleElements(Definitions definitions, Direction direction, String serviceName) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidator.java
@@ -33,11 +33,13 @@ import org.w3c.dom.Element;
 import org.w3c.dom.ls.LSResourceResolver;
 import org.xml.sax.SAXException;
 
+import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
 
@@ -119,6 +121,20 @@ public class WSDLValidator extends AbstractXMLSchemaValidator {
     private static Schema compileFaultStructureSchema(String resourceName) {
         try {
             var sf = HardenedSchemaFactory.newInstance(XSD_NS);
+            // soap12-fault.xsd imports the XML namespace for xml:lang; serve it from the bundled
+            // xml.xsd instead of letting the (hardened, network-blocked) factory fetch it.
+            sf.setResourceResolver((type, namespaceURI, publicId, systemId, baseURI) -> {
+                if (!XMLConstants.XML_NS_URI.equals(namespaceURI)) {
+                    return null;
+                }
+                try {
+                    return new LSInputImpl(publicId, systemId,
+                            Objects.requireNonNull(WSDLValidator.class.getResourceAsStream("xml.xsd"),
+                                    "Bundled schema resource not found: xml.xsd"));
+                } catch (IOException e) {
+                    throw new RuntimeException("Cannot load bundled xml.xsd.", e);
+                }
+            });
             return sf.newSchema(new StreamSource(
                     Objects.requireNonNull(WSDLValidator.class.getResourceAsStream(resourceName),
                             "Bundled schema resource not found: " + resourceName)));
@@ -238,6 +254,7 @@ public class WSDLValidator extends AbstractXMLSchemaValidator {
         if (!validateAgainstSchemas(() -> getFaultDetailBody(xopr.reconstituteIfNecessary(message), version), exceptions)) {
             return abort(exc, Interceptor.Flow.RESPONSE, exceptions);
         }
+        valid.incrementAndGet();
         return CONTINUE;
     }
 

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidator.java
@@ -44,8 +44,6 @@ import java.util.*;
 import static com.predic8.membrane.annot.Constants.SoapVersion.SOAP11;
 import static com.predic8.membrane.annot.Constants.SoapVersion.SOAP12;
 import static com.predic8.membrane.annot.Constants.XSD_NS;
-import static com.predic8.membrane.core.http.Header.VALIDATION_ERROR_SOURCE;
-import static com.predic8.membrane.core.interceptor.Outcome.ABORT;
 import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
 import static com.predic8.membrane.core.interceptor.schemavalidation.WSDLMessageElementExtractor.*;
 import static com.predic8.membrane.core.util.SOAPUtil.FaultCode.Client;
@@ -146,9 +144,13 @@ public class WSDLValidator extends AbstractXMLSchemaValidator {
         var result = analyseSOAPMessage(xopr, message);
 
         if (!result.isSOAP()) {
-            setErrorResponse(exc, "Not a valid SOAP message.");
-            exc.getResponse().getHeader().add(VALIDATION_ERROR_SOURCE, flow.name());
-            return ABORT;
+            return abort(exc, flow, "Not a valid SOAP message.");
+        }
+
+        // wsdl:fault describes what a service returns, so a fault is never a legal request - not
+        // even with skipFaults, which is about tolerating the faults a backend sends back.
+        if (result.isFault() && flow == Interceptor.Flow.REQUEST) {
+            return abort(exc, flow, "A SOAP Fault is not a valid request. Possible elements are %s".formatted(requestElements));
         }
 
         if (result.isFault() && skipFaults) {
@@ -158,26 +160,22 @@ public class WSDLValidator extends AbstractXMLSchemaValidator {
 
         if (!versions.isEmpty()) {
             if (result.version() == SOAP11 && !versions.contains(SOAP_11)) {
-                setErrorResponse(exc, "SOAP version 1.1 is not valid");
-                return ABORT;
+                return abort(exc, flow, "SOAP version 1.1 is not valid");
             }
             if (result.version() == SOAP12 && !versions.contains(SOAP_12)) {
-                setErrorResponse(exc, "SOAP version 1.2 is not valid");
-                return ABORT;
+                return abort(exc, flow, "SOAP version 1.2 is not valid");
             }
         }
 
         if (result.isFault()) {
-            return validateFault(exc, flow, message, result.version());
+            return validateFault(exc, message, result.version());
         }
 
         if (flow == Interceptor.Flow.REQUEST && !isPossibleRequestElement(result.soapElement())) {
-            setErrorResponse(exc, "%s is not a valid request element. Possible elements are %s".formatted(result.soapElement(), requestElements));
-            return ABORT;
+            return abort(exc, flow, "%s is not a valid request element. Possible elements are %s".formatted(result.soapElement(), requestElements));
         }
         if (flow == Interceptor.Flow.RESPONSE && !isPossibleResponseElement(result.soapElement())) {
-            setErrorResponse(exc, "%s is not a valid response element. Possible elements are %s".formatted(result.soapElement(), responseElements));
-            return ABORT;
+            return abort(exc, flow, "%s is not a valid response element. Possible elements are %s".formatted(result.soapElement(), responseElements));
         }
         return super.validateMessage(exc, flow);
     }
@@ -187,39 +185,58 @@ public class WSDLValidator extends AbstractXMLSchemaValidator {
      * (faultcode/faultstring/detail resp. Code/Reason/Detail), then - if a detail/Detail payload
      * is present and the WSDL declares wsdl:fault elements for this service - validates that
      * payload against the WSDL's embedded schemas, same as request/response elements.
+     * <p>
+     * Only reached in the response flow: a fault is rejected outright as a request, so every
+     * rejection here is reported against {@link Interceptor.Flow#RESPONSE}.
      */
-    private Outcome validateFault(Exchange exc, Interceptor.Flow flow, Message message, SoapVersion version) throws Exception {
+    private Outcome validateFault(Exchange exc, Message message, SoapVersion version) throws Exception {
         var exceptions = new ArrayList<Exception>();
 
-        var structureValidator = faultStructureSchemas.get(version).newValidator();
+        // Only SOAP 1.1 and 1.2 fault shapes are bundled. analyseSOAPMessage cannot currently
+        // report any other version for a message it accepted as SOAP, so this is a guard against
+        // an invariant three classes away - not a reachable state.
+        var faultStructureSchema = faultStructureSchemas.get(version);
+        if (faultStructureSchema == null) {
+            return abort(exc, Interceptor.Flow.RESPONSE, "Cannot validate a fault of SOAP version %s. Only SOAP 1.1 and SOAP 1.2 faults are supported.".formatted(version));
+        }
+
+        // A fresh validator per fault, deliberately not from the validators pool: the expensive
+        // artifact is the compiled Schema, and that is already cached in faultStructureSchemas.
+        // Schema is immutable and thread-safe, so newValidator() is a cheap allocation off an
+        // already-compiled grammar - and a fresh instance has no handler state to reset. These
+        // schemas must not join the validators pool: that pool holds the WSDL's embedded schemas,
+        // which validateAgainstSchemas iterates looking for *any* match, whereas exactly one fault
+        // schema applies, selected by SOAP version.
+        var structureValidator = faultStructureSchema.newValidator();
         HardenedSchemaFactory.hardenValidator(structureValidator);
         var handler = new SchemaValidatorErrorHandler();
         structureValidator.setErrorHandler(handler);
         structureValidator.validate(getMessageBody(xopr.reconstituteIfNecessary(message)));
         if (!handler.noErrors()) {
-            setErrorResponse(exc, flow, List.of(handler.getException()));
-            exc.getResponse().getHeader().add(VALIDATION_ERROR_SOURCE, flow.name());
-            return ABORT;
+            return abort(exc, Interceptor.Flow.RESPONSE, List.of(handler.getException()));
         }
 
-        var detailElement = extractFaultDetailElement(xopr, message, version);
-        if (detailElement == null) {
-            // detail/Detail is optional per the SOAP spec.
+        var detailEntries = extractFaultDetailElements(xopr, message, version);
+        if (detailEntries.isEmpty()) {
+            // detail/Detail is optional per the SOAP spec, and may be empty.
             return CONTINUE;
         }
         if (faultDetailElements.isEmpty()) {
             log.debug("WSDL declares no wsdl:fault for this service; skipping validation of fault detail content.");
             return CONTINUE;
         }
+        // SOAP allows several detail entries, but a WSDL fault message has a single part, so a
+        // WSDL-described fault carries exactly one - and only that one could be validated below.
+        if (detailEntries.size() > 1) {
+            return abort(exc, Interceptor.Flow.RESPONSE, "A fault detail must contain exactly one element, because a WSDL fault message has a single part, but found %d: %s".formatted(detailEntries.size(), detailEntries));
+        }
+        var detailElement = detailEntries.getFirst();
         if (!faultDetailElements.contains(detailElement)) {
-            setErrorResponse(exc, "%s is not a valid fault detail element. Possible elements are %s".formatted(detailElement, faultDetailElements));
-            return ABORT;
+            return abort(exc, Interceptor.Flow.RESPONSE, "%s is not a valid fault detail element. Possible elements are %s".formatted(detailElement, faultDetailElements));
         }
 
         if (!validateAgainstSchemas(() -> getFaultDetailBody(xopr.reconstituteIfNecessary(message), version), exceptions)) {
-            setErrorResponse(exc, flow, exceptions);
-            exc.getResponse().getHeader().add(VALIDATION_ERROR_SOURCE, flow.name());
-            return ABORT;
+            return abort(exc, Interceptor.Flow.RESPONSE, exceptions);
         }
         return CONTINUE;
     }

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidator.java
@@ -38,10 +38,13 @@ import javax.xml.namespace.QName;
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
+import javax.xml.validation.Validator;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 
 import static com.predic8.membrane.annot.Constants.SoapVersion.SOAP11;
 import static com.predic8.membrane.annot.Constants.SoapVersion.SOAP12;
@@ -87,6 +90,14 @@ public class WSDLValidator extends AbstractXMLSchemaValidator {
     private final Map<SoapVersion, Schema> faultStructureSchemas;
 
     /**
+     * One pool of ready-to-use validators per SOAP version, filled in {@link #init()}. Kept apart
+     * from the pool of the WSDL's embedded schemas: that one is iterated looking for <i>any</i>
+     * schema the message matches, whereas exactly one fault schema applies, selected by SOAP
+     * version.
+     */
+    private Map<SoapVersion, BlockingQueue<Validator>> faultStructureValidators;
+
+    /**
      * Parsed WSDL document
      */
     private final com.predic8.membrane.core.util.wsdl.parser.Definitions definitions;
@@ -116,6 +127,26 @@ public class WSDLValidator extends AbstractXMLSchemaValidator {
         faultStructureSchemas = new EnumMap<>(SoapVersion.class);
         faultStructureSchemas.put(SOAP11, compileFaultStructureSchema("soap11-fault.xsd"));
         faultStructureSchemas.put(SOAP12, compileFaultStructureSchema("soap12-fault.xsd"));
+    }
+
+    @Override
+    public void init() {
+        super.init();
+        int concurrency = poolConcurrency();
+        faultStructureValidators = new EnumMap<>(SoapVersion.class);
+        faultStructureSchemas.forEach((version, schema) -> {
+            var pool = new ArrayBlockingQueue<Validator>(concurrency);
+            for (int i = 0; i < concurrency; i++)
+                pool.add(newHardenedValidator(schema));
+            faultStructureValidators.put(version, pool);
+        });
+    }
+
+    private static Validator newHardenedValidator(Schema schema) {
+        var validator = schema.newValidator();
+        HardenedSchemaFactory.hardenValidator(validator);
+        validator.setErrorHandler(new SchemaValidatorErrorHandler());
+        return validator;
     }
 
     private static Schema compileFaultStructureSchema(String resourceName) {
@@ -211,25 +242,13 @@ public class WSDLValidator extends AbstractXMLSchemaValidator {
         // Only SOAP 1.1 and 1.2 fault shapes are bundled. analyseSOAPMessage cannot currently
         // report any other version for a message it accepted as SOAP, so this is a guard against
         // an invariant three classes away - not a reachable state.
-        var faultStructureSchema = faultStructureSchemas.get(version);
-        if (faultStructureSchema == null) {
+        var structureValidators = faultStructureValidators.get(version);
+        if (structureValidators == null) {
             return abort(exc, Interceptor.Flow.RESPONSE, "Cannot validate a fault of SOAP version %s. Only SOAP 1.1 and SOAP 1.2 faults are supported.".formatted(version));
         }
 
-        // A fresh validator per fault, deliberately not from the validators pool: the expensive
-        // artifact is the compiled Schema, and that is already cached in faultStructureSchemas.
-        // Schema is immutable and thread-safe, so newValidator() is a cheap allocation off an
-        // already-compiled grammar - and a fresh instance has no handler state to reset. These
-        // schemas must not join the validators pool: that pool holds the WSDL's embedded schemas,
-        // which validateAgainstSchemas iterates looking for *any* match, whereas exactly one fault
-        // schema applies, selected by SOAP version.
-        var structureValidator = faultStructureSchema.newValidator();
-        HardenedSchemaFactory.hardenValidator(structureValidator);
-        var handler = new SchemaValidatorErrorHandler();
-        structureValidator.setErrorHandler(handler);
-        structureValidator.validate(getMessageBody(xopr.reconstituteIfNecessary(message)));
-        if (!handler.noErrors()) {
-            return abort(exc, Interceptor.Flow.RESPONSE, List.of(handler.getException()));
+        if (!validateWith(structureValidators, getMessageBody(xopr.reconstituteIfNecessary(message)), exceptions)) {
+            return abort(exc, Interceptor.Flow.RESPONSE, exceptions);
         }
 
         var detailEntries = extractFaultDetailElements(xopr, message, version);

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidator.java
@@ -14,6 +14,7 @@
 
 package com.predic8.membrane.core.interceptor.schemavalidation;
 
+import com.predic8.membrane.annot.Constants.SoapVersion;
 import com.predic8.membrane.core.exchange.Exchange;
 import com.predic8.membrane.core.http.Message;
 import com.predic8.membrane.core.interceptor.Interceptor;
@@ -23,29 +24,30 @@ import com.predic8.membrane.core.resolver.ResolverMap;
 import com.predic8.membrane.core.resolver.ResourceRetrievalException;
 import com.predic8.membrane.core.util.ConfigurationException;
 import com.predic8.membrane.core.util.LSInputImpl;
-import com.predic8.membrane.core.util.MessageUtil;
 import com.predic8.membrane.core.util.wsdl.parser.Definitions.SOAPVersion;
 import com.predic8.membrane.core.util.xml.XMLUtil;
+import com.predic8.membrane.core.util.xml.parser.HardenedSchemaFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
 import org.w3c.dom.ls.LSResourceResolver;
+import org.xml.sax.SAXException;
 
 import javax.xml.namespace.QName;
 import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static com.predic8.membrane.annot.Constants.SoapVersion.SOAP11;
 import static com.predic8.membrane.annot.Constants.SoapVersion.SOAP12;
+import static com.predic8.membrane.annot.Constants.XSD_NS;
 import static com.predic8.membrane.core.http.Header.VALIDATION_ERROR_SOURCE;
 import static com.predic8.membrane.core.interceptor.Outcome.ABORT;
 import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
-import static com.predic8.membrane.core.interceptor.schemavalidation.WSDLMessageElementExtractor.getPossibleRequestElements;
-import static com.predic8.membrane.core.interceptor.schemavalidation.WSDLMessageElementExtractor.getPossibleResponseElements;
+import static com.predic8.membrane.core.interceptor.schemavalidation.WSDLMessageElementExtractor.*;
 import static com.predic8.membrane.core.util.SOAPUtil.FaultCode.Client;
 import static com.predic8.membrane.core.util.SOAPUtil.*;
 import static com.predic8.membrane.core.util.wsdl.parser.Definitions.SOAPVersion.SOAP_11;
@@ -71,6 +73,20 @@ public class WSDLValidator extends AbstractXMLSchemaValidator {
     private final boolean skipFaults;
 
     /**
+     * Elements allowed as the payload of a SOAP fault's detail/Detail, as declared via
+     * wsdl:fault on the service's operations.
+     */
+    private final Set<QName> faultDetailElements;
+
+    /**
+     * Schemas describing the structural shape of a SOAP 1.1/1.2 Fault element (faultcode/
+     * faultstring/detail resp. Code/Reason/Detail). Membrane doesn't otherwise bundle a SOAP
+     * envelope schema, so these are compiled once per validator instance from small dedicated
+     * resources rather than being derived from the WSDL.
+     */
+    private final Map<SoapVersion, Schema> faultStructureSchemas;
+
+    /**
      * Parsed WSDL document
      */
     private final com.predic8.membrane.core.util.wsdl.parser.Definitions definitions;
@@ -94,7 +110,23 @@ public class WSDLValidator extends AbstractXMLSchemaValidator {
 
         requestElements = getPossibleRequestElements(definitions, serviceName);
         responseElements = getPossibleResponseElements(definitions, serviceName);
+        faultDetailElements = getPossibleFaultDetailElements(definitions, serviceName);
         versions = definitions.getSoapVersions();
+
+        faultStructureSchemas = new EnumMap<>(SoapVersion.class);
+        faultStructureSchemas.put(SOAP11, compileFaultStructureSchema("soap11-fault.xsd"));
+        faultStructureSchemas.put(SOAP12, compileFaultStructureSchema("soap12-fault.xsd"));
+    }
+
+    private static Schema compileFaultStructureSchema(String resourceName) {
+        try {
+            var sf = HardenedSchemaFactory.newInstance(XSD_NS);
+            return sf.newSchema(new StreamSource(
+                    Objects.requireNonNull(WSDLValidator.class.getResourceAsStream(resourceName),
+                            "Bundled schema resource not found: " + resourceName)));
+        } catch (SAXException e) {
+            throw new ConfigurationException("Cannot load bundled SOAP fault schema %s.".formatted(resourceName), e);
+        }
     }
 
     @Override
@@ -135,15 +167,61 @@ public class WSDLValidator extends AbstractXMLSchemaValidator {
             }
         }
 
+        if (result.isFault()) {
+            return validateFault(exc, flow, message, result.version());
+        }
+
         if (flow == Interceptor.Flow.REQUEST && !isPossibleRequestElement(result.soapElement())) {
             setErrorResponse(exc, "%s is not a valid request element. Possible elements are %s".formatted(result.soapElement(), requestElements));
             return ABORT;
         }
-        if (flow == Interceptor.Flow.RESPONSE && !result.isFault() && !isPossibleResponseElement(result.soapElement())) {
+        if (flow == Interceptor.Flow.RESPONSE && !isPossibleResponseElement(result.soapElement())) {
             setErrorResponse(exc, "%s is not a valid response element. Possible elements are %s".formatted(result.soapElement(), responseElements));
             return ABORT;
         }
         return super.validateMessage(exc, flow);
+    }
+
+    /**
+     * Validates a SOAP fault: first structurally, against the bundled SOAP 1.1/1.2 Fault shape
+     * (faultcode/faultstring/detail resp. Code/Reason/Detail), then - if a detail/Detail payload
+     * is present and the WSDL declares wsdl:fault elements for this service - validates that
+     * payload against the WSDL's embedded schemas, same as request/response elements.
+     */
+    private Outcome validateFault(Exchange exc, Interceptor.Flow flow, Message message, SoapVersion version) throws Exception {
+        var exceptions = new ArrayList<Exception>();
+
+        var structureValidator = faultStructureSchemas.get(version).newValidator();
+        HardenedSchemaFactory.hardenValidator(structureValidator);
+        var handler = new SchemaValidatorErrorHandler();
+        structureValidator.setErrorHandler(handler);
+        structureValidator.validate(getMessageBody(xopr.reconstituteIfNecessary(message)));
+        if (!handler.noErrors()) {
+            setErrorResponse(exc, flow, List.of(handler.getException()));
+            exc.getResponse().getHeader().add(VALIDATION_ERROR_SOURCE, flow.name());
+            return ABORT;
+        }
+
+        var detailElement = extractFaultDetailElement(xopr, message, version);
+        if (detailElement == null) {
+            // detail/Detail is optional per the SOAP spec.
+            return CONTINUE;
+        }
+        if (faultDetailElements.isEmpty()) {
+            log.debug("WSDL declares no wsdl:fault for this service; skipping validation of fault detail content.");
+            return CONTINUE;
+        }
+        if (!faultDetailElements.contains(detailElement)) {
+            setErrorResponse(exc, "%s is not a valid fault detail element. Possible elements are %s".formatted(detailElement, faultDetailElements));
+            return ABORT;
+        }
+
+        if (!validateAgainstSchemas(() -> getFaultDetailBody(xopr.reconstituteIfNecessary(message), version), exceptions)) {
+            setErrorResponse(exc, flow, exceptions);
+            exc.getResponse().getHeader().add(VALIDATION_ERROR_SOURCE, flow.name());
+            return ABORT;
+        }
+        return CONTINUE;
     }
 
     private boolean isPossibleRequestElement(javax.xml.namespace.QName name) {
@@ -193,7 +271,7 @@ public class WSDLValidator extends AbstractXMLSchemaValidator {
 
     @Override
     protected Source getMessageBody(InputStream input) {
-        return MessageUtil.getSOAPBody(input);
+        return getSOAPBody(input);
     }
 
     @Override

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/XMLSchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/XMLSchemaValidator.java
@@ -41,7 +41,6 @@ import java.util.List;
 
 import static com.predic8.membrane.annot.Constants.XSD_NS;
 import static com.predic8.membrane.core.exceptions.ProblemDetails.user;
-import static com.predic8.membrane.core.http.Header.VALIDATION_ERROR_SOURCE;
 
 public class XMLSchemaValidator extends AbstractXMLSchemaValidator {
 
@@ -121,7 +120,6 @@ public class XMLSchemaValidator extends AbstractXMLSchemaValidator {
                 .title(getErrorTitle())
                 .internal("validation", convertExceptionsToMap(exceptions))
                 .buildAndSetResponse(exchange);
-        exchange.getResponse().getHeader().add(VALIDATION_ERROR_SOURCE, flow.name());
     }
 
     @Override

--- a/core/src/main/java/com/predic8/membrane/core/util/MessageUtil.java
+++ b/core/src/main/java/com/predic8/membrane/core/util/MessageUtil.java
@@ -15,14 +15,8 @@ package com.predic8.membrane.core.util;
 
 import com.predic8.membrane.core.http.Message;
 import com.predic8.membrane.core.http.ReadingBodyException;
-import com.predic8.membrane.core.interceptor.schemavalidation.SOAPXMLFilter;
-import com.predic8.membrane.core.util.xml.parser.HardenedSaxParser;
 import org.brotli.dec.BrotliInputStream;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
 
-import javax.xml.transform.Source;
-import javax.xml.transform.sax.SAXSource;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -69,14 +63,6 @@ public class MessageUtil {
 			return msg.getBody().getContent();
 		} catch (IOException e) {
 			throw new ReadingBodyException(e);
-		}
-	}
-	
-	public static Source getSOAPBody(InputStream stream) {
-		try {
-            return new SAXSource(new SOAPXMLFilter(HardenedSaxParser.newSAXParser().getXMLReader()), new InputSource(stream));
-		} catch (SAXException e) {
-			throw new RuntimeException("Error initializing SAXSource", e);
 		}
 	}
 }

--- a/core/src/main/java/com/predic8/membrane/core/util/SOAPUtil.java
+++ b/core/src/main/java/com/predic8/membrane/core/util/SOAPUtil.java
@@ -95,7 +95,7 @@ public class SOAPUtil {
         Element body = doc.createElementNS(SOAP11_NS, "soap:Body");
         env.appendChild(body);
 
-        Element fault = doc.createElement("Fault");
+        Element fault = doc.createElementNS(SOAP11_NS, "soap:Fault");
         body.appendChild(fault);
 
         Element faultCode = doc.createElement("faultcode");

--- a/core/src/main/java/com/predic8/membrane/core/util/SOAPUtil.java
+++ b/core/src/main/java/com/predic8/membrane/core/util/SOAPUtil.java
@@ -17,12 +17,17 @@ package com.predic8.membrane.core.util;
 import com.predic8.membrane.core.http.Message;
 import com.predic8.membrane.core.http.ReadingBodyException;
 import com.predic8.membrane.core.http.Response;
+import com.predic8.membrane.core.interceptor.schemavalidation.FaultDetailXMLFilter;
+import com.predic8.membrane.core.interceptor.schemavalidation.SOAPXMLFilter;
 import com.predic8.membrane.core.multipart.XOPReconstitutor;
+import com.predic8.membrane.core.util.xml.parser.HardenedSaxParser;
 import com.predic8.membrane.core.util.xml.parser.HardenedStaxInputFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -31,6 +36,9 @@ import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
+import javax.xml.transform.Source;
+import javax.xml.transform.sax.SAXSource;
+import java.io.InputStream;
 import java.util.Map;
 
 import static com.predic8.membrane.annot.Constants.*;
@@ -194,6 +202,66 @@ public class SOAPUtil {
 
     public static boolean isSOAP11Element(QName name) {
         return SOAP11_NS.equals(name.getNamespaceURI());
+    }
+
+    /**
+     * Extracts the QName of the single element inside a SOAP fault's {@code detail} (SOAP 1.1,
+     * unqualified) or {@code Detail} (SOAP 1.2, {@link com.predic8.membrane.annot.Constants#SOAP12_NS})
+     * element, if present.
+     *
+     * @return the fault detail payload's QName, or {@code null} if the fault carries no detail
+     *         (or the detail element has no child).
+     */
+    public static QName extractFaultDetailElement(XOPReconstitutor xopr, Message msg, SoapVersion version) {
+        try {
+            var parser = HardenedStaxInputFactory.inputFactory().createXMLEventReader(xopr.reconstituteIfNecessary(msg));
+            boolean inDetail = false;
+            while (parser.hasNext()) {
+                var event = parser.nextEvent();
+                if (!event.isStartElement())
+                    continue;
+                var name = ((StartElement) event).getName();
+                if (!inDetail) {
+                    inDetail = isDetailElement(name, version);
+                    continue;
+                }
+                return name;
+            }
+        } catch (Exception e) {
+            log.debug("Could not extract fault detail element: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    private static boolean isDetailElement(QName name, SoapVersion version) {
+        return switch (version) {
+            case SOAP11 -> "detail".equals(name.getLocalPart()) && name.getNamespaceURI().isEmpty();
+            case SOAP12 -> "Detail".equals(name.getLocalPart()) && SOAP12_NS.equals(name.getNamespaceURI());
+            default -> false;
+        };
+    }
+
+    /**
+     * Strips the SOAP envelope so that only the payload below {@code <soap:Body>} is passed on.
+     */
+    public static Source getSOAPBody(InputStream stream) {
+        try {
+            return new SAXSource(new SOAPXMLFilter(HardenedSaxParser.newSAXParser().getXMLReader()), new InputSource(stream));
+        } catch (SAXException e) {
+            throw new RuntimeException("Error initializing SAXSource", e);
+        }
+    }
+
+    /**
+     * Narrows a SOAP fault message down to the content of its {@code detail}/{@code Detail}
+     * element, for schema-validating a fault's payload separately from its envelope structure.
+     */
+    public static Source getFaultDetailBody(InputStream stream, SoapVersion version) {
+        try {
+            return new SAXSource(new FaultDetailXMLFilter(HardenedSaxParser.newSAXParser().getXMLReader(), version), new InputSource(stream));
+        } catch (SAXException e) {
+            throw new RuntimeException("Error initializing SAXSource", e);
+        }
     }
 
     private static void readUntilEndTag(XMLEventReader parser) throws XMLStreamException {

--- a/core/src/main/java/com/predic8/membrane/core/util/SOAPUtil.java
+++ b/core/src/main/java/com/predic8/membrane/core/util/SOAPUtil.java
@@ -39,6 +39,8 @@ import javax.xml.stream.events.XMLEvent;
 import javax.xml.transform.Source;
 import javax.xml.transform.sax.SAXSource;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import static com.predic8.membrane.annot.Constants.*;
@@ -205,32 +207,42 @@ public class SOAPUtil {
     }
 
     /**
-     * Extracts the QName of the single element inside a SOAP fault's {@code detail} (SOAP 1.1,
-     * unqualified) or {@code Detail} (SOAP 1.2, {@link com.predic8.membrane.annot.Constants#SOAP12_NS})
-     * element, if present.
+     * Extracts the QNames of the detail entries - the direct children of a SOAP fault's
+     * {@code detail} (SOAP 1.1, unqualified) or {@code Detail} (SOAP 1.2,
+     * {@link com.predic8.membrane.annot.Constants#SOAP12_NS}) element. Descendants below the
+     * entries themselves are not reported.
      *
-     * @return the fault detail payload's QName, or {@code null} if the fault carries no detail
-     *         (or the detail element has no child).
+     * @return the detail entries in document order; empty if the fault carries no detail, the
+     *         detail element is empty, or the message could not be parsed.
      */
-    public static QName extractFaultDetailElement(XOPReconstitutor xopr, Message msg, SoapVersion version) {
+    public static List<QName> extractFaultDetailElements(XOPReconstitutor xopr, Message msg, SoapVersion version) {
+        var entries = new ArrayList<QName>();
         try {
             var parser = HardenedStaxInputFactory.inputFactory().createXMLEventReader(xopr.reconstituteIfNecessary(msg));
-            boolean inDetail = false;
+            int depth = -1; // -1 outside detail, 0 on the detail element, n when n levels inside it
             while (parser.hasNext()) {
                 var event = parser.nextEvent();
-                if (!event.isStartElement())
-                    continue;
-                var name = ((StartElement) event).getName();
-                if (!inDetail) {
-                    inDetail = isDetailElement(name, version);
+                if (event.isStartElement()) {
+                    var name = ((StartElement) event).getName();
+                    if (depth < 0) {
+                        if (isDetailElement(name, version))
+                            depth = 0;
+                        continue;
+                    }
+                    if (++depth == 1)
+                        entries.add(name);
                     continue;
                 }
-                return name;
+                if (event.isEndElement() && depth >= 0) {
+                    if (depth == 0)
+                        return entries; // detail closed
+                    depth--;
+                }
             }
         } catch (Exception e) {
-            log.debug("Could not extract fault detail element: {}", e.getMessage());
+            log.debug("Could not extract fault detail elements: {}", e.getMessage());
         }
-        return null;
+        return entries;
     }
 
     private static boolean isDetailElement(QName name, SoapVersion version) {

--- a/core/src/main/resources/com/predic8/membrane/core/interceptor/schemavalidation/soap11-fault.xsd
+++ b/core/src/main/resources/com/predic8/membrane/core/interceptor/schemavalidation/soap11-fault.xsd
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Structural shape of a SOAP 1.1 Fault element, used by WSDLValidator to check that a fault
+  response/request is a well-formed SOAP 1.1 fault before validating its <detail> content
+  against the WSDL's own embedded schemas. This is not the full SOAP 1.1 envelope schema —
+  only the Fault element is modeled, since that's the only part WSDLValidator validates
+  structurally.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://schemas.xmlsoap.org/soap/envelope/"
+           targetNamespace="http://schemas.xmlsoap.org/soap/envelope/"
+           elementFormDefault="unqualified">
+
+    <xs:element name="Fault" type="tns:Fault"/>
+
+    <xs:complexType name="Fault">
+        <xs:sequence>
+            <xs:element name="faultcode" type="xs:QName"/>
+            <xs:element name="faultstring" type="xs:string"/>
+            <xs:element name="faultactor" type="xs:anyURI" minOccurs="0"/>
+            <xs:element name="detail" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:any namespace="##any" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+                    </xs:sequence>
+                    <xs:anyAttribute namespace="##any" processContents="lax"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/core/src/main/resources/com/predic8/membrane/core/interceptor/schemavalidation/soap12-fault.xsd
+++ b/core/src/main/resources/com/predic8/membrane/core/interceptor/schemavalidation/soap12-fault.xsd
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Structural shape of a SOAP 1.2 Fault element, used by WSDLValidator to check that a fault
+  response/request is a well-formed SOAP 1.2 fault before validating its <Detail> content
+  against the WSDL's own embedded schemas. This is not the full SOAP 1.2 envelope schema —
+  only the Fault element is modeled, since that's the only part WSDLValidator validates
+  structurally. xml:lang on Reason/Text is intentionally left unconstrained (##any attribute)
+  to avoid pulling in the xml.xsd import for a purely structural check.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://www.w3.org/2003/05/soap-envelope"
+           targetNamespace="http://www.w3.org/2003/05/soap-envelope"
+           elementFormDefault="qualified">
+
+    <xs:element name="Fault" type="tns:Fault"/>
+
+    <xs:complexType name="Fault">
+        <xs:sequence>
+            <xs:element name="Code" type="tns:faultcode"/>
+            <xs:element name="Reason" type="tns:faultreason"/>
+            <xs:element name="Node" type="xs:anyURI" minOccurs="0"/>
+            <xs:element name="Role" type="xs:anyURI" minOccurs="0"/>
+            <xs:element name="Detail" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:any namespace="##any" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+                    </xs:sequence>
+                    <xs:anyAttribute namespace="##any" processContents="lax"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="faultcode">
+        <xs:sequence>
+            <xs:element name="Value" type="xs:QName"/>
+            <xs:element name="Subcode" type="tns:faultcode" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="faultreason">
+        <xs:sequence>
+            <xs:element name="Text" type="tns:reasontext" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="reasontext">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:anyAttribute namespace="##any" processContents="lax"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+</xs:schema>

--- a/core/src/main/resources/com/predic8/membrane/core/interceptor/schemavalidation/soap12-fault.xsd
+++ b/core/src/main/resources/com/predic8/membrane/core/interceptor/schemavalidation/soap12-fault.xsd
@@ -4,13 +4,16 @@
   response/request is a well-formed SOAP 1.2 fault before validating its <Detail> content
   against the WSDL's own embedded schemas. This is not the full SOAP 1.2 envelope schema —
   only the Fault element is modeled, since that's the only part WSDLValidator validates
-  structurally. xml:lang on Reason/Text is intentionally left unconstrained (##any attribute)
-  to avoid pulling in the xml.xsd import for a purely structural check.
+  structurally. The xml:lang import is served from the bundled xml.xsd (see xml.xsd in this
+  package) via WSDLValidator's resource resolver, so compiling this schema never fetches an
+  external resource.
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:tns="http://www.w3.org/2003/05/soap-envelope"
            targetNamespace="http://www.w3.org/2003/05/soap-envelope"
            elementFormDefault="qualified">
+
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace"/>
 
     <xs:element name="Fault" type="tns:Fault"/>
 
@@ -31,10 +34,29 @@
         </xs:sequence>
     </xs:complexType>
 
+    <!-- The top-level Code/Value is restricted to the SOAP 1.2 fault-code QNames defined by the
+         spec; a Subcode's Value is application-defined and stays an unrestricted xs:QName. -->
+    <xs:simpleType name="faultcodeEnum">
+        <xs:restriction base="xs:QName">
+            <xs:enumeration value="tns:DataEncodingUnknown"/>
+            <xs:enumeration value="tns:MustUnderstand"/>
+            <xs:enumeration value="tns:Receiver"/>
+            <xs:enumeration value="tns:Sender"/>
+            <xs:enumeration value="tns:VersionMismatch"/>
+        </xs:restriction>
+    </xs:simpleType>
+
     <xs:complexType name="faultcode">
         <xs:sequence>
+            <xs:element name="Value" type="tns:faultcodeEnum"/>
+            <xs:element name="Subcode" type="tns:subcode" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="subcode">
+        <xs:sequence>
             <xs:element name="Value" type="xs:QName"/>
-            <xs:element name="Subcode" type="tns:faultcode" minOccurs="0"/>
+            <xs:element name="Subcode" type="tns:subcode" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
 
@@ -47,7 +69,7 @@
     <xs:complexType name="reasontext">
         <xs:simpleContent>
             <xs:extension base="xs:string">
-                <xs:anyAttribute namespace="##any" processContents="lax"/>
+                <xs:attribute ref="xml:lang" use="required"/>
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>

--- a/core/src/main/resources/com/predic8/membrane/core/interceptor/schemavalidation/xml.xsd
+++ b/core/src/main/resources/com/predic8/membrane/core/interceptor/schemavalidation/xml.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Minimal stand-in for the W3C xml.xsd (http://www.w3.org/2001/xml.xsd), declaring only the
+  xml:lang attribute soap12-fault.xsd needs on Reason/Text. Bundled locally and served via
+  WSDLValidator's resource resolver so compiling the fault structure schema never fetches an
+  external resource.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.w3.org/XML/1998/namespace"
+           elementFormDefault="qualified">
+
+    <xs:attribute name="lang" type="xs:language"/>
+</xs:schema>

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/FaultDetailXMLFilterTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/FaultDetailXMLFilterTest.java
@@ -1,0 +1,138 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+package com.predic8.membrane.core.interceptor.schemavalidation;
+
+import com.predic8.membrane.annot.Constants.SoapVersion;
+import com.predic8.membrane.core.util.SOAPUtil;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamResult;
+import java.io.ByteArrayInputStream;
+import java.io.StringWriter;
+
+import static com.predic8.membrane.annot.Constants.SoapVersion.SOAP11;
+import static com.predic8.membrane.annot.Constants.SoapVersion.SOAP12;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FaultDetailXMLFilterTest {
+
+    /**
+     * The fault payload may itself contain an element named {@code detail} — fault schemas
+     * usually leave {@code elementFormDefault} at its {@code unqualified} default. Matching the
+     * name again on the closing tag would end the payload there, dropping everything after it
+     * and emitting an unbalanced document.
+     */
+    @Test
+    void keepsNestedDetailElement() throws Exception {
+        String out = filterFaultDetail(SOAP11, """
+                <s11:Envelope xmlns:s11="http://schemas.xmlsoap.org/soap/envelope/">
+                  <s11:Body>
+                    <s11:Fault>
+                      <faultcode>Server</faultcode>
+                      <faultstring>City not found</faultstring>
+                      <detail>
+                        <p:err xmlns:p="http://example.com/svc">
+                          <detail>inner</detail>
+                          <code>7</code>
+                        </p:err>
+                      </detail>
+                    </s11:Fault>
+                  </s11:Body>
+                </s11:Envelope>
+                """);
+
+        assertTrue(out.contains("err"), out);
+        assertTrue(out.contains("inner"), out);     // the nested detail survived
+        assertTrue(out.contains("code"), out);      // ... and so did its sibling
+        assertTrue(out.contains("7"), out);
+    }
+
+    /**
+     * Only the detail content may be emitted. Text from the surrounding envelope would land in
+     * front of the payload's root element, making the result unusable as an XML document.
+     */
+    @Test
+    void stripsEnvelopeText() throws Exception {
+        String out = filterFaultDetail(SOAP11, """
+                <s11:Envelope xmlns:s11="http://schemas.xmlsoap.org/soap/envelope/">
+                  <s11:Body>
+                    <s11:Fault>
+                      <faultcode>Server</faultcode>
+                      <faultstring>City not found</faultstring>
+                      <detail><p:err xmlns:p="http://example.com/svc">boom</p:err></detail>
+                    </s11:Fault>
+                  </s11:Body>
+                </s11:Envelope>
+                """);
+
+        assertTrue(out.contains("err"), out);
+        assertTrue(out.contains("boom"), out);
+        assertFalse(out.contains("City not found"), out);
+        assertFalse(out.contains("Server"), out);
+    }
+
+    @Test
+    void soap12Detail() throws Exception {
+        String out = filterFaultDetail(SOAP12, """
+                <s12:Envelope xmlns:s12="http://www.w3.org/2003/05/soap-envelope">
+                  <s12:Body>
+                    <s12:Fault>
+                      <s12:Code><s12:Value>Receiver</s12:Value></s12:Code>
+                      <s12:Reason><s12:Text>City not found</s12:Text></s12:Reason>
+                      <s12:Detail><p:err xmlns:p="http://example.com/svc">boom</p:err></s12:Detail>
+                    </s12:Fault>
+                  </s12:Body>
+                </s12:Envelope>
+                """);
+
+        assertTrue(out.contains("err"), out);
+        assertTrue(out.contains("boom"), out);
+        assertFalse(out.contains("Receiver"), out);
+        assertFalse(out.contains("City not found"), out);
+    }
+
+    /**
+     * The boundary is matched per SOAP version: an unqualified SOAP 1.1 {@code detail} is not a
+     * SOAP 1.2 {@code Detail}, so nothing is extracted.
+     */
+    @Test
+    void soap11DetailNotMatchedInSoap12Mode() throws Exception {
+        String out = filterFaultDetail(SOAP12, """
+                <s11:Envelope xmlns:s11="http://schemas.xmlsoap.org/soap/envelope/">
+                  <s11:Body>
+                    <s11:Fault>
+                      <faultcode>Server</faultcode>
+                      <detail><p:err xmlns:p="http://example.com/svc">boom</p:err></detail>
+                    </s11:Fault>
+                  </s11:Body>
+                </s11:Envelope>
+                """);
+
+        assertFalse(out.contains("err"), out);
+        assertFalse(out.contains("boom"), out);
+    }
+
+    private static String filterFaultDetail(SoapVersion version, String soap) throws Exception {
+        TransformerFactory tf = TransformerFactory.newInstance();
+        tf.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        Transformer t = tf.newTransformer();
+        StringWriter sw = new StringWriter();
+        t.transform(SOAPUtil.getFaultDetailBody(new ByteArrayInputStream(soap.getBytes(UTF_8)), version), new StreamResult(sw));
+        return sw.toString();
+    }
+}

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/SOAPFaultTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/SOAPFaultTest.java
@@ -14,7 +14,8 @@
 package com.predic8.membrane.core.interceptor.schemavalidation;
 
 import com.predic8.membrane.core.exchange.Exchange;
-import com.predic8.membrane.core.router.*;
+import com.predic8.membrane.core.router.DummyTestRouter;
+import com.predic8.membrane.core.router.Router;
 import com.predic8.membrane.core.util.SOAPUtil;
 import org.junit.jupiter.api.Test;
 
@@ -22,11 +23,9 @@ import java.util.Map;
 
 import static com.predic8.membrane.core.http.MimeType.TEXT_XML;
 import static com.predic8.membrane.core.http.Response.ok;
-import static com.predic8.membrane.core.interceptor.Outcome.ABORT;
 import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
 import static com.predic8.membrane.core.util.SOAPUtil.FaultCode.Server;
 import static com.predic8.membrane.test.StringAssertions.assertContains;
-import static com.predic8.membrane.test.StringAssertions.assertContainsNot;
 import static com.predic8.membrane.test.TestUtil.getPathFromResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -36,10 +35,12 @@ public class SOAPFaultTest {
 
 	@Test
 	public void testValidateFaults() {
+		// ArticleService.wsdl declares no wsdl:fault, so a structurally valid SOAP 1.1 fault -
+		// like the one createSOAPFaultResponse produces - passes through unvalidated.
 		var i = createValidatorInterceptor(false);
 		Exchange exc = createFaultExchange();
-		assertEquals(ABORT, i.handleResponse(exc));
-		assertContainsNot("secret", exc.getResponse().toString());
+		assertEquals(CONTINUE, i.handleResponse(exc));
+		assertContains("secret", exc.getResponse().toString());
 	}
 
 	@Test

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/SOAPUtilTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/SOAPUtilTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.xml.namespace.QName;
 import java.io.FileInputStream;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.predic8.membrane.annot.Constants.SoapVersion.SOAP11;
@@ -31,6 +32,7 @@ import static com.predic8.membrane.core.http.Response.ok;
 import static com.predic8.membrane.core.util.RecordingServerTestUtil.freePort;
 import static com.predic8.membrane.core.util.RecordingServerTestUtil.startRecordingServer;
 import static com.predic8.membrane.core.util.SOAPUtil.analyseSOAPMessage;
+import static com.predic8.membrane.core.util.SOAPUtil.extractFaultDetailElements;
 import static org.junit.jupiter.api.Assertions.*;
 
 
@@ -123,6 +125,77 @@ public class SOAPUtilTest {
         assertTrue(result.isSOAP());
         assertTrue(result.isFault());
         assertEquals(SOAP11, result.version());
+    }
+
+    @Test
+    void faultDetailEntries() {
+        assertEquals(List.of(new QName(TB_NS, "notFound"), new QName(MEMBRANE_NS, "hint")),
+                extractFaultDetailElements(new XOPReconstitutor(), getMessageFromString("""
+                        <s11:Envelope xmlns:s11="http://schemas.xmlsoap.org/soap/envelope/">
+                          <s11:Body>
+                            <s11:Fault>
+                              <faultcode>Server</faultcode>
+                              <faultstring>Not found</faultstring>
+                              <detail>
+                                <ns1:notFound xmlns:ns1="http://thomas-bayer.com/blz/">
+                                  <nested/>
+                                </ns1:notFound>
+                                <ns2:hint xmlns:ns2="http://membrane-api.io/"/>
+                              </detail>
+                            </s11:Fault>
+                          </s11:Body>
+                        </s11:Envelope>
+                        """), SOAP11));
+    }
+
+    @Test
+    void faultDetailEntriesEmptyWithoutDetail() {
+        assertTrue(extractFaultDetailElements(new XOPReconstitutor(), getMessageFromString("""
+                <s11:Envelope xmlns:s11="http://schemas.xmlsoap.org/soap/envelope/">
+                  <s11:Body>
+                    <s11:Fault>
+                      <faultcode>Server</faultcode>
+                      <faultstring>Not found</faultstring>
+                    </s11:Fault>
+                  </s11:Body>
+                </s11:Envelope>
+                """), SOAP11).isEmpty());
+    }
+
+    /**
+     * Nothing after the closing detail tag may be reported as an entry.
+     */
+    @Test
+    void faultDetailEntriesStopAtEndOfDetail() {
+        assertEquals(List.of(new QName(TB_NS, "notFound")),
+                extractFaultDetailElements(new XOPReconstitutor(), getMessageFromString("""
+                        <s11:Envelope xmlns:s11="http://schemas.xmlsoap.org/soap/envelope/">
+                          <s11:Body>
+                            <s11:Fault>
+                              <detail>
+                                <ns1:notFound xmlns:ns1="http://thomas-bayer.com/blz/"/>
+                              </detail>
+                              <faultactor>http://example.com/actor</faultactor>
+                            </s11:Fault>
+                          </s11:Body>
+                        </s11:Envelope>
+                        """), SOAP11));
+    }
+
+    @Test
+    void faultDetailEntriesSoap12() {
+        assertEquals(List.of(new QName(MEMBRANE_NS, "hint")),
+                extractFaultDetailElements(new XOPReconstitutor(), getMessageFromString("""
+                        <s12:Envelope xmlns:s12="http://www.w3.org/2003/05/soap-envelope">
+                          <s12:Body>
+                            <s12:Fault>
+                              <s12:Code><s12:Value>Receiver</s12:Value></s12:Code>
+                              <s12:Reason><s12:Text>Not found</s12:Text></s12:Reason>
+                              <s12:Detail><ns2:hint xmlns:ns2="http://membrane-api.io/"/></s12:Detail>
+                            </s12:Fault>
+                          </s12:Body>
+                        </s12:Envelope>
+                        """), SOAP12));
     }
 
     @Test

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/SOAPUtilTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/SOAPUtilTest.java
@@ -127,6 +127,18 @@ public class SOAPUtilTest {
         assertEquals(SOAP11, result.version());
     }
 
+    /**
+     * createSOAP11Fault's Fault element must carry the SOAP 1.1 envelope namespace, matching the
+     * bundled soap11-fault.xsd - otherwise Membrane-generated faults fail their own structural
+     * validation.
+     */
+    @Test
+    void createSOAP11FaultQualifiesFaultElement() throws Exception {
+        var fault = SOAPUtil.createSOAP11Fault(SOAPUtil.FaultCode.Client, "failed", null)
+                .getElementsByTagNameNS("*", "Fault").item(0);
+        assertEquals("http://schemas.xmlsoap.org/soap/envelope/", fault.getNamespaceURI());
+    }
+
     @Test
     void faultDetailEntries() {
         assertEquals(List.of(new QName(TB_NS, "notFound"), new QName(MEMBRANE_NS, "hint")),

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/SOAPXMLFilterTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/SOAPXMLFilterTest.java
@@ -13,7 +13,7 @@
    limitations under the License. */
 package com.predic8.membrane.core.interceptor.schemavalidation;
 
-import com.predic8.membrane.core.util.MessageUtil;
+import com.predic8.membrane.core.util.SOAPUtil;
 import org.junit.jupiter.api.Test;
 
 import javax.xml.transform.Transformer;
@@ -75,7 +75,7 @@ class SOAPXMLFilterTest {
         tf.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
         Transformer t = tf.newTransformer();
         StringWriter sw = new StringWriter();
-        t.transform(MessageUtil.getSOAPBody(new ByteArrayInputStream(soap.getBytes(UTF_8))), new StreamResult(sw));
+        t.transform(SOAPUtil.getSOAPBody(new ByteArrayInputStream(soap.getBytes(UTF_8))), new StreamResult(sw));
         return sw.toString();
     }
 }

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLMessageElementExtractorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLMessageElementExtractorTest.java
@@ -14,12 +14,17 @@
 
 package com.predic8.membrane.core.interceptor.schemavalidation;
 
-import com.predic8.membrane.core.resolver.*;
-import com.predic8.membrane.core.util.wsdl.parser.*;
-import org.jetbrains.annotations.*;
-import org.junit.jupiter.api.*;
+import com.predic8.membrane.core.resolver.ResolverMap;
+import com.predic8.membrane.core.util.ConfigurationException;
+import com.predic8.membrane.core.util.wsdl.parser.Definitions;
+import com.predic8.membrane.test.TestAppender;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
 
-import javax.xml.namespace.*;
+import javax.xml.namespace.QName;
+import java.util.Set;
 
 import static com.predic8.membrane.core.interceptor.schemavalidation.WSDLMessageElementExtractor.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -29,6 +34,9 @@ class WSDLMessageElementExtractorTest {
     private static final String CITIES_NS = "https://predic8.de/cities";
     private static final QName GET_CITY_QNAME = new QName(CITIES_NS, "getCity");
     private static final QName GET_CITYRESPONSE_QNAME = new QName(CITIES_NS, "getCityResponse");
+
+    private static final String CALC_NS = "http://example.com/calc";
+    private static final String SVC_NS = "http://example.com/svc";
 
     private static final String XMAIL_NS = "urn:ws-xwebservices-com:XWebEmailValidation:EmailValidation:v2:Messages";
     private static final QName GET_EMAIL_QNAME = new QName(XMAIL_NS, "ValidateEmailRequest");
@@ -63,6 +71,86 @@ class WSDLMessageElementExtractorTest {
         var requestElements = getPossibleRequestElements(getDefinitions("classpath:/validation/inline-anytype.wsdl"), "Hello_Service");
         assertEquals(1, requestElements.size());
         assertTrue(requestElements.contains(new QName("http://www.examples.com/wsdl/HelloService.wsdl", "sayHello")));
+    }
+
+    @Test
+    void faultDetailElements() throws Exception {
+        var faultElements = getPossibleFaultDetailElements(getDefinitions("classpath:/ws/cities-with-fault.wsdl"), null);
+
+        assertEquals(1, faultElements.size());
+        assertTrue(faultElements.contains(new QName(CITIES_NS, "cityNotFound")));
+    }
+
+    /**
+     * A {@code soap:fault} is never RPC-wrapped, so even under an RPC binding the fault detail
+     * element is the fault message's part element - not the operation name, which is what the RPC
+     * wrapper rule yields for input/output.
+     */
+    @Test
+    void faultDetailElementsRpcStyle() throws Exception {
+        var definitions = getDefinitions("classpath:/ws/rpc-with-fault.wsdl");
+
+        assertEquals(Set.of(new QName(CALC_NS, "divByZero")), getPossibleFaultDetailElements(definitions, null));
+        assertEquals(Set.of(new QName(CALC_NS, "divide")), getPossibleRequestElements(definitions, null));
+    }
+
+    /**
+     * All faults of an operation contribute their detail element, not just the first.
+     */
+    @Test
+    void twoFaultsOnOneOperation() throws Exception {
+        assertEquals(Set.of(new QName(CITIES_NS, "cityNotFound"), new QName(CITIES_NS, "rateLimited")),
+                getPossibleFaultDetailElements(getDefinitions("classpath:/ws/two-faults-per-operation.wsdl"), null));
+    }
+
+    @Test
+    void noFaultDeclared() throws Exception {
+        assertTrue(getPossibleFaultDetailElements(getDefinitions("classpath:/ws/cities.wsdl"), null).isEmpty());
+    }
+
+    /**
+     * A fault whose part names a type has no element to validate its detail against. Dropping it
+     * would make the result indistinguishable from a WSDL declaring no faults, silently disabling
+     * fault validation - so it is rejected instead.
+     */
+    @Test
+    void faultPartNamingATypeIsRejected() throws Exception {
+        var definitions = getDefinitions("classpath:/ws/fault-part-with-type.wsdl");
+
+        var e = assertThrows(ConfigurationException.class, () -> getPossibleFaultDetailElements(definitions, null));
+        assertTrue(e.getMessage().contains("NotFoundFault"), e.getMessage());
+        assertTrue(e.getMessage().contains("names a type instead of an element"), e.getMessage());
+    }
+
+    /**
+     * Only the first part of a fault message is ever validated, so the extra ones must be reported
+     * at startup instead of looking covered.
+     */
+    @Test
+    void faultMessageWithSeveralPartsWarnsAndUsesTheFirst() throws Exception {
+        var root = (Logger) LogManager.getRootLogger();
+        var appender = new TestAppender("WSDLMessageElementExtractorTest");
+        appender.start();
+        root.addAppender(appender);
+        try {
+            var elements = getPossibleFaultDetailElements(getDefinitions("classpath:/ws/fault-message-with-two-parts.wsdl"), null);
+
+            assertEquals(Set.of(new QName(SVC_NS, "notFound")), elements);
+            assertTrue(appender.contains("declares 2 parts"), appender.getMessages().toString());
+            assertTrue(appender.contains("NotFoundFault"), appender.getMessages().toString());
+        } finally {
+            root.removeAppender(appender);
+            appender.stop();
+        }
+    }
+
+    @Test
+    void faultMessageWithoutPartIsRejected() throws Exception {
+        var definitions = getDefinitions("classpath:/ws/fault-message-without-part.wsdl");
+
+        var e = assertThrows(ConfigurationException.class, () -> getPossibleFaultDetailElements(definitions, null));
+        assertTrue(e.getMessage().contains("NotFoundFault"), e.getMessage());
+        assertTrue(e.getMessage().contains("has no part"), e.getMessage());
     }
 
     private static @NotNull Definitions getDefinitions(String location) throws Exception {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidatorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidatorTest.java
@@ -14,16 +14,22 @@
 package com.predic8.membrane.core.interceptor.schemavalidation;
 
 import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.http.HeaderField;
+import com.predic8.membrane.core.http.HeaderName;
 import com.predic8.membrane.core.http.Request;
 import com.predic8.membrane.core.http.Response;
 import com.predic8.membrane.core.interceptor.Outcome;
 import com.predic8.membrane.core.resolver.ResolverMap;
+import com.predic8.membrane.core.util.ConfigurationException;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
 
+import static com.predic8.membrane.core.http.Header.VALIDATION_ERROR_SOURCE;
 import static com.predic8.membrane.core.http.MimeType.TEXT_XML;
 import static com.predic8.membrane.core.interceptor.Interceptor.Flow.REQUEST;
 import static com.predic8.membrane.core.interceptor.Interceptor.Flow.RESPONSE;
@@ -41,6 +47,8 @@ public class WSDLValidatorTest {
     public static final String ABSTRACT_SERVICE_NO_BINDING_WSDL = "src/test/resources/ws/abstract-service-no-binding.wsdl";
     public static final String CITIES_WITH_FAULT_WSDL = "src/test/resources/ws/cities-with-fault.wsdl";
     public static final String HELLO_SOAP12_WSDL = "src/test/resources/ws/hello-soap12.wsdl";
+    public static final String RPC_WITH_FAULT_WSDL = "src/test/resources/ws/rpc-with-fault.wsdl";
+    public static final String TWO_FAULTS_PER_OPERATION_WSDL = "src/test/resources/ws/two-faults-per-operation.wsdl";
 
     @Test
     void invalidRequestElement() throws Exception {
@@ -232,6 +240,104 @@ public class WSDLValidatorTest {
         dumpResonseBody(exc);
     }
 
+    /**
+     * SOAP permits several detail entries, but a WSDL fault message has a single part, so a
+     * described fault carries exactly one. Without an explicit check the second entry reaches the
+     * validator as if it were a child of the first, which reports a misleading schema error.
+     */
+    @Test
+    void faultDetailWithSeveralEntries() throws Exception {
+        Exchange exc = getResponseExchange(soap11("""
+                <s11:Fault>
+                    <faultcode>Server</faultcode>
+                    <faultstring>City not found</faultstring>
+                    <detail>
+                        <cit:cityNotFound xmlns:cit="https://predic8.de/cities"><name>Springfield</name></cit:cityNotFound>
+                        <cit:cityNotFound xmlns:cit="https://predic8.de/cities"><name>Shelbyville</name></cit:cityNotFound>
+                    </detail>
+                </s11:Fault>
+                """));
+
+        assertEquals(ABORT, createValidator(CITIES_WITH_FAULT_WSDL, null, false).validateMessage(exc, RESPONSE));
+        dumpResonseBody(exc);
+        assertTrue(exc.getResponse().getBodyAsStringDecoded().contains("must contain exactly one element"));
+    }
+
+    /**
+     * An empty detail element carries no payload to validate.
+     */
+    @Test
+    void faultWithEmptyDetail() throws Exception {
+        Exchange exc = getResponseExchange(soap11("""
+                <s11:Fault>
+                    <faultcode>Server</faultcode>
+                    <faultstring>City not found</faultstring>
+                    <detail/>
+                </s11:Fault>
+                """));
+
+        assertEquals(CONTINUE, createValidator(CITIES_WITH_FAULT_WSDL, null, false).validateMessage(exc, RESPONSE));
+        dumpResonseBody(exc);
+    }
+
+    /**
+     * Under an RPC binding the fault detail element must still be taken from the fault message's
+     * part - deriving it like an RPC request/response wrapper would name it after the operation
+     * and reject every legitimate fault.
+     */
+    @Test
+    void faultDetailUnderRpcBinding() throws Exception {
+        Exchange exc = getResponseExchange(soap11("""
+                <s11:Fault>
+                    <faultcode>Server</faultcode>
+                    <faultstring>Division by zero</faultstring>
+                    <detail>
+                        <c:divByZero xmlns:c="http://example.com/calc">
+                            <message>divisor was 0</message>
+                        </c:divByZero>
+                    </detail>
+                </s11:Fault>
+                """));
+
+        assertEquals(CONTINUE, createValidator(RPC_WITH_FAULT_WSDL, null, false).validateMessage(exc, RESPONSE));
+        dumpResonseBody(exc);
+    }
+
+    /**
+     * A WSDL declares faults as service output only, so a fault arriving as a request describes
+     * nothing the backend could handle and must not be forwarded.
+     */
+    @Test
+    void faultAsRequest() throws Exception {
+        Exchange exc = getRequestExchange(soap11("""
+                <s11:Fault>
+                    <faultcode>Server</faultcode>
+                    <faultstring>City not found</faultstring>
+                </s11:Fault>
+                """));
+
+        assertEquals(ABORT, createValidator(CITIES_WITH_FAULT_WSDL, null, false).validateMessage(exc, REQUEST));
+        dumpResonseBody(exc);
+        assertTrue(exc.getResponse().getBodyAsStringDecoded().contains("A SOAP Fault is not a valid request"));
+    }
+
+    /**
+     * skipFaults tolerates the faults a backend returns; it must not open the request direction.
+     */
+    @Test
+    void faultAsRequestWithSkipFaults() throws Exception {
+        Exchange exc = getRequestExchange(soap11("""
+                <s11:Fault>
+                    <faultcode>Server</faultcode>
+                    <faultstring>City not found</faultstring>
+                </s11:Fault>
+                """));
+
+        assertEquals(ABORT, createValidator(CITIES_WITH_FAULT_WSDL, null, true).validateMessage(exc, REQUEST));
+        dumpResonseBody(exc);
+        assertTrue(exc.getResponse().getBodyAsStringDecoded().contains("A SOAP Fault is not a valid request"));
+    }
+
     @Test
     void skipFaults() throws Exception {
         var exc = getResponseExchange(soap11("""
@@ -279,6 +385,103 @@ public class WSDLValidatorTest {
         dumpResonseBody(exc);
         assertEquals(ABORT, outcome);
         assertTrue(exc.getResponse().getBodyAsStringDecoded().contains("is not a valid request element"));
+    }
+
+    /**
+     * An operation may declare several faults. Each of them is a valid fault detail, and each is
+     * validated against its own declaration - matching one declared element must not let another
+     * element's content through.
+     */
+    @Test
+    void firstOfTwoDeclaredFaults() throws Exception {
+        Exchange exc = getResponseExchange(soap11("""
+                <s11:Fault>
+                    <faultcode>Server</faultcode>
+                    <faultstring>City not found</faultstring>
+                    <detail>
+                        <cit:cityNotFound xmlns:cit="https://predic8.de/cities">
+                            <name>Springfield</name>
+                        </cit:cityNotFound>
+                    </detail>
+                </s11:Fault>
+                """));
+
+        assertEquals(CONTINUE, createValidator(TWO_FAULTS_PER_OPERATION_WSDL, null, false).validateMessage(exc, RESPONSE));
+        dumpResonseBody(exc);
+    }
+
+    @Test
+    void secondOfTwoDeclaredFaults() throws Exception {
+        Exchange exc = getResponseExchange(soap11("""
+                <s11:Fault>
+                    <faultcode>Server</faultcode>
+                    <faultstring>Too many requests</faultstring>
+                    <detail>
+                        <cit:rateLimited xmlns:cit="https://predic8.de/cities">
+                            <retryAfter>30</retryAfter>
+                        </cit:rateLimited>
+                    </detail>
+                </s11:Fault>
+                """));
+
+        assertEquals(CONTINUE, createValidator(TWO_FAULTS_PER_OPERATION_WSDL, null, false).validateMessage(exc, RESPONSE));
+        dumpResonseBody(exc);
+    }
+
+    /**
+     * The detail element is declared, but carries the content model of the operation's other
+     * fault - so membership alone must not be enough to pass.
+     */
+    @Test
+    void declaredFaultElementWithTheOtherFaultsContent() throws Exception {
+        Exchange exc = getResponseExchange(soap11("""
+                <s11:Fault>
+                    <faultcode>Server</faultcode>
+                    <faultstring>City not found</faultstring>
+                    <detail>
+                        <cit:cityNotFound xmlns:cit="https://predic8.de/cities">
+                            <retryAfter>30</retryAfter>
+                        </cit:cityNotFound>
+                    </detail>
+                </s11:Fault>
+                """));
+
+        assertEquals(ABORT, createValidator(TWO_FAULTS_PER_OPERATION_WSDL, null, false).validateMessage(exc, RESPONSE));
+        dumpResonseBody(exc);
+        assertTrue(exc.getResponse().getBodyAsStringDecoded().contains("retryAfter"));
+    }
+
+    /**
+     * A fault the validator could never check must fail at startup, not silently disable fault
+     * validation for a route that looks configured for it.
+     */
+    @Test
+    void wsdlWithUnvalidatableFaultIsRejectedAtStartup() {
+        var e = assertThrows(ConfigurationException.class,
+                () -> createValidator("src/test/resources/ws/fault-part-with-type.wsdl", null, false));
+        assertTrue(e.getMessage().contains("names a type instead of an element"), e.getMessage());
+    }
+
+    /**
+     * Every rejection - not just a schema mismatch - must mark the response with the flow it was
+     * rejected in, notify the configured failure handler and count as invalid.
+     */
+    @Test
+    void rejectionReportsFlowAndNotifiesFailureHandler() throws Exception {
+        var handled = new ArrayList<String>();
+        var validator = new WSDLValidator(new ResolverMap(), CITIES_WSDL, null, (msg, exc) -> handled.add(msg), false);
+        validator.init();
+
+        Exchange exc = getRequestExchange(soap11("""
+                <foo:notInWsdl xmlns:foo="http://membrane-api.io/foo"/>
+                """));
+
+        assertEquals(ABORT, validator.validateMessage(exc, REQUEST));
+        assertEquals(List.of("REQUEST"), exc.getResponse().getHeader().getValues(new HeaderName(VALIDATION_ERROR_SOURCE))
+                .stream().map(HeaderField::getValue).toList());
+        assertEquals(1, handled.size(), handled.toString());
+        assertTrue(handled.getFirst().contains("not a valid request element"), handled.toString());
+        assertEquals(1, validator.getInvalid());
     }
 
     private static Exchange getRequestExchange(String body) throws URISyntaxException {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidatorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidatorTest.java
@@ -28,6 +28,8 @@ import org.slf4j.LoggerFactory;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import static com.predic8.membrane.core.http.Header.VALIDATION_ERROR_SOURCE;
 import static com.predic8.membrane.core.http.MimeType.TEXT_XML;
@@ -35,6 +37,7 @@ import static com.predic8.membrane.core.interceptor.Interceptor.Flow.REQUEST;
 import static com.predic8.membrane.core.interceptor.Interceptor.Flow.RESPONSE;
 import static com.predic8.membrane.core.interceptor.Outcome.ABORT;
 import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class WSDLValidatorTest {
@@ -49,6 +52,19 @@ public class WSDLValidatorTest {
     public static final String HELLO_SOAP12_WSDL = "src/test/resources/ws/hello-soap12.wsdl";
     public static final String RPC_WITH_FAULT_WSDL = "src/test/resources/ws/rpc-with-fault.wsdl";
     public static final String TWO_FAULTS_PER_OPERATION_WSDL = "src/test/resources/ws/two-faults-per-operation.wsdl";
+
+    private static final String WELL_FORMED_FAULT_11 = soap11("""
+            <s11:Fault>
+                <faultcode>Server</faultcode>
+                <faultstring>City not found</faultstring>
+            </s11:Fault>
+            """);
+
+    private static final String MALFORMED_FAULT_11 = soap11("""
+            <s11:Fault>
+                <faultcode>Server</faultcode>
+            </s11:Fault>
+            """);
 
     @Test
     void invalidRequestElement() throws Exception {
@@ -523,6 +539,42 @@ public class WSDLValidatorTest {
         assertEquals(1, handled.size(), handled.toString());
         assertTrue(handled.getFirst().contains("not a valid request element"), handled.toString());
         assertEquals(1, validator.getInvalid());
+    }
+
+    /**
+     * Fault structure validators come from a pool and are reused, so a failed validation must not
+     * leave error state behind that makes the next - valid - fault fail too.
+     */
+    @Test
+    void faultValidatorsAreReusedAcrossCalls() throws Exception {
+        var validator = createValidator(CITIES_WSDL, null, false);
+
+        assertEquals(CONTINUE, validator.validateMessage(getResponseExchange(WELL_FORMED_FAULT_11), RESPONSE));
+        assertEquals(CONTINUE, validator.validateMessage(getResponseExchange(WELL_FORMED_FAULT_11), RESPONSE));
+        assertEquals(ABORT, validator.validateMessage(getResponseExchange(MALFORMED_FAULT_11), RESPONSE));
+        assertEquals(CONTINUE, validator.validateMessage(getResponseExchange(WELL_FORMED_FAULT_11), RESPONSE));
+    }
+
+    /**
+     * More concurrent faults than the pool holds: every message must get its own validator, and
+     * the abort path must return its validator to the pool like the success path does.
+     */
+    @Test
+    void faultValidationIsConcurrencySafe() throws Exception {
+        var validator = createValidator(CITIES_WSDL, null, false);
+        int tasks = Runtime.getRuntime().availableProcessors() * 2 + 4;
+
+        try (var executor = Executors.newFixedThreadPool(8)) {
+            var futures = new ArrayList<Future<Outcome>>();
+            for (int i = 0; i < tasks; i++) {
+                boolean wellFormed = i % 2 == 0;
+                futures.add(executor.submit(() -> validator.validateMessage(
+                        getResponseExchange(wellFormed ? WELL_FORMED_FAULT_11 : MALFORMED_FAULT_11), RESPONSE)));
+            }
+            for (int i = 0; i < tasks; i++) {
+                assertEquals(i % 2 == 0 ? CONTINUE : ABORT, futures.get(i).get(30, SECONDS), "task " + i);
+            }
+        }
     }
 
     private static Exchange getRequestExchange(String body) throws URISyntaxException {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidatorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidatorTest.java
@@ -13,19 +13,22 @@
    limitations under the License. */
 package com.predic8.membrane.core.interceptor.schemavalidation;
 
-import com.predic8.membrane.core.exchange.*;
-import com.predic8.membrane.core.http.*;
-import com.predic8.membrane.core.interceptor.*;
-import com.predic8.membrane.core.resolver.*;
-import org.junit.jupiter.api.*;
-import org.slf4j.*;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.http.Request;
+import com.predic8.membrane.core.http.Response;
+import com.predic8.membrane.core.interceptor.Outcome;
+import com.predic8.membrane.core.resolver.ResolverMap;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.net.*;
+import java.net.URISyntaxException;
 
 import static com.predic8.membrane.core.http.MimeType.TEXT_XML;
 import static com.predic8.membrane.core.interceptor.Interceptor.Flow.REQUEST;
 import static com.predic8.membrane.core.interceptor.Interceptor.Flow.RESPONSE;
-import static com.predic8.membrane.core.interceptor.Outcome.*;
+import static com.predic8.membrane.core.interceptor.Outcome.ABORT;
+import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class WSDLValidatorTest {
@@ -36,6 +39,8 @@ public class WSDLValidatorTest {
     public static final String TWO_SEPARATED_SERVICES_WSDL = "src/test/resources/ws/two-separated-services.wsdl";
     public static final String MULTIPLE_PORTS_WSDL = "src/test/resources/ws/multiple-ports-in-a-service.wsdl";
     public static final String ABSTRACT_SERVICE_NO_BINDING_WSDL = "src/test/resources/ws/abstract-service-no-binding.wsdl";
+    public static final String CITIES_WITH_FAULT_WSDL = "src/test/resources/ws/cities-with-fault.wsdl";
+    public static final String HELLO_SOAP12_WSDL = "src/test/resources/ws/hello-soap12.wsdl";
 
     @Test
     void invalidRequestElement() throws Exception {
@@ -129,6 +134,102 @@ public class WSDLValidatorTest {
         dumpResonseBody(exc);
         assertNotNull(exc.getResponse());
         assertTrue(exc.getResponse().getBodyAsStringDecoded().contains("validation failed"));
+    }
+
+    @Test
+    void malformedFault11() throws Exception {
+        Exchange exc = getResponseExchange(soap11("""
+                <s11:Fault>
+                    <faultcode>Server</faultcode>
+                </s11:Fault>
+                """));
+
+        assertEquals(ABORT, createValidator(CITIES_WSDL, null, false).validateMessage(exc, RESPONSE));
+        dumpResonseBody(exc);
+        assertTrue(exc.getResponse().getBodyAsStringDecoded().contains("faultstring"));
+    }
+
+    @Test
+    void malformedFault12() throws Exception {
+        Exchange exc = getResponseExchange(soap12("""
+                <s12:Fault xmlns:s12="http://www.w3.org/2003/05/soap-envelope">
+                    <s12:Code><s12:Value>Receiver</s12:Value></s12:Code>
+                </s12:Fault>
+                """));
+
+        assertEquals(ABORT, createValidator(HELLO_SOAP12_WSDL, null, false).validateMessage(exc, RESPONSE));
+        dumpResonseBody(exc);
+        assertTrue(exc.getResponse().getBodyAsStringDecoded().contains("Reason"));
+    }
+
+    @Test
+    void wellFormedFaultWithoutDetail() throws Exception {
+        Exchange exc = getResponseExchange(soap11("""
+                <s11:Fault>
+                    <faultcode>Server</faultcode>
+                    <faultstring>City not found</faultstring>
+                </s11:Fault>
+                """));
+
+        assertEquals(CONTINUE, createValidator(CITIES_WSDL, null, false).validateMessage(exc, RESPONSE));
+        dumpResonseBody(exc);
+    }
+
+    @Test
+    void faultDetailNotDeclaredAsWsdlFault() throws Exception {
+        Exchange exc = getResponseExchange(soap11("""
+                <s11:Fault>
+                    <faultcode>Server</faultcode>
+                    <faultstring>City not found</faultstring>
+                    <detail>
+                        <cit:getCityResponse xmlns:cit="https://predic8.de/cities">
+                            <country>France</country>
+                            <population>2000000</population>
+                        </cit:getCityResponse>
+                    </detail>
+                </s11:Fault>
+                """));
+
+        assertEquals(ABORT, createValidator(CITIES_WITH_FAULT_WSDL, null, false).validateMessage(exc, RESPONSE));
+        dumpResonseBody(exc);
+        assertTrue(exc.getResponse().getBodyAsStringDecoded().contains("not a valid fault detail element"));
+    }
+
+    @Test
+    void faultDetailMatchesWsdlFaultButFailsSchema() throws Exception {
+        Exchange exc = getResponseExchange(soap11("""
+                <s11:Fault>
+                    <faultcode>Server</faultcode>
+                    <faultstring>City not found</faultstring>
+                    <detail>
+                        <cit:cityNotFound xmlns:cit="https://predic8.de/cities">
+                            <wrongElement>Springfield</wrongElement>
+                        </cit:cityNotFound>
+                    </detail>
+                </s11:Fault>
+                """));
+
+        assertEquals(ABORT, createValidator(CITIES_WITH_FAULT_WSDL, null, false).validateMessage(exc, RESPONSE));
+        dumpResonseBody(exc);
+        assertTrue(exc.getResponse().getBodyAsStringDecoded().contains("validation failed"));
+    }
+
+    @Test
+    void faultDetailMatchesWsdlFaultAndSchema() throws Exception {
+        Exchange exc = getResponseExchange(soap11("""
+                <s11:Fault>
+                    <faultcode>Server</faultcode>
+                    <faultstring>City not found</faultstring>
+                    <detail>
+                        <cit:cityNotFound xmlns:cit="https://predic8.de/cities">
+                            <name>Springfield</name>
+                        </cit:cityNotFound>
+                    </detail>
+                </s11:Fault>
+                """));
+
+        assertEquals(CONTINUE, createValidator(CITIES_WITH_FAULT_WSDL, null, false).validateMessage(exc, RESPONSE));
+        dumpResonseBody(exc);
     }
 
     @Test

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidatorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidatorTest.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
@@ -65,6 +66,27 @@ public class WSDLValidatorTest {
                 <faultcode>Server</faultcode>
             </s11:Fault>
             """);
+
+    private static final String WELL_FORMED_FAULT_12 = soap12("""
+            <s12:Fault xmlns:s12="http://www.w3.org/2003/05/soap-envelope">
+                <s12:Code><s12:Value>s12:Receiver</s12:Value></s12:Code>
+                <s12:Reason><s12:Text xml:lang="en">Something went wrong</s12:Text></s12:Reason>
+            </s12:Fault>
+            """);
+
+    private static final String MALFORMED_FAULT_12 = soap12("""
+            <s12:Fault xmlns:s12="http://www.w3.org/2003/05/soap-envelope">
+                <s12:Code><s12:Value>s12:Receiver</s12:Value></s12:Code>
+            </s12:Fault>
+            """);
+
+    /**
+     * Cycled through by the concurrency test: index parity decides well-formedness, the pair
+     * decides the SOAP version - so every version sees both outcomes.
+     */
+    private static final String[] FAULTS_BY_VERSION_AND_WELLFORMEDNESS = {
+            WELL_FORMED_FAULT_11, MALFORMED_FAULT_11, WELL_FORMED_FAULT_12, MALFORMED_FAULT_12
+    };
 
     @Test
     void invalidRequestElement() throws Exception {
@@ -556,21 +578,32 @@ public class WSDLValidatorTest {
     }
 
     /**
-     * More concurrent faults than the pool holds: every message must get its own validator, and
-     * the abort path must return its validator to the pool like the success path does.
+     * More concurrent faults per SOAP version than that version's pool holds, all released at
+     * once: every message must get its own validator, callers that find the pool empty must block
+     * on take() rather than fail, and the abort path must return its validator to the pool like
+     * the success path does. Uses a WSDL declaring both SOAP versions so both pools are exercised
+     * by one validator instance.
      */
     @Test
     void faultValidationIsConcurrencySafe() throws Exception {
-        var validator = createValidator(CITIES_WSDL, null, false);
-        int tasks = Runtime.getRuntime().availableProcessors() * 2 + 4;
+        var validator = createValidator(MULTIPLE_PORTS_WSDL, "Service", false);
+        // Two more tasks per version than that version's pool has validators, so at least two
+        // take() calls per pool find it empty.
+        int tasksPerVersion = AbstractXMLSchemaValidator.poolConcurrency() + 2;
+        int tasks = tasksPerVersion * 2;
+        var start = new CountDownLatch(1);
 
-        try (var executor = Executors.newFixedThreadPool(8)) {
+        // A thread per task: fewer would serialise the tasks and the pools would never run dry.
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
             var futures = new ArrayList<Future<Outcome>>();
             for (int i = 0; i < tasks; i++) {
-                boolean wellFormed = i % 2 == 0;
-                futures.add(executor.submit(() -> validator.validateMessage(
-                        getResponseExchange(wellFormed ? WELL_FORMED_FAULT_11 : MALFORMED_FAULT_11), RESPONSE)));
+                String fault = FAULTS_BY_VERSION_AND_WELLFORMEDNESS[i % 4];
+                futures.add(executor.submit(() -> {
+                    start.await();
+                    return validator.validateMessage(getResponseExchange(fault), RESPONSE);
+                }));
             }
+            start.countDown();
             for (int i = 0; i < tasks; i++) {
                 assertEquals(i % 2 == 0 ? CONTINUE : ABORT, futures.get(i).get(30, SECONDS), "task " + i);
             }

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidatorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidatorTest.java
@@ -161,13 +161,54 @@ public class WSDLValidatorTest {
     void malformedFault12() throws Exception {
         Exchange exc = getResponseExchange(soap12("""
                 <s12:Fault xmlns:s12="http://www.w3.org/2003/05/soap-envelope">
-                    <s12:Code><s12:Value>Receiver</s12:Value></s12:Code>
+                    <s12:Code><s12:Value>s12:Receiver</s12:Value></s12:Code>
                 </s12:Fault>
                 """));
 
         assertEquals(ABORT, createValidator(HELLO_SOAP12_WSDL, null, false).validateMessage(exc, RESPONSE));
         dumpResonseBody(exc);
         assertTrue(exc.getResponse().getBodyAsStringDecoded().contains("Reason"));
+    }
+
+    @Test
+    void wellFormedFault12() throws Exception {
+        Exchange exc = getResponseExchange(soap12("""
+                <s12:Fault xmlns:s12="http://www.w3.org/2003/05/soap-envelope">
+                    <s12:Code><s12:Value>s12:Receiver</s12:Value></s12:Code>
+                    <s12:Reason><s12:Text xml:lang="en">Something went wrong</s12:Text></s12:Reason>
+                </s12:Fault>
+                """));
+
+        assertEquals(CONTINUE, createValidator(HELLO_SOAP12_WSDL, null, false).validateMessage(exc, RESPONSE));
+        dumpResonseBody(exc);
+    }
+
+    @Test
+    void fault12ReasonTextWithoutLanguage() throws Exception {
+        Exchange exc = getResponseExchange(soap12("""
+                <s12:Fault xmlns:s12="http://www.w3.org/2003/05/soap-envelope">
+                    <s12:Code><s12:Value>s12:Receiver</s12:Value></s12:Code>
+                    <s12:Reason><s12:Text>Something went wrong</s12:Text></s12:Reason>
+                </s12:Fault>
+                """));
+
+        assertEquals(ABORT, createValidator(HELLO_SOAP12_WSDL, null, false).validateMessage(exc, RESPONSE));
+        dumpResonseBody(exc);
+        assertTrue(exc.getResponse().getBodyAsStringDecoded().contains("validation failed"));
+    }
+
+    @Test
+    void fault12InvalidTopLevelCode() throws Exception {
+        Exchange exc = getResponseExchange(soap12("""
+                <s12:Fault xmlns:s12="http://www.w3.org/2003/05/soap-envelope">
+                    <s12:Code><s12:Value>s12:NotARealFaultCode</s12:Value></s12:Code>
+                    <s12:Reason><s12:Text xml:lang="en">Something went wrong</s12:Text></s12:Reason>
+                </s12:Fault>
+                """));
+
+        assertEquals(ABORT, createValidator(HELLO_SOAP12_WSDL, null, false).validateMessage(exc, RESPONSE));
+        dumpResonseBody(exc);
+        assertTrue(exc.getResponse().getBodyAsStringDecoded().contains("validation failed"));
     }
 
     @Test

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/XMLSchemaValidatorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/XMLSchemaValidatorTest.java
@@ -16,6 +16,7 @@ package com.predic8.membrane.core.interceptor.schemavalidation;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.http.HeaderName;
 import com.predic8.membrane.core.resolver.ResolverMap;
 import com.predic8.membrane.core.router.TestRouter;
 import org.junit.jupiter.api.BeforeEach;
@@ -69,6 +70,8 @@ class XMLSchemaValidatorTest {
         assertEquals(APPLICATION_PROBLEM_JSON, exc.getResponse().getHeader().getContentType());
         assertEquals(400,exc.getResponse().getStatusCode());
         assertEquals(REQUEST.name(), exc.getResponse().getHeader().getFirstValue(VALIDATION_ERROR_SOURCE));
+        assertEquals(1, exc.getResponse().getHeader().getValues(new HeaderName(VALIDATION_ERROR_SOURCE)).size(),
+                "the flow marker must be set exactly once");
         JsonNode jn = om.readTree(exc.getResponse().getBodyAsStreamDecoded());
 
         assertEquals("XML message validation failed", jn.get("title").asText());

--- a/core/src/test/resources/ws/cities-with-fault.wsdl
+++ b/core/src/test/resources/ws/cities-with-fault.wsdl
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:cs="https://predic8.de/cities"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:s="http://schemas.xmlsoap.org/wsdl/soap/"
+                  targetNamespace="https://predic8.de/cities" name="cities">
+    <wsdl:types>
+        <xsd:schema targetNamespace="https://predic8.de/cities">
+            <xsd:element name="getCity">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="name" type="xsd:string"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="getCityResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="country" type="xsd:string"/>
+                        <xsd:element name="population" type="xsd:integer"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="cityNotFound">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="name" type="xsd:string"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="City">
+        <wsdl:part name="getCity" element="cs:getCity"/>
+    </wsdl:message>
+    <wsdl:message name="CityResponse">
+        <wsdl:part name="getCityResponse" element="cs:getCityResponse"/>
+    </wsdl:message>
+    <wsdl:message name="CityNotFound">
+        <wsdl:part name="cityNotFound" element="cs:cityNotFound"/>
+    </wsdl:message>
+    <wsdl:portType name="CityPort">
+        <wsdl:operation name="getCity">
+            <wsdl:input message="cs:City"></wsdl:input>
+            <wsdl:output message="cs:CityResponse"></wsdl:output>
+            <wsdl:fault name="CityNotFound" message="cs:CityNotFound"></wsdl:fault>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="CitySoapBinding" type="cs:CityPort">
+        <s:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"></s:binding>
+        <wsdl:operation name="getCity">
+            <s:operation soapAction="https://predic8.de/cities"></s:operation>
+            <wsdl:input>
+                <s:body use="literal" namespace="https://predic8.de/cities"></s:body>
+            </wsdl:input>
+            <wsdl:output>
+                <s:body use="literal" namespace="https://predic8.de/cities"></s:body>
+            </wsdl:output>
+            <wsdl:fault name="CityNotFound">
+                <s:fault use="literal" name="CityNotFound"></s:fault>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="CityService">
+        <wsdl:port name="CityPort" binding="cs:CitySoapBinding">
+            <s:address location="http://localhost:2001/services/cities"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/core/src/test/resources/ws/fault-message-with-two-parts.wsdl
+++ b/core/src/test/resources/ws/fault-message-with-two-parts.wsdl
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  The wsdl:fault's message declares TWO parts, but a wsdl:fault must have exactly one. Only the
+  first part is used to validate the fault detail; WSDLValidator warns about the rest at startup.
+-->
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:tns="http://example.com/svc"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:s="http://schemas.xmlsoap.org/wsdl/soap/"
+                  targetNamespace="http://example.com/svc" name="svc">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://example.com/svc">
+            <xsd:element name="lookup" type="xsd:string"/>
+            <xsd:element name="lookupResponse" type="xsd:string"/>
+            <xsd:element name="notFound" type="xsd:string"/>
+            <xsd:element name="extraDetail" type="xsd:string"/>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="LookupRequest">
+        <wsdl:part name="parameters" element="tns:lookup"/>
+    </wsdl:message>
+    <wsdl:message name="LookupResponse">
+        <wsdl:part name="parameters" element="tns:lookupResponse"/>
+    </wsdl:message>
+    <wsdl:message name="NotFoundFault">
+        <wsdl:part name="notFound" element="tns:notFound"/>
+        <wsdl:part name="extra" element="tns:extraDetail"/>
+    </wsdl:message>
+    <wsdl:portType name="SvcPort">
+        <wsdl:operation name="lookup">
+            <wsdl:input message="tns:LookupRequest"/>
+            <wsdl:output message="tns:LookupResponse"/>
+            <wsdl:fault name="NotFoundFault" message="tns:NotFoundFault"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="SvcBinding" type="tns:SvcPort">
+        <s:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="lookup">
+            <s:operation soapAction="http://example.com/svc/lookup"/>
+            <wsdl:input>
+                <s:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <s:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="NotFoundFault">
+                <s:fault use="literal" name="NotFoundFault"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="SvcService">
+        <wsdl:port name="SvcPort" binding="tns:SvcBinding">
+            <s:address location="http://localhost:2001/svc"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/core/src/test/resources/ws/fault-message-without-part.wsdl
+++ b/core/src/test/resources/ws/fault-message-without-part.wsdl
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  The wsdl:fault's message declares no part at all, so the fault's detail content cannot be
+  validated. WSDLValidator rejects such a WSDL at startup rather than silently skipping fault
+  validation.
+-->
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:tns="http://example.com/svc"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:s="http://schemas.xmlsoap.org/wsdl/soap/"
+                  targetNamespace="http://example.com/svc" name="svc">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://example.com/svc">
+            <xsd:element name="lookup" type="xsd:string"/>
+            <xsd:element name="lookupResponse" type="xsd:string"/>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="LookupRequest">
+        <wsdl:part name="parameters" element="tns:lookup"/>
+    </wsdl:message>
+    <wsdl:message name="LookupResponse">
+        <wsdl:part name="parameters" element="tns:lookupResponse"/>
+    </wsdl:message>
+    <wsdl:message name="NotFoundFault"/>
+    <wsdl:portType name="SvcPort">
+        <wsdl:operation name="lookup">
+            <wsdl:input message="tns:LookupRequest"/>
+            <wsdl:output message="tns:LookupResponse"/>
+            <wsdl:fault name="NotFoundFault" message="tns:NotFoundFault"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="SvcBinding" type="tns:SvcPort">
+        <s:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="lookup">
+            <s:operation soapAction="http://example.com/svc/lookup"/>
+            <wsdl:input>
+                <s:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <s:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="NotFoundFault">
+                <s:fault use="literal" name="NotFoundFault"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="SvcService">
+        <wsdl:port name="SvcPort" binding="tns:SvcBinding">
+            <s:address location="http://localhost:2001/svc"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/core/src/test/resources/ws/fault-part-with-type.wsdl
+++ b/core/src/test/resources/ws/fault-part-with-type.wsdl
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  The wsdl:fault's message part names a TYPE instead of an element, so the fault's detail content
+  cannot be validated. WSDLValidator rejects such a WSDL at startup rather than silently skipping
+  fault validation.
+-->
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:tns="http://example.com/svc"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:s="http://schemas.xmlsoap.org/wsdl/soap/"
+                  targetNamespace="http://example.com/svc" name="svc">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://example.com/svc">
+            <xsd:element name="lookup" type="xsd:string"/>
+            <xsd:element name="lookupResponse" type="xsd:string"/>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="LookupRequest">
+        <wsdl:part name="parameters" element="tns:lookup"/>
+    </wsdl:message>
+    <wsdl:message name="LookupResponse">
+        <wsdl:part name="parameters" element="tns:lookupResponse"/>
+    </wsdl:message>
+    <wsdl:message name="NotFoundFault">
+        <wsdl:part name="reason" type="xsd:string"/>
+    </wsdl:message>
+    <wsdl:portType name="SvcPort">
+        <wsdl:operation name="lookup">
+            <wsdl:input message="tns:LookupRequest"/>
+            <wsdl:output message="tns:LookupResponse"/>
+            <wsdl:fault name="NotFoundFault" message="tns:NotFoundFault"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="SvcBinding" type="tns:SvcPort">
+        <s:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="lookup">
+            <s:operation soapAction="http://example.com/svc/lookup"/>
+            <wsdl:input>
+                <s:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <s:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="NotFoundFault">
+                <s:fault use="literal" name="NotFoundFault"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="SvcService">
+        <wsdl:port name="SvcPort" binding="tns:SvcBinding">
+            <s:address location="http://localhost:2001/svc"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/core/src/test/resources/ws/rpc-with-fault.wsdl
+++ b/core/src/test/resources/ws/rpc-with-fault.wsdl
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  RPC-style binding with a wsdl:fault. A soap:fault is never RPC-wrapped, so the fault detail
+  element is the fault message's part element (tns:divByZero) - not the operation name, which is
+  what the RPC wrapper rule yields for input/output.
+-->
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:tns="http://example.com/calc"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:s="http://schemas.xmlsoap.org/wsdl/soap/"
+                  targetNamespace="http://example.com/calc" name="calc">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://example.com/calc">
+            <xsd:element name="divByZero">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="message" type="xsd:string"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="DivideRequest">
+        <wsdl:part name="dividend" type="xsd:int"/>
+        <wsdl:part name="divisor" type="xsd:int"/>
+    </wsdl:message>
+    <wsdl:message name="DivideResponse">
+        <wsdl:part name="quotient" type="xsd:int"/>
+    </wsdl:message>
+    <wsdl:message name="DivByZeroFault">
+        <wsdl:part name="fault" element="tns:divByZero"/>
+    </wsdl:message>
+    <wsdl:portType name="CalcPort">
+        <wsdl:operation name="divide">
+            <wsdl:input message="tns:DivideRequest"/>
+            <wsdl:output message="tns:DivideResponse"/>
+            <wsdl:fault name="DivByZeroFault" message="tns:DivByZeroFault"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="CalcBinding" type="tns:CalcPort">
+        <s:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="divide">
+            <s:operation soapAction="http://example.com/calc/divide"/>
+            <wsdl:input>
+                <s:body use="literal" namespace="http://example.com/calc"/>
+            </wsdl:input>
+            <wsdl:output>
+                <s:body use="literal" namespace="http://example.com/calc"/>
+            </wsdl:output>
+            <wsdl:fault name="DivByZeroFault">
+                <s:fault use="literal" name="DivByZeroFault"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="CalcService">
+        <wsdl:port name="CalcPort" binding="tns:CalcBinding">
+            <s:address location="http://localhost:2001/calc"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/core/src/test/resources/ws/two-faults-per-operation.wsdl
+++ b/core/src/test/resources/ws/two-faults-per-operation.wsdl
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  One operation declaring TWO wsdl:faults whose detail elements have different content models:
+  cityNotFound carries a name, rateLimited a retryAfter. Both are valid fault details for the
+  operation, but each must validate against its own declaration.
+-->
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:cs="https://predic8.de/cities"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:s="http://schemas.xmlsoap.org/wsdl/soap/"
+                  targetNamespace="https://predic8.de/cities" name="cities">
+    <wsdl:types>
+        <xsd:schema targetNamespace="https://predic8.de/cities">
+            <xsd:element name="getCity">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="name" type="xsd:string"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="getCityResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="country" type="xsd:string"/>
+                        <xsd:element name="population" type="xsd:integer"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="cityNotFound">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="name" type="xsd:string"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="rateLimited">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="retryAfter" type="xsd:integer"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="City">
+        <wsdl:part name="getCity" element="cs:getCity"/>
+    </wsdl:message>
+    <wsdl:message name="CityResponse">
+        <wsdl:part name="getCityResponse" element="cs:getCityResponse"/>
+    </wsdl:message>
+    <wsdl:message name="CityNotFound">
+        <wsdl:part name="cityNotFound" element="cs:cityNotFound"/>
+    </wsdl:message>
+    <wsdl:message name="RateLimited">
+        <wsdl:part name="rateLimited" element="cs:rateLimited"/>
+    </wsdl:message>
+    <wsdl:portType name="CityPort">
+        <wsdl:operation name="getCity">
+            <wsdl:input message="cs:City"/>
+            <wsdl:output message="cs:CityResponse"/>
+            <wsdl:fault name="CityNotFound" message="cs:CityNotFound"/>
+            <wsdl:fault name="RateLimited" message="cs:RateLimited"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="CitySoapBinding" type="cs:CityPort">
+        <s:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="getCity">
+            <s:operation soapAction="https://predic8.de/cities"/>
+            <wsdl:input>
+                <s:body use="literal" namespace="https://predic8.de/cities"/>
+            </wsdl:input>
+            <wsdl:output>
+                <s:body use="literal" namespace="https://predic8.de/cities"/>
+            </wsdl:output>
+            <wsdl:fault name="CityNotFound">
+                <s:fault use="literal" name="CityNotFound"/>
+            </wsdl:fault>
+            <wsdl:fault name="RateLimited">
+                <s:fault use="literal" name="RateLimited"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="CityService">
+        <wsdl:port name="CityPort" binding="cs:CitySoapBinding">
+            <s:address location="http://localhost:2001/services/cities"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SOAP 1.1 and SOAP 1.2 fault validation.
  * Validates fault details against WSDL-declared elements for document and RPC-style services.
  * Supports multiple fault definitions and extracts only relevant fault-detail content.
  * Improved concurrent validation and validator reuse.

* **Bug Fixes**
  * SOAP faults in requests are now rejected consistently.
  * Improved validation error reporting, response headers, callbacks, and invalid-message tracking.
  * Added clearer startup handling for unsupported or incomplete WSDL fault definitions.
  * Structurally valid response faults can pass through when no WSDL fault is declared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->