### PR TITLE
fix: honor message charset in XMLUtil.getInputSource

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/util/xml/XMLUtil.java
+++ b/core/src/main/java/com/predic8/membrane/core/util/xml/XMLUtil.java
@@ -104,11 +104,19 @@ public class XMLUtil {
 
     /**
      * For XML processing sometimes an InputSource is needed.
+     * Passes the body as a byte stream so the parser can determine the encoding
+     * itself (from the message's charset or, failing that, the XML declaration/BOM)
+     * instead of it being pre-decoded with the JVM default charset.
      * @param msg Message with body
      * @return InputSource of the message body
      */
     public static @NotNull InputSource getInputSource(Message msg) {
-        return new InputSource(new InputStreamReader(msg.getBodyAsStreamDecoded()));
+        InputSource source = new InputSource(msg.getBodyAsStreamDecoded());
+        String charset = msg.getHeader().getCharset();
+        if (charset != null) {
+            source.setEncoding(charset);
+        }
+        return source;
     }
 
     public static void mapToXml(Document doc, Element parent, Map<String, Object> map) {

--- a/core/src/test/java/com/predic8/membrane/core/util/XMLUtilTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/util/XMLUtilTest.java
@@ -13,16 +13,16 @@
    limitations under the License. */
 package com.predic8.membrane.core.util;
 
-import com.predic8.membrane.core.http.*;
-import com.predic8.membrane.core.util.xml.*;
-import com.predic8.membrane.core.util.xml.parser.*;
-import org.junit.jupiter.api.*;
-import org.w3c.dom.*;
+import com.predic8.membrane.core.http.Request;
+import com.predic8.membrane.core.util.xml.XMLUtil;
+import com.predic8.membrane.core.util.xml.parser.HardenedXmlParser;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
 
-import javax.xml.namespace.*;
+import javax.xml.namespace.QName;
 
-import static java.nio.charset.StandardCharsets.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class XMLUtilTest {
 
@@ -50,7 +50,7 @@ public class XMLUtilTest {
     void getInputSourceHonorsTheMessagesCharset() throws Exception {
         Request req = new Request();
         req.setBodyContent("""
-                <?xml version="1.0" encoding="ISO-8859-1"?>
+                <?xml version="1.0"?>
                 <order><city>Bönnigheim</city></order>""".getBytes(ISO_8859_1));
         req.getHeader().setContentType("text/xml; charset=ISO-8859-1");
 

--- a/core/src/test/java/com/predic8/membrane/core/util/XMLUtilTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/util/XMLUtilTest.java
@@ -13,11 +13,15 @@
    limitations under the License. */
 package com.predic8.membrane.core.util;
 
+import com.predic8.membrane.core.http.*;
 import com.predic8.membrane.core.util.xml.*;
+import com.predic8.membrane.core.util.xml.parser.*;
 import org.junit.jupiter.api.*;
+import org.w3c.dom.*;
 
 import javax.xml.namespace.*;
 
+import static java.nio.charset.StandardCharsets.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class XMLUtilTest {
@@ -36,5 +40,39 @@ public class XMLUtilTest {
     @Test
     void equalsIgnorePrefix() {
         assertEquals(PREFIX_A, PREFIX_B);
+    }
+
+    /**
+     * The message's charset (here ISO-8859-1) must govern decoding, not the JVM default
+     * charset, so a non-ASCII byte in the body is decoded correctly.
+     */
+    @Test
+    void getInputSourceHonorsTheMessagesCharset() throws Exception {
+        Request req = new Request();
+        req.setBodyContent("""
+                <?xml version="1.0" encoding="ISO-8859-1"?>
+                <order><city>Bönnigheim</city></order>""".getBytes(ISO_8859_1));
+        req.getHeader().setContentType("text/xml; charset=ISO-8859-1");
+
+        Document doc = HardenedXmlParser.getInstance().parse(XMLUtil.getInputSource(req));
+
+        assertEquals("Bönnigheim", doc.getElementsByTagName("city").item(0).getTextContent());
+    }
+
+    /**
+     * With no charset on the header, the XML declaration (read from the byte stream, not
+     * pre-decoded) still decides.
+     */
+    @Test
+    void getInputSourceFallsBackToTheXmlDeclarationWithoutAHeaderCharset() throws Exception {
+        Request req = new Request();
+        req.setBodyContent("""
+                <?xml version="1.0" encoding="ISO-8859-1"?>
+                <order><city>Bönnigheim</city></order>""".getBytes(ISO_8859_1));
+        req.getHeader().setContentType("text/xml");
+
+        Document doc = HardenedXmlParser.getInstance().parse(XMLUtil.getInputSource(req));
+
+        assertEquals("Bönnigheim", doc.getElementsByTagName("city").item(0).getTextContent());
     }
 }


### PR DESCRIPTION
## Problem

`XMLUtil.getInputSource` decoded the message body with an `InputStreamReader` using the JVM default charset, so:

1. The message's declared `Content-Type` charset was ignored (`-Dfile.encoding` decided instead).
2. The XML `encoding` declaration had no effect either, since per the XML spec it's only consulted when the parser is fed a byte stream, not a pre-decoded character stream.

This affects both consumers of `XMLUtil.getInputSource`: `XPathExchangeExpression` (xpath configuration) and the `xpath()` built-in function. A non-UTF-8 body with non-ASCII characters could be misdecoded, silently breaking xpath comparisons.

## Fix

Pass the byte stream straight to the `InputSource` and set its encoding from `msg.getHeader().getCharset()` when the header declares one, letting the parser fall back to its own BOM/declaration detection otherwise — following RFC 7303 precedence.

## Tests

Added to `XMLUtilTest`:
- `getInputSourceHonorsTheMessagesCharset` — reproduces the issue's ISO-8859-1 `Bönnigheim` case with a header charset.
- `getInputSourceFallsBackToTheXmlDeclarationWithoutAHeaderCharset` — same body with no header charset, confirming the XML declaration still decides.

Fixes #3129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XML processing for messages using non-default character encodings.
  * HTTP-specified character sets are now honored, while XML declarations are used when no character set is provided.
  * Prevented potential character corruption caused by relying on the system’s default encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->