### PR TITLE
Handle `ProblemDetails` creation to include `path` only in non-production mode

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/server/WebServerInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/server/WebServerInterceptor.java
@@ -30,6 +30,7 @@ import java.nio.file.*;
 import java.util.*;
 import java.util.regex.*;
 
+import com.predic8.membrane.core.exceptions.*;
 import static com.predic8.membrane.core.exceptions.ProblemDetails.*;
 import static com.predic8.membrane.core.http.MimeType.*;
 import static com.predic8.membrane.core.http.Response.ok;
@@ -247,11 +248,13 @@ public class WebServerInterceptor extends AbstractInterceptor {
         try {
             return createResponseInternal(rr, resPath);
         } catch (Exception e) {
-            return internal(router.getConfiguration().isProduction(), getDisplayName())
+            boolean production = router.getConfiguration().isProduction();
+            ProblemDetails pd = internal(production, getDisplayName())
                     .title("Could not resolve file")
-                    .topLevel("path", resPath)
-                    .exception(e)
-                    .build();
+                    .exception(e);
+            if (!production)
+                pd.topLevel("path", resPath);
+            return pd.build();
         }
     }
 

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/server/WebServerInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/server/WebServerInterceptorTest.java
@@ -15,6 +15,8 @@ package com.predic8.membrane.core.interceptor.server;
 
 import com.fasterxml.jackson.databind.*;
 import com.predic8.membrane.core.exchange.*;
+import com.predic8.membrane.core.http.*;
+import com.predic8.membrane.core.resolver.*;
 import com.predic8.membrane.core.router.*;
 import org.junit.jupiter.api.*;
 
@@ -53,6 +55,28 @@ class WebServerInterceptorTest {
         // No index file is set, and no index page is generated, so throw not found.
         // System.out.println("exc.getResponse().getBodyAsStringDecoded() = " + exc.getResponse().getBodyAsStringDecoded());
         assertEquals(404, exc.getResponse().getStatusCode());
+    }
+
+    @Test
+    void errorResponseInDevelopmentIncludesPath() throws Exception {
+        Response response = ws.createResponse(r.getResolverMap(), "file:/nonexistent/path/secret.html");
+        String body = response.getBodyAsStringDecoded();
+        JsonNode json = om.readTree(body);
+        assertEquals(500, response.getStatusCode());
+        assertTrue(json.has("path"), "path field must be present in development mode");
+        assertEquals("file:/nonexistent/path/secret.html", json.get("path").asText());
+    }
+
+    @Test
+    void errorResponseInProductionHidesPath() throws Exception {
+        WebServerInterceptor wsProduction = new WebServerInterceptor(DummyTestRouter.productionRouter()) {{
+            setDocBase(Objects.requireNonNull(this.getClass().getResource("/html/")).toString());
+        }};
+        Response response = wsProduction.createResponse(r.getResolverMap(), "file:/nonexistent/path/secret.html");
+        String body = response.getBodyAsStringDecoded();
+        JsonNode json = om.readTree(body);
+        assertEquals(500, response.getStatusCode());
+        assertFalse(json.has("path"), "path field must be absent in production mode");
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error responses now include the requested path only in development environments.
  * Production error responses no longer expose path details, improving security and privacy.
* **Tests**
  * Added coverage to verify path visibility differs correctly between development and production modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->