### PR TITLE
Start Membrane once per test class in example/tutorial ITs

### DIFF
--- a/distribution/src/test/java/com/predic8/membrane/examples/util/AbstractSampleMembraneStartStopTestcase.java
+++ b/distribution/src/test/java/com/predic8/membrane/examples/util/AbstractSampleMembraneStartStopTestcase.java
@@ -14,22 +14,68 @@
 
 package com.predic8.membrane.examples.util;
 
-import org.junit.jupiter.api.*;
-
-import java.io.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 public abstract class AbstractSampleMembraneStartStopTestcase extends DistributionExtractingTestcase {
 
     protected Process2 process;
 
+    /**
+     * Console output of the running gateway. Recreated with every gateway start.
+     */
+    protected BufferLogger logger;
+
+    /**
+     * Whether every {@code @Test} needs its own gateway process.
+     * <p>
+     * Defaults to <code>false</code>: one gateway is started per test class. Starting one per
+     * test method costs ~800ms each and leaves a server side TIME_WAIT entry on the fixed
+     * tutorial ports for every connection of the killed process, which on macOS accumulates
+     * until new outbound connects draw a colliding 4-tuple and have their SYN dropped.
+     * <p>
+     * Override and return <code>true</code> for tests that assert on startup output, patch the
+     * configuration before startup, or otherwise depend on a pristine gateway.
+     */
+    protected boolean restartForEachTest() {
+        return false;
+    }
+
+    @BeforeAll
+    void startMembraneForClass() throws Exception {
+        if (!restartForEachTest())
+            startMembrane();
+    }
+
+    @AfterAll
+    void stopMembraneAfterClass() {
+        if (!restartForEachTest())
+            stopMembrane();
+    }
+
     @BeforeEach
-    void startMembrane() throws IOException, InterruptedException {
-        process = startServiceProxyScript();
+    void startMembraneForTest() throws Exception {
+        if (restartForEachTest())
+            startMembrane();
     }
 
     @AfterEach
-    void stopMembrane() {
-        if (process != null)
+    void stopMembraneAfterTest() {
+        if (restartForEachTest())
+            stopMembrane();
+    }
+
+    protected void startMembrane() throws Exception {
+        logger = new BufferLogger();
+        process = startServiceProxyScript(logger);
+    }
+
+    protected void stopMembrane() {
+        if (process != null) {
             process.killScript();
+            process = null;
+        }
     }
 }

--- a/distribution/src/test/java/com/predic8/membrane/examples/util/DistributionExtractingTestcase.java
+++ b/distribution/src/test/java/com/predic8/membrane/examples/util/DistributionExtractingTestcase.java
@@ -16,7 +16,7 @@ package com.predic8.membrane.examples.util;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +37,12 @@ import static org.apache.commons.io.FileUtils.writeStringToFile;
 
 /**
  * Extracts the .zip distribution built by Maven.
+ * <p>
+ * A single instance per test class ({@link TestInstance.Lifecycle#PER_CLASS}) so that the
+ * distribution and the gateway can be set up in {@code @BeforeAll} while still using the
+ * instance methods that describe the example under test.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class DistributionExtractingTestcase {
 
     protected static final Logger log = LoggerFactory.getLogger(DistributionExtractingTestcase.class.getName());
@@ -45,8 +50,8 @@ public abstract class DistributionExtractingTestcase {
     public static final String MEMBRANE_LOG_LEVEL = "info";
     public static final String LOCALHOST_2000 = "http://localhost:2000";
 
-    private static File unzipDir;
-    private static File membraneHome;
+    private File unzipDir;
+    private File membraneHome;
     protected File baseDir;
 
     /**
@@ -69,7 +74,7 @@ public abstract class DistributionExtractingTestcase {
     }
 
     @BeforeAll
-    public static void beforeAll() throws Exception {
+    public void beforeAll() throws Exception {
         log.info("unzipping router distribution");
 
         File targetDir = getTargetDir();
@@ -84,19 +89,16 @@ public abstract class DistributionExtractingTestcase {
         membraneHome = requireNonNull(unzipDir.listFiles((dir, name) -> name.startsWith("membrane-api-gateway")))[0];
 
         replaceLog4JConfig();
+
+        baseDir = getExampleDir(getExampleDirName());
+        log.info("running test... in {}", baseDir);
     }
 
     @AfterAll
-    public static void done() {
+    public void done() {
         log.info("cleaning up...");
         recursiveDelete(unzipDir);
         log.info("cleaning up... done");
-    }
-
-    @BeforeEach
-    void init() {
-        baseDir = getExampleDir(getExampleDirName());
-        log.info("running test... in {}", baseDir);
     }
 
     private static File getTargetDir() throws IOException {
@@ -123,7 +125,7 @@ public abstract class DistributionExtractingTestcase {
             throw new RuntimeException("Could not mkdir " + dir.getAbsolutePath());
     }
 
-    private static void replaceLog4JConfig() throws IOException {
+    private void replaceLog4JConfig() throws IOException {
         File log4jproperties = new File(membraneHome, "conf" + separator + "log4j2.xml");
         if (!log4jproperties.exists())
             throw new RuntimeException("log4j2.xml does not exits.");

--- a/distribution/src/test/java/com/predic8/membrane/examples/withoutinternet/opentelemetry/OpenTelemetryExampleTest.java
+++ b/distribution/src/test/java/com/predic8/membrane/examples/withoutinternet/opentelemetry/OpenTelemetryExampleTest.java
@@ -15,12 +15,8 @@ package com.predic8.membrane.examples.withoutinternet.opentelemetry;
 
 
 import com.predic8.membrane.examples.util.AbstractSampleMembraneStartStopTestcase;
-import com.predic8.membrane.examples.util.BufferLogger;
-import com.predic8.membrane.examples.util.Process2;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.util.List;
 
 import static com.predic8.membrane.examples.withoutinternet.opentelemetry.Traceparent.parse;
@@ -33,14 +29,6 @@ public class OpenTelemetryExampleTest extends AbstractSampleMembraneStartStopTes
     @Override
     protected String getExampleDirName() {
         return "monitoring-tracing/opentelemetry";
-    }
-
-    BufferLogger logger;
-
-    @BeforeEach
-    void startMembrane() throws IOException, InterruptedException {
-        logger = new BufferLogger();
-        process = new Process2.Builder().in(baseDir).script("membrane").withWatcher(logger).waitForMembrane().start();
     }
 
     @Test

--- a/distribution/src/test/java/com/predic8/membrane/examples/withoutinternet/test/GroovyExampleTest.java
+++ b/distribution/src/test/java/com/predic8/membrane/examples/withoutinternet/test/GroovyExampleTest.java
@@ -15,15 +15,10 @@
 package com.predic8.membrane.examples.withoutinternet.test;
 
 import com.predic8.membrane.examples.util.AbstractSampleMembraneStartStopTestcase;
-import com.predic8.membrane.examples.util.BufferLogger;
-import com.predic8.membrane.examples.util.Process2;
 import io.restassured.response.Response;
 import org.json.JSONException;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
-
-import java.io.IOException;
 
 import static com.predic8.membrane.core.http.MimeType.APPLICATION_JSON;
 import static com.predic8.membrane.test.StringAssertions.assertContains;
@@ -37,17 +32,6 @@ public class GroovyExampleTest extends AbstractSampleMembraneStartStopTestcase {
     @Override
     protected String getExampleDirName() {
         return "scripting/groovy";
-    }
-
-    BufferLogger logger;
-
-    @BeforeEach
-    void startMembrane() throws IOException, InterruptedException {
-        logger = new BufferLogger();
-        process = new Process2.Builder().in(baseDir).script("membrane").withWatcher(logger).waitForMembrane().start();
-
-        // Dump HTTP
-        //filters(new RequestLoggingFilter(), new ResponseLoggingFilter());
     }
 
     @Test

--- a/distribution/src/test/java/com/predic8/membrane/examples/withoutinternet/test/JavascriptExampleTest.java
+++ b/distribution/src/test/java/com/predic8/membrane/examples/withoutinternet/test/JavascriptExampleTest.java
@@ -14,35 +14,23 @@
 
 package com.predic8.membrane.examples.withoutinternet.test;
 
-import com.predic8.membrane.examples.util.*;
-import io.restassured.response.*;
-import org.json.*;
-import org.junit.jupiter.api.*;
-import org.skyscreamer.jsonassert.*;
+import com.predic8.membrane.examples.util.AbstractSampleMembraneStartStopTestcase;
+import io.restassured.response.Response;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
-import java.io.*;
-
-import static com.predic8.membrane.core.http.MimeType.*;
-import static com.predic8.membrane.test.StringAssertions.*;
-import static io.restassured.RestAssured.*;
-import static org.hamcrest.Matchers.*;
+import static com.predic8.membrane.core.http.MimeType.APPLICATION_JSON;
+import static com.predic8.membrane.test.StringAssertions.assertContains;
+import static io.restassured.RestAssured.get;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
 
 public class JavascriptExampleTest extends AbstractSampleMembraneStartStopTestcase {
 
     @Override
     protected String getExampleDirName() {
         return "scripting/javascript";
-    }
-
-    BufferLogger logger;
-
-    @BeforeEach
-    void startMembrane() throws IOException, InterruptedException {
-        logger = new BufferLogger();
-        process = new Process2.Builder().in(baseDir).script("membrane").withWatcher(logger).waitForMembrane().start();
-
-        // Dump HTTP
-        //filters(new RequestLoggingFilter(), new ResponseLoggingFilter());
     }
 
     @Test

--- a/distribution/src/test/java/com/predic8/membrane/tutorials/operation/LokiTutorialTest.java
+++ b/distribution/src/test/java/com/predic8/membrane/tutorials/operation/LokiTutorialTest.java
@@ -22,8 +22,6 @@ import com.predic8.membrane.core.interceptor.Outcome;
 import com.predic8.membrane.core.proxies.ServiceProxy;
 import com.predic8.membrane.core.proxies.ServiceProxyKey;
 import com.predic8.membrane.core.router.DefaultRouter;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -57,17 +55,17 @@ public class LokiTutorialTest extends AbstractOperationTutorialTest {
     }
 
     /**
-     * Hides {@code AbstractSampleMembraneStartStopTestcase.startMembrane()} so the Loki stand-in
-     * is listening before Membrane starts and no push can be missed.
+     * Brings the Loki stand-in up before Membrane starts, so no push can be missed.
      */
-    @BeforeEach
-    void startMembrane() throws Exception {
+    @Override
+    protected void startMembrane() throws Exception {
         startLokiMock();
-        process = startServiceProxyScript();
+        super.startMembrane();
     }
 
-    @AfterEach
-    void stopLokiMock() {
+    @Override
+    protected void stopMembrane() {
+        super.stopMembrane();
         if (lokiMock != null)
             lokiMock.stop();
     }

--- a/distribution/src/test/java/com/predic8/membrane/tutorials/operation/OpenTelemetryTutorialTest.java
+++ b/distribution/src/test/java/com/predic8/membrane/tutorials/operation/OpenTelemetryTutorialTest.java
@@ -14,13 +14,10 @@
 
 package com.predic8.membrane.tutorials.operation;
 
-import com.predic8.membrane.examples.util.BufferLogger;
 import com.predic8.membrane.examples.util.SubstringWaitableConsoleEvent;
 import com.predic8.membrane.examples.withoutinternet.opentelemetry.Traceparent;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.util.List;
 
 import static com.predic8.membrane.examples.withoutinternet.opentelemetry.Traceparent.parse;
@@ -37,17 +34,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class OpenTelemetryTutorialTest extends AbstractOperationTutorialTest {
 
-    private BufferLogger logger;
-
     @Override
     protected String getTutorialYaml() {
         return "40-OpenTelemetry.yaml";
     }
 
-    @BeforeEach
-    void startMembrane() throws IOException, InterruptedException {
-        logger = new BufferLogger();
-        process = startServiceProxyScript(logger);
+    /**
+     * {@link #traceparentIsPropagatedToBackend()} compares the first two traceparents in the
+     * captured console output, so it needs a gateway whose log holds only its own requests.
+     */
+    @Override
+    protected boolean restartForEachTest() {
+        return true;
     }
 
     @Test


### PR DESCRIPTION
Fixes #3171.

`AbstractSampleMembraneStartStopTestcase` started and killed a real gateway process in `@BeforeEach`/`@AfterEach`, so each of the ~146 test methods across its ~55 subclasses paid a full start/stop cycle (~800ms each). Beyond wall-clock, every killed instance leaves server-side `TIME_WAIT` entries on the fixed tutorial ports; on macOS these were observed not to expire, until a new outbound connect draws a colliding 4-tuple and has its SYN silently dropped — the amplifier behind the #3168 flake.

## What changed

- `DistributionExtractingTestcase` is now `@TestInstance(PER_CLASS)`; `beforeAll`/`done` are instance methods and the old `@BeforeEach init()` that set `baseDir` is folded into `beforeAll`, so the example directory is known before any subclass `@BeforeAll` runs. `unzipDir`/`membraneHome` became instance fields.
- `AbstractSampleMembraneStartStopTestcase` starts/stops the gateway in `@BeforeAll`/`@AfterAll`, with an opt-out `restartForEachTest()` (default `false`) that routes start/stop back to `@BeforeEach`/`@AfterEach` for tests needing a pristine instance. It also always attaches a `BufferLogger` (`protected logger`), which removed the reason several subclasses overrode the start hook.
- `GroovyExampleTest`, `JavascriptExampleTest`, `OpenTelemetryExampleTest`: dropped their `@BeforeEach startMembrane()` and `logger` field in favour of the base class.
- `LokiTutorialTest`: its Loki stand-in now hangs off overridden `startMembrane()`/`stopMembrane()`, so it is correct in either mode.
- `OpenTelemetryTutorialTest`: opts into `restartForEachTest()` — it compares the first two traceparents in the captured console output, which would otherwise include earlier tests' requests.

## Verification

`mvn -pl distribution test-compile` is clean, and 29 IT classes (~120 tests) were run individually, selected to cover every shared-state pattern in the affected subclasses: console-log assertions (`Groovy`, `Javascript`, `AccessLog`, `Chain`, both OpenTelemetry, `CorrelationId`, `Propagation`, `Loki`, the orchestration `SubstringWaitableConsoleEvent` tests), rate limiting / 429 (`SharingApiKeys`), file state (`AccessLog`, `FileExchangeStore`), sessions (`McpProtection`), and classes extending `DistributionExtractingTestcase` directly (`VerifyConfiguration`, `JavaLicenseInfo`, `OAuth2API`, `Loadbalancing6HealthMonitor`). All pass; `OpenAPIValidationExampleTest`'s 12 tests now finish in 2.2s on a single gateway.

The full example IT suite has not been run locally — CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Test Improvements**
  * Improved gateway lifecycle management across integration and tutorial tests.
  * Added support for sharing a gateway across a test class or restarting it before each test.
  * Standardized startup and shutdown handling, including logger reset and process cleanup.
  * Simplified individual tests by centralizing common setup and teardown behavior.
  * Updated Loki and OpenTelemetry scenarios to use the shared lifecycle configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->