### PR TITLE
fix: align partner.wsdl request wrapper names with doc/literal wrapped style

### DIFF
--- a/distribution/tutorials/soap/mocks/partner.wsdl
+++ b/distribution/tutorials/soap/mocks/partner.wsdl
@@ -53,7 +53,7 @@
                 </xsd:sequence>
             </xsd:complexType>
 
-            <xsd:element name="getPartnerRequest">
+            <xsd:element name="getPartner">
                 <xsd:complexType>
                     <xsd:sequence>
                         <xsd:element name="id" type="xsd:long"/>
@@ -69,7 +69,7 @@
                 </xsd:complexType>
             </xsd:element>
 
-            <xsd:element name="getPartnersRequest">
+            <xsd:element name="getPartners">
                 <xsd:complexType/>
             </xsd:element>
 
@@ -82,7 +82,7 @@
                 </xsd:complexType>
             </xsd:element>
 
-            <xsd:element name="createPartnerRequest">
+            <xsd:element name="createPartner">
                 <xsd:complexType>
                     <xsd:sequence>
                         <xsd:element name="name" type="xsd:string"/>
@@ -101,7 +101,7 @@
                 </xsd:complexType>
             </xsd:element>
 
-            <xsd:element name="updatePartnerRequest">
+            <xsd:element name="updatePartner">
                 <xsd:complexType>
                     <xsd:sequence>
                         <xsd:element name="id" type="xsd:long"/>
@@ -121,7 +121,7 @@
                 </xsd:complexType>
             </xsd:element>
 
-            <xsd:element name="deletePartnerRequest">
+            <xsd:element name="deletePartner">
                 <xsd:complexType>
                     <xsd:sequence>
                         <xsd:element name="id" type="xsd:long"/>
@@ -137,7 +137,7 @@
     </wsdl:types>
 
     <wsdl:message name="GetPartnerRequest">
-        <wsdl:part name="parameters" element="tns:getPartnerRequest"/>
+        <wsdl:part name="parameters" element="tns:getPartner"/>
     </wsdl:message>
 
     <wsdl:message name="GetPartnerResponse">
@@ -145,7 +145,7 @@
     </wsdl:message>
 
     <wsdl:message name="GetPartnersRequest">
-        <wsdl:part name="parameters" element="tns:getPartnersRequest"/>
+        <wsdl:part name="parameters" element="tns:getPartners"/>
     </wsdl:message>
 
     <wsdl:message name="GetPartnersResponse">
@@ -153,7 +153,7 @@
     </wsdl:message>
 
     <wsdl:message name="CreatePartnerRequest">
-        <wsdl:part name="parameters" element="tns:createPartnerRequest"/>
+        <wsdl:part name="parameters" element="tns:createPartner"/>
     </wsdl:message>
 
     <wsdl:message name="CreatePartnerResponse">
@@ -161,7 +161,7 @@
     </wsdl:message>
 
     <wsdl:message name="UpdatePartnerRequest">
-        <wsdl:part name="parameters" element="tns:updatePartnerRequest"/>
+        <wsdl:part name="parameters" element="tns:updatePartner"/>
     </wsdl:message>
 
     <wsdl:message name="UpdatePartnerResponse">
@@ -169,7 +169,7 @@
     </wsdl:message>
 
     <wsdl:message name="DeletePartnerRequest">
-        <wsdl:part name="parameters" element="tns:deletePartnerRequest"/>
+        <wsdl:part name="parameters" element="tns:deletePartner"/>
     </wsdl:message>
 
     <wsdl:message name="DeletePartnerResponse">


### PR DESCRIPTION
## Summary
Reviewed `distribution/tutorials/soap/mocks/partner.wsdl` against the document/literal wrapped conventions (WS-I Basic Profile / JAX-WS 2.0 "wrapped" rule). One violation found: the input wrapper elements were named `<operation>Request` (e.g. `getPartnerRequest`), but the wrapped-style rule requires the request element name to match the operation name exactly (`getPartner`).

## Changes
- Renamed the five request elements and their `wsdl:part element="tns:..."` references: `getPartnerRequest`→`getPartner`, `getPartnersRequest`→`getPartners`, `createPartnerRequest`→`createPartner`, `updatePartnerRequest`→`updatePartner`, `deletePartnerRequest`→`deletePartner`.
- `wsdl:message` names (`GetPartnerRequest` etc.) left unchanged — the wrapped rule only applies to the referenced element name.
- Response wrapper names, `96-WSDL-to-OpenAPI-REST.yaml`, and `mocks/partner-service.apis.yaml` are unaffected: neither references the input element names (REST routing uses operation names/paths, mock routing uses the `SOAPAction` header, and id extraction uses a `local-name()` XPath).

## Testing
Ran `Wsdl2OpenAPIRestTutorialTest` against the rebuilt distribution — all 6 tests pass, and the logs confirm the generated SOAP requests now use the wrapped-style element names (e.g. `<ns:getPartner><id>1</id></ns:getPartner>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated SOAP request definitions to use consistent operation names.
  * Corrected request message references for partner retrieval, creation, updating, and deletion operations.
  * Response definitions and service operations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->