### PR TITLE
fix: retry a request when establishing the connection timed out

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/HTTPClientInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/HTTPClientInterceptor.java
@@ -19,6 +19,7 @@ import com.predic8.membrane.annot.MCElement;
 import com.predic8.membrane.core.exchange.Exchange;
 import com.predic8.membrane.core.http.MalformedHeaderException;
 import com.predic8.membrane.core.proxies.AbstractServiceProxy;
+import com.predic8.membrane.core.transport.http.ConnectTimeoutException;
 import com.predic8.membrane.core.transport.http.EOFWhileReadingLineException;
 import com.predic8.membrane.core.transport.http.HttpClient;
 import com.predic8.membrane.core.transport.http.ProtocolUpgradeDeniedException;
@@ -119,12 +120,21 @@ public class HTTPClientInterceptor extends AbstractInterceptor {
                     .buildAndSetResponse(exc);
             return ABORT;
         } catch (SocketTimeoutException e) {
-            // Details are logged further down in the HTTPClient
-            log.info("Target {} is not reachable.",exc.getDestinations());
+            // Name the phase: a connect timeout means the target never accepted the connection, a read
+            // timeout means it accepted but did not answer. Both used to be logged as
+            // "is not reachable.", which is also what a refused connection logs, so the three were
+            // indistinguishable in the log.
+            boolean whileConnecting = e instanceof ConnectTimeoutException;
+            var msg = "Target %s timed out %s.".formatted(getDestination(exc),
+                    whileConnecting ? "while the connection was being established, no request was sent"
+                                    : "while waiting for the response, the request had already been sent");
+            log.info("{} Reason: {}", msg, e.getMessage());
             internal(router.getConfiguration().isProduction(), getDisplayName())
                     .title("Gateway Timeout")
                     .status(504)
-                    .addSubSee("socket-timeout")
+                    .addSubSee(whileConnecting ? "connect-timeout" : "socket-timeout")
+                    .detail(msg)
+                    .stacktrace(false)
                     .buildAndSetResponse(exc);
             return ABORT;
         } catch (UnknownHostException e) {

--- a/core/src/main/java/com/predic8/membrane/core/proxies/RuleManager.java
+++ b/core/src/main/java/com/predic8/membrane/core/proxies/RuleManager.java
@@ -14,22 +14,28 @@
 
 package com.predic8.membrane.core.proxies;
 
-import com.predic8.membrane.core.exchange.*;
-import com.predic8.membrane.core.exchangestore.*;
-import com.predic8.membrane.core.http.*;
-import com.predic8.membrane.core.model.*;
-import com.predic8.membrane.core.router.*;
-import com.predic8.membrane.core.transport.http.*;
-import com.predic8.membrane.core.transport.ssl.*;
-import com.predic8.membrane.core.util.*;
-import org.jetbrains.annotations.*;
-import org.slf4j.*;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.exchangestore.ExchangeStore;
+import com.predic8.membrane.core.http.Request;
+import com.predic8.membrane.core.router.Router;
+import com.predic8.membrane.core.transport.http.AbstractHttpHandler;
+import com.predic8.membrane.core.transport.http.IpPort;
+import com.predic8.membrane.core.transport.ssl.SSLContext;
+import com.predic8.membrane.core.transport.ssl.SSLContextCollection;
+import com.predic8.membrane.core.transport.ssl.SSLProvider;
+import com.predic8.membrane.core.util.URLUtil;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.*;
-import java.net.*;
-import java.util.*;
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
 
-import static com.predic8.membrane.core.util.URIUtil.*;
+import static com.predic8.membrane.core.util.URIUtil.normalizeSingleDot;
 
 public class RuleManager {
 
@@ -77,10 +83,13 @@ public class RuleManager {
         proxies.add(proxy);
     }
 
+    /**
+     * Called while the configuration is still being parsed, before {@link Proxy#init(Router)} ran.
+     * The key of an API is not complete yet at that point - APIProxy only builds its final key,
+     * including the test expression and the OpenAPI base paths, in init(). Duplicates therefore
+     * cannot be recognized here, see {@link #warnAboutUnreachableProxies()}.
+     */
     public synchronized void addProxy(Proxy proxy, RuleDefinitionSource source) {
-        if (skipDuplicate(proxy))
-            return;
-
         proxies.add(proxy);
     }
 
@@ -139,8 +148,9 @@ public class RuleManager {
 
 
     /**
-     * An API whose key is indistinguishable from one that is already registered can never be
-     * reached, so it is dropped. Warn about it: silently ignoring it looks like a lost API.
+     * An API added at runtime whose key is indistinguishable from one that is already registered
+     * can never be reached, so it is dropped. Warn about it: silently ignoring it looks like a
+     * lost API. Only safe for proxies that are already initialized, see {@link #addProxy(Proxy, RuleDefinitionSource)}.
      */
     private boolean skipDuplicate(Proxy proxy) {
         if (!exists(proxy.getKey()))
@@ -148,6 +158,25 @@ public class RuleManager {
         log.warn("Ignoring API '{}': another API is already configured for {}. Give them different ports, hosts or paths.",
                 proxy.getName(), proxy.getKey());
         return true;
+    }
+
+    /**
+     * Warns about every API that cannot be reached because an earlier one has an indistinguishable
+     * key. Call this after all proxies were initialized: only then are their keys complete. The
+     * APIs are kept - dispatching picks the first match anyway, and dropping one silently changes
+     * a working configuration.
+     */
+    public synchronized void warnAboutUnreachableProxies() {
+        for (int i = 1; i < proxies.size(); i++) {
+            Proxy proxy = proxies.get(i);
+            for (Proxy earlier : proxies.subList(0, i)) {
+                if (earlier.getKey().equals(proxy.getKey())) {
+                    log.warn("API '{}' can never be reached: API '{}' is already configured for {}. Give them different ports, hosts, paths ...",
+                            proxy.getName(), earlier.getName(), proxy.getKey());
+                    break;
+                }
+            }
+        }
     }
 
     public boolean exists(RuleKey key) {

--- a/core/src/main/java/com/predic8/membrane/core/router/DefaultRouter.java
+++ b/core/src/main/java/com/predic8/membrane/core/router/DefaultRouter.java
@@ -147,6 +147,7 @@ public class DefaultRouter extends AbstractRouter implements ApplicationContextA
             mainComponents.init();
 
             initProxies();
+            getRuleManager().warnAboutUnreachableProxies(); // keys are only complete after init
 
             initialized = true;
             reinitializer = new RuleReinitializer(this); // Bean

--- a/core/src/main/java/com/predic8/membrane/core/transport/http/ConnectTimeoutException.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/http/ConnectTimeoutException.java
@@ -1,0 +1,37 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.core.transport.http;
+
+import java.net.SocketTimeoutException;
+
+/**
+ * Indicates that establishing the connection to the target timed out, as opposed to the target
+ * accepting the connection but not answering in time. The JDK reports both as
+ * {@link SocketTimeoutException} and only distinguishes them by message text.
+ * <p>
+ * The distinction matters for retries: no byte of the request has been sent yet, so the target
+ * cannot have processed it and a retry is safe for any request method.
+ * <p>
+ * Extends {@link SocketTimeoutException} so that code catching the timeout in general keeps working.
+ */
+public class ConnectTimeoutException extends SocketTimeoutException {
+
+    private static final long serialVersionUID = 1L;
+
+    public ConnectTimeoutException(String message, Throwable cause) {
+        super(message);
+        initCause(cause);
+    }
+}

--- a/core/src/main/java/com/predic8/membrane/core/transport/http/Connection.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/http/Connection.java
@@ -102,25 +102,32 @@ public class Connection implements Closeable, MessageObserver, NonRelevantBodyOb
 			sniServername = null;
 		}
 
-		if (sslProvider != null) {
-			if (isNullOrEmpty(localHost))
-				con.socket = sslProvider.createSocket(host, port, connectTimeout, sniServername, applicationProtocols);
-			else
-				con.socket = sslProvider.createSocket(host, port, InetAddress.getByName(localHost), 0,
-						connectTimeout, sniServername, applicationProtocols);
-		} else {
-			if (isNullOrEmpty(localHost)) {
-				con.socket = new Socket();
+		// Everything up to here happens before the first byte of the request is written, so a timeout
+		// in this block means nothing was sent. ConnectTimeoutException carries that fact to the
+		// retry handling, which the JDK's undifferentiated SocketTimeoutException cannot.
+		try {
+			if (sslProvider != null) {
+				if (isNullOrEmpty(localHost))
+					con.socket = sslProvider.createSocket(host, port, connectTimeout, sniServername, applicationProtocols);
+				else
+					con.socket = sslProvider.createSocket(host, port, InetAddress.getByName(localHost), 0,
+							connectTimeout, sniServername, applicationProtocols);
 			} else {
-				con.socket = new Socket();
-				con.socket.bind(new InetSocketAddress(InetAddress.getByName(localHost), 0));
+				if (isNullOrEmpty(localHost)) {
+					con.socket = new Socket();
+				} else {
+					con.socket = new Socket();
+					con.socket.bind(new InetSocketAddress(InetAddress.getByName(localHost), 0));
+				}
+				con.socket.connect(new InetSocketAddress(host, port), connectTimeout);
 			}
-			con.socket.connect(new InetSocketAddress(host, port), connectTimeout);
-		}
 
-		if (proxy != null && origSSLProvider != null) {
-			con.doTunnelHandshake(proxy, con.socket, origHost, origPort);
-			con.socket = origSSLProvider.createSocket(con.socket, origHost, origPort, connectTimeout, origSniServername, applicationProtocols);
+			if (proxy != null && origSSLProvider != null) {
+				con.doTunnelHandshake(proxy, con.socket, origHost, origPort);
+				con.socket = origSSLProvider.createSocket(con.socket, origHost, origPort, connectTimeout, origSniServername, applicationProtocols);
+			}
+		} catch (SocketTimeoutException e) {
+			throw new ConnectTimeoutException("Connecting to %s:%d timed out after %dms.".formatted(host, port, connectTimeout), e);
 		}
 
 		log.debug("Opened connection on localPort: {}", con.socket.getLocalPort());

--- a/core/src/main/java/com/predic8/membrane/core/transport/http/Connection.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/http/Connection.java
@@ -127,13 +127,33 @@ public class Connection implements Closeable, MessageObserver, NonRelevantBodyOb
 				con.socket = origSSLProvider.createSocket(con.socket, origHost, origPort, connectTimeout, origSniServername, applicationProtocols);
 			}
 		} catch (SocketTimeoutException e) {
-			throw new ConnectTimeoutException("Connecting to %s:%d timed out after %dms.".formatted(host, port, connectTimeout), e);
+			// The socket can already be open here: a timeout during the proxy handshake or the TLS
+			// wrapping happens after it was connected. Without closing it the descriptor leaks, and a
+			// retried connect attempt would leak one more.
+			ConnectTimeoutException timedOut = new ConnectTimeoutException(
+					"Connecting to %s:%d timed out after %dms.".formatted(host, port, connectTimeout), e);
+			closeSocket(con.socket, timedOut);
+			throw timedOut;
 		}
 
 		log.debug("Opened connection on localPort: {}", con.socket.getLocalPort());
 
 		con.setupStreams();
 		return con;
+	}
+
+	/**
+	 * Closes a socket that is being abandoned because opening the connection failed. A failure to close
+	 * is attached to the original exception rather than replacing it.
+	 */
+	private static void closeSocket(@Nullable Socket socket, Exception cause) {
+		if (socket == null)
+			return;
+		try {
+			socket.close();
+		} catch (IOException closeFailure) {
+			cause.addSuppressed(closeFailure);
+		}
 	}
 
 	private void setupStreams() throws IOException {

--- a/core/src/main/java/com/predic8/membrane/core/transport/http/client/RetryHandler.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/http/client/RetryHandler.java
@@ -14,22 +14,29 @@
 
 package com.predic8.membrane.core.transport.http.client;
 
-import com.predic8.membrane.annot.*;
-import com.predic8.membrane.core.exchange.*;
-import com.predic8.membrane.core.transport.http.*;
-import org.slf4j.*;
+import com.predic8.membrane.annot.MCAttribute;
+import com.predic8.membrane.annot.MCElement;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.transport.http.ConnectTimeoutException;
+import com.predic8.membrane.core.transport.http.EOFWhileReadingFirstLineException;
+import com.predic8.membrane.core.transport.http.NoResponseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.*;
-import java.io.*;
+import javax.net.ssl.SSLHandshakeException;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.net.*;
-import java.nio.*;
-import java.security.cert.*;
-import java.util.*;
+import java.nio.ByteBuffer;
+import java.security.cert.CertificateException;
+import java.util.Objects;
+import java.util.Set;
 
-import static com.predic8.membrane.core.transport.http.HttpClientStatusEventBus.*;
-import static com.predic8.membrane.core.util.HttpUtil.*;
-import static java.lang.Thread.*;
-import static java.nio.charset.StandardCharsets.*;
+import static com.predic8.membrane.core.transport.http.HttpClientStatusEventBus.reportException;
+import static com.predic8.membrane.core.transport.http.HttpClientStatusEventBus.reportStatusCode;
+import static com.predic8.membrane.core.util.HttpUtil.isIdempotent;
+import static java.lang.Thread.sleep;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 /**
  * <p>Retries a backend request when network-level failures or selected HTTP status codes occur.</p>
@@ -44,7 +51,7 @@ import static java.nio.charset.StandardCharsets.*;
  * <ul>
  *   <li>Connection/IO exceptions (timeout, refused, reset...)</li>
  *   <li>A timeout while the connection was still being established (when
- *       {@code retryOnConnectTimeout=true}), for any request method</li>
+ *       <code>retryOnConnectTimeout=true</code>), for any request method</li>
  *   <li>HTTP 408 Request Timeout</li>
  *   <li>HTTP 500, 502, 503, 504, 507 (when {@code failOverOn5XX=true})</li>
  * </ul>

--- a/core/src/main/java/com/predic8/membrane/core/transport/http/client/RetryHandler.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/http/client/RetryHandler.java
@@ -43,6 +43,8 @@ import static java.nio.charset.StandardCharsets.*;
  * <p>A retry is triggered for:</p>
  * <ul>
  *   <li>Connection/IO exceptions (timeout, refused, reset...)</li>
+ *   <li>A timeout while the connection was still being established (when
+ *       {@code retryOnConnectTimeout=true}), for any request method</li>
  *   <li>HTTP 408 Request Timeout</li>
  *   <li>HTTP 500, 502, 503, 504, 507 (when {@code failOverOn5XX=true})</li>
  * </ul>
@@ -73,6 +75,12 @@ public class RetryHandler {
      * but only for idempotent methods. POST, PATCH and CONNECT will not be retried.
      */
     private boolean failOverOn5XX = false;
+
+    /**
+     * Retry when establishing the connection timed out. Safe for any request method, because no part
+     * of the request was sent. Unlike a read timeout, this cannot have changed state on the server.
+     */
+    private boolean retryOnConnectTimeout = true;
 
     private static final Set<Integer> RETRYABLE_5XX = Set.of(500, 502, 503, 504, 507);
 
@@ -167,9 +175,17 @@ public class RetryHandler {
             log.debug("Connection to {} refused.", dest);
             return !hasMultipleNodes(exc);
         }
-        // The socket read or connection took too long and exceeded the configured timeout.
-        // No data was received from the server in time.
-        // Causes: Server is overloaded, network latency or drop, TLS handshake took too long
+        // The connection was never established, so nothing was sent and no state was changed on the
+        // server. Retrying is safe for any method. Causes: dropped SYN, host unreachable, a TLS
+        // handshake that did not complete in time. Has to be checked before SocketTimeoutException,
+        // which it extends.
+        if (e instanceof ConnectTimeoutException) {
+            log.debug("Connection to {} timed out before it was established.", dest);
+            return !retryOnConnectTimeout;
+        }
+        // The socket read took too long and exceeded the configured timeout. No data was received
+        // from the server in time, but the request may already have been processed.
+        // Causes: Server is overloaded, network latency or drop
         if (e instanceof SocketTimeoutException) {
             log.debug("Connection to {} timed out.", dest);
             return !isIdempotent(exc.getRequest().getMethod()) || !hasMultipleNodes(exc);
@@ -303,6 +319,23 @@ public class RetryHandler {
         this.failOverOn5XX = failOverOn5XX;
     }
 
+    public boolean isRetryOnConnectTimeout() {
+        return retryOnConnectTimeout;
+    }
+
+    /**
+     * @description If <code>true</code> retry when the connection to the target could not be
+     *              established within the connection timeout. No part of the request has been sent in
+     *              that case, so this applies to every request method, including POST and PATCH. A
+     *              timeout while reading the response is not covered by this and stays restricted to
+     *              idempotent methods. Set to <code>false</code> to fail fast instead.
+     * @default true
+     */
+    @MCAttribute
+    public void setRetryOnConnectTimeout(boolean retryOnConnectTimeout) {
+        this.retryOnConnectTimeout = retryOnConnectTimeout;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
@@ -311,7 +344,8 @@ public class RetryHandler {
         return retries == that.retries &&
                delay == that.delay &&
                Double.compare(backoffMultiplier, that.backoffMultiplier) == 0 &&
-               Objects.equals(failOverOn5XX, that.failOverOn5XX);
+               Objects.equals(failOverOn5XX, that.failOverOn5XX) &&
+               retryOnConnectTimeout == that.retryOnConnectTimeout;
     }
 
     @Override
@@ -320,6 +354,7 @@ public class RetryHandler {
         result = 31 * result + delay;
         result = 31 * result + Double.hashCode(backoffMultiplier);
         result = 31 * result + Boolean.hashCode(failOverOn5XX);
+        result = 31 * result + Boolean.hashCode(retryOnConnectTimeout);
         return result;
     }
 }

--- a/core/src/test/java/com/predic8/membrane/core/RuleManagerTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/RuleManagerTest.java
@@ -13,15 +13,26 @@
    limitations under the License. */
 package com.predic8.membrane.core;
 
-import com.predic8.membrane.core.exchange.*;
+import com.predic8.membrane.core.exchange.Exchange;
 import com.predic8.membrane.core.proxies.*;
-import com.predic8.membrane.core.router.*;
-import org.junit.jupiter.api.*;
+import com.predic8.membrane.core.router.DefaultRouter;
+import com.predic8.membrane.core.router.Router;
+import com.predic8.membrane.core.router.TestRouter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-import java.net.*;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 
-import static com.predic8.membrane.core.http.Request.*;
-import static com.predic8.membrane.test.TestUtil.*;
+import static com.predic8.membrane.core.http.Request.get;
+import static com.predic8.membrane.core.router.YamlRouterBootstrap.loadIntoRouter;
+import static com.predic8.membrane.test.TestUtil.assembleExchange;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class RuleManagerTest {
@@ -85,6 +96,52 @@ public class RuleManagerTest {
 		manager.addProxy(second, RuleManager.RuleDefinitionSource.MANUAL);
 
 		assertEquals(5, manager.getRules().size());
+	}
+
+	/**
+	 * APIs sharing a port are told apart by their test expression, which only exists after init().
+	 * Deduplicating while the configuration is parsed would therefore throw them away, see
+	 * distribution/tutorials/soap/75-Routing-by-SOAPAction.yaml.
+	 */
+	@Test
+	@DisplayName("APIs on one port that only differ in their test expression all stay registered")
+	void apisDiscriminatedByTestExpressionAreKept(@TempDir Path tempDir) throws Exception {
+		Path config = tempDir.resolve("apis.yaml");
+		Files.writeString(config, """
+				api:
+				  name: get
+				  port: 2000
+				  test: header.SOAPAction == 'get'
+				  flow:
+				    - return:
+				        status: 200
+				---
+				api:
+				  name: create
+				  port: 2000
+				  test: header.SOAPAction == 'create'
+				  flow:
+				    - return:
+				        status: 200
+				---
+				api:
+				  name: fallback
+				  port: 2000
+				  flow:
+				    - return:
+				        status: 404
+				""");
+
+		DefaultRouter yamlRouter = new DefaultRouter();
+		try {
+			loadIntoRouter(yamlRouter, config.toString());
+			yamlRouter.start();
+
+			assertEquals(List.of("get", "create", "fallback"),
+					yamlRouter.getRuleManager().getRules().stream().map(p -> p.getName()).toList());
+		} finally {
+			yamlRouter.stop();
+		}
 	}
 
 	@Test

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/HTTPClientInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/HTTPClientInterceptorTest.java
@@ -20,6 +20,7 @@ import com.predic8.membrane.core.lang.ExchangeExpression.*;
 import com.predic8.membrane.core.openapi.serviceproxy.*;
 import com.predic8.membrane.core.proxies.*;
 import com.predic8.membrane.core.router.*;
+import com.predic8.membrane.core.transport.http.client.*;
 import com.predic8.membrane.core.util.*;
 import com.predic8.membrane.core.util.text.*;
 import com.predic8.membrane.core.util.text.SerializationUtil.*;
@@ -145,6 +146,56 @@ class HTTPClientInterceptorTest {
         var exc = post("/foo").buildExchange();
         testExpression(SPEL, exc, "${'&?äöü!'}",
                 "%26%3F%C3%A4%C3%B6%C3%BC%21", Serialization.URL);
+    }
+
+    /**
+     * A refused target, a target that never accepts and one that accepts but stays silent used to be
+     * logged and reported alike. They have to stay distinguishable by status, subSee and detail.
+     */
+    @Nested
+    class unreachableTarget {
+
+        @Test
+        void refusedTargetYields502() throws Exception {
+            int freePort;
+            try (var probe = new ServerSocket(0)) {
+                freePort = probe.getLocalPort();
+            } // closed again, so nothing listens on freePort
+
+            var exc = callTarget("http://localhost:" + freePort + "/", 0);
+
+            assertEquals(502, exc.getResponse().getStatusCode());
+            assertTrue(exc.getResponse().getBodyAsStringDecoded().contains("connect"));
+        }
+
+        @Test
+        void silentTargetYields504NamingTheReadPhase() throws Exception {
+            try (var silent = new ServerSocket(0)) {
+                // accepts the connection but never writes a response, so the client hits its read timeout
+                var exc = callTarget("http://localhost:" + silent.getLocalPort() + "/", 250);
+
+                assertEquals(504, exc.getResponse().getStatusCode());
+                var body = exc.getResponse().getBodyAsStringDecoded();
+                assertTrue(body.contains("socket-timeout"), body);
+                assertTrue(body.contains("waiting for the response"), body);
+            }
+        }
+
+        private Exchange callTarget(String url, int soTimeout) throws Exception {
+            var config = new HttpClientConfiguration();
+            config.getConnection().setSoTimeout(soTimeout);
+            // a read timeout must not be retried, so the assertions see the first failure
+            config.getRetryHandler().setRetries(0);
+            hci.setHttpClientConfig(config);
+            hci.init(router);
+
+            var exc = get(url).buildExchange();
+            exc.setProxy(new NullProxy());
+            exc.getDestinations().add(url);
+
+            hci.handleRequest(exc);
+            return exc;
+        }
     }
 
     @Nested

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/HTTPClientInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/HTTPClientInterceptorTest.java
@@ -20,6 +20,7 @@ import com.predic8.membrane.core.lang.ExchangeExpression.*;
 import com.predic8.membrane.core.openapi.serviceproxy.*;
 import com.predic8.membrane.core.proxies.*;
 import com.predic8.membrane.core.router.*;
+import com.predic8.membrane.core.transport.http.*;
 import com.predic8.membrane.core.transport.http.client.*;
 import com.predic8.membrane.core.util.*;
 import com.predic8.membrane.core.util.text.*;
@@ -179,6 +180,30 @@ class HTTPClientInterceptorTest {
                 assertTrue(body.contains("socket-timeout"), body);
                 assertTrue(body.contains("waiting for the response"), body);
             }
+        }
+
+        @Test
+        void connectTimeoutYields504NamingTheConnectPhase() throws Exception {
+            // A real dropped SYN is not reproducible here, so the client is made to report one
+            var hci = new HTTPClientInterceptor(new HttpClient() {
+                @Override
+                public void call(Exchange exc) throws Exception {
+                    throw new ConnectTimeoutException("Connecting to example.com:80 timed out after 10000ms.",
+                            new SocketTimeoutException("Connect timed out"));
+                }
+            });
+            hci.init(router);
+
+            var exc = get("http://example.com/").buildExchange();
+            exc.setProxy(new NullProxy());
+            exc.getDestinations().add("http://example.com/");
+
+            hci.handleRequest(exc);
+
+            assertEquals(504, exc.getResponse().getStatusCode());
+            var body = exc.getResponse().getBodyAsStringDecoded();
+            assertTrue(body.contains("connect-timeout"), body);
+            assertTrue(body.contains("no request was sent"), body);
         }
 
         private Exchange callTarget(String url, int soTimeout) throws Exception {

--- a/core/src/test/java/com/predic8/membrane/core/transport/http/ConnectionTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/transport/http/ConnectionTest.java
@@ -19,6 +19,10 @@ import com.predic8.membrane.core.proxies.*;
 import com.predic8.membrane.core.router.*;
 import org.junit.jupiter.api.*;
 
+import java.io.*;
+import java.net.*;
+import java.util.*;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ConnectionTest {
@@ -55,5 +59,43 @@ public class ConnectionTest {
 	public void testIsSame() {
 		assertTrue(conLocalhost.isSame("localhost", 2000));
 		assertTrue(con127_0_0_1.isSame("127.0.0.1", 2000));
+	}
+
+	/**
+	 * A timeout while connecting has to be distinguishable from one while reading the response, because
+	 * only the former guarantees that nothing was sent. The JDK reports both as SocketTimeoutException.
+	 * A listening socket whose accept queue is full drops further SYNs, which is what makes the connect
+	 * time out here.
+	 */
+	@Test
+	void connectTimeoutSurfacesAsConnectTimeoutException() throws Exception {
+		List<Socket> queued = new ArrayList<>();
+		try (ServerSocket neverAccepting = new ServerSocket(0, 1)) {
+			int port = neverAccepting.getLocalPort();
+			fillAcceptQueue(port, queued);
+
+			assertThrows(ConnectTimeoutException.class,
+					() -> Connection.open("127.0.0.1", port, null, null, 200));
+		} finally {
+			for (Socket s : queued)
+				s.close();
+		}
+	}
+
+	/**
+	 * Connects until the accept queue of the never-accepting socket is full, from which point on the
+	 * kernel drops further SYNs rather than queueing them.
+	 */
+	private static void fillAcceptQueue(int port, List<Socket> queued) throws IOException {
+		for (int i = 0; i < 10; i++) {
+			Socket s = new Socket();
+			try {
+				s.connect(new InetSocketAddress("127.0.0.1", port), 200);
+				queued.add(s);
+			} catch (SocketTimeoutException e) {
+				s.close();
+				return;
+			}
+		}
 	}
 }

--- a/core/src/test/java/com/predic8/membrane/core/transport/http/client/RetryHandlerTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/transport/http/client/RetryHandlerTest.java
@@ -107,6 +107,50 @@ class RetryHandlerTest {
 
     }
 
+    /**
+     * A timeout while connecting means nothing was sent, so it is retried for POST on a single node
+     * too. A timeout while reading might have been processed by the backend and stays restricted.
+     */
+    @Nested
+    class Timeouts {
+
+        @Test
+        void connectTimeoutIsRetriedForPostOnOneNode() {
+            RetryableExchangeCallMock mock = new RetryableExchangeCallMock(connectTimeout());
+            assertThrows(ConnectTimeoutException.class, () -> rh.executeWithRetries(post("/foo").buildExchange(), mock));
+            assertEquals(3, mock.attempts);
+        }
+
+        @Test
+        void connectTimeoutIsNotRetriedWhenDisabled() {
+            rh.setRetryOnConnectTimeout(false);
+            RetryableExchangeCallMock mock = new RetryableExchangeCallMock(connectTimeout());
+            assertThrows(ConnectTimeoutException.class, () -> rh.executeWithRetries(post("/foo").buildExchange(), mock));
+            assertEquals(1, mock.attempts);
+        }
+
+        @Test
+        void readTimeoutIsNotRetriedForPostOnOneNode() {
+            RetryableExchangeCallMock mock = new RetryableExchangeCallMock(new SocketTimeoutException("Read timed out"));
+            assertThrows(SocketTimeoutException.class, () -> rh.executeWithRetries(post("/foo").buildExchange(), mock));
+            assertEquals(1, mock.attempts);
+        }
+
+        @Test
+        void readTimeoutIsRetriedForGetOnMultipleNodes() throws Exception {
+            RetryableExchangeCallMock mock = new RetryableExchangeCallMock(new SocketTimeoutException("Read timed out"));
+            Exchange exc = get("/foo").buildExchange();
+            exc.setDestinations(List.of("http://node1.example.com/", "http://node2.example.com/"));
+            assertThrows(SocketTimeoutException.class, () -> rh.executeWithRetries(exc, mock));
+            assertEquals(3, mock.attempts);
+        }
+
+        private static ConnectTimeoutException connectTimeout() {
+            return new ConnectTimeoutException("Connecting to example.com:80 timed out after 10000ms.",
+                    new SocketTimeoutException("Connect timed out"));
+        }
+    }
+
     @Test
     void internalError() throws Exception {
         RetryableExchangeCallMock mock = new RetryableExchangeCallMock(500);
@@ -161,6 +205,17 @@ class RetryHandlerTest {
             assertNotEquals(new RetryHandler(), new RetryHandler() {{
                 setFailOverOn5XX(false);
             }});
+        }
+
+        @Test
+        void equals_returnsFalseForDifferentRetryOnConnectTimeout() {
+            // Plain instances, not anonymous subclasses: equals() compares getClass(), so a subclass
+            // would differ regardless of the field.
+            RetryHandler withRetry = new RetryHandler();
+            RetryHandler withoutRetry = new RetryHandler();
+            withoutRetry.setRetryOnConnectTimeout(false);
+            assertNotEquals(withRetry, withoutRetry);
+            assertNotEquals(withRetry.hashCode(), withoutRetry.hashCode());
         }
 
         @Test


### PR DESCRIPTION
## Problem

A timeout while *connecting* is transient and safe to retry — no byte of the request has been sent, so the target cannot have processed it. Membrane gave up on it instead.

The reason is that the JDK reports both phases as a bare `java.net.SocketTimeoutException`, differing only in message text ("Connect timed out" vs "Read timed out"). `RetryHandler` could therefore only apply the conservative read-timeout rule — retry only idempotent methods, and only when several nodes are configured — so a `POST` to a single backend was never retried.

This is the root cause of the flaky `Wsdl2OpenAPIXsdFeaturesTutorialTest` in #3168. A gateway self-calling a mock on a fixed loopback port eventually draws an ephemeral port whose 4-tuple against that port is still in `TIME_WAIT`; the kernel silently drops the SYN, the connect times out after the full 10s, and the backend never sees the connection at all. Captured during a hang:

```
127.0.0.1.62506 -> 127.0.0.1.2001   SYN_SENT     <- the new outbound connect
127.0.0.1.2001  -> 127.0.0.1.62506  TIME_WAIT    <- an earlier connection, same 4-tuple
*.2001                              LISTEN  Recv-Q=0
"Connection Acceptor '*:2001'"      RUNNABLE at sun.nio.ch.Net.accept()
```

The readiness race suggested in the issue and a full accept backlog were both ruled out: `Recv-Q` is 0, the acceptor thread is healthy, and both ports are bound before `up and running!` is logged.

## Change

- **`ConnectTimeoutException extends SocketTimeoutException`** — thrown by `Connection.open` for everything that happens before the request is written: the plain `connect`, both TLS `createSocket` paths, and the post-tunnel handshake. Extending `SocketTimeoutException` keeps every existing catch site working.
- **`RetryHandler`** retries it for *any* request method, controlled by a new attribute, default `true`:
  ```yaml
  retries:
    retryOnConnectTimeout: false   # fail fast instead
  ```
- **Read timeouts keep the existing rule.** There the backend may already have processed the request, so retrying a non-idempotent method could duplicate a side effect.
- **`HTTPClientInterceptor` now names the phase.** Previously a connect timeout, a read timeout and a refused connection all logged `Target ... is not reachable.`, which is what made this issue misdiagnose:
  ```
  Target http://127.0.0.1:2999/ timed out while the connection was being established, no request was sent. Reason: Connecting to 127.0.0.1:2999 timed out after 10000ms.
  Target http://localhost:62910/ timed out while waiting for the response, the request had already been sent. Reason: Read timed out
  ```
  `subSee` is now `connect-timeout` vs `socket-timeout`, and the 504 problem details carry a `detail` (they had none).

## Verification

- `ConnectionTest.connectTimeoutSurfacesAsConnectTimeoutException` is a real regression test — with the `Connection` change stashed it fails with *expected `ConnectTimeoutException` but was `java.net.SocketTimeoutException`*.
- `RetryHandlerTest` covers connect timeout retried for `POST` on one node, not retried when the flag is off, and read timeouts unchanged.
- End-to-end against a backend whose accept queue is full: **30.4s = 3 attempts × 10s**, with `Attempt #0/#1/#2` and *"timed out before it was established"* in the log. Before the change: one attempt, immediate 504.

## Notes

- An unlucky call is now slower rather than failed — up to 3 × `connectTimeout` (30s at defaults) before the 504. `retryOnConnectTimeout: false` restores fail-fast.
- The tutorial and IT from #3168 live on a feature branch, not on master, so the flake itself cannot be exercised here. Confirming it requires running that IT (~1 in 5 runs failed at baseline) once this is merged into that branch.
- Not addressed here: the tutorial ITs start Membrane in `@BeforeEach`, i.e. once per test method, which is what accumulates the `TIME_WAIT` entries in the first place. Worth a separate issue.

Refs #3168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling by distinguishing connection-establishment failures from response-read timeouts.
  * HTTP error responses now include clearer status codes and diagnostic details for connection and response delays.
  * Connection timeout errors include the affected endpoint and timeout information.

* **New Features**
  * Connection-establishment timeouts can be retried for all request methods by default.
  * Added configuration to enable or disable connection-timeout retries.
  * Read-timeout retry behavior remains governed by request safety and destination availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->