### PR TITLE
Fix path exposure in WebServerInterceptor log

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/server/WebServerInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/server/WebServerInterceptor.java
@@ -249,7 +249,7 @@ public class WebServerInterceptor extends AbstractInterceptor {
         } catch (Exception e) {
             return internal(router.getConfiguration().isProduction(), getDisplayName())
                     .title("Could not resolve file")
-                    .topLevel("path", resPath)
+                    .internal("path", resPath)
                     .exception(e)
                     .build();
         }

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/server/WebServerInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/server/WebServerInterceptorTest.java
@@ -67,4 +67,26 @@ class WebServerInterceptorTest {
         assertTrue(body.contains("<a href=\"./index.html\">index.html</a>"));
         assertTrue(body.contains("<a href=\"./page.html\">page.html</a>"));
     }
+
+    @Test
+    void createResponseHidesPathInProduction() throws Exception {
+        Router prod = DummyTestRouter.productionRouter();
+        WebServerInterceptor prodWs = new WebServerInterceptor(prod);
+
+        JsonNode body = om.readTree(prodWs.createResponse(prod.getResolverMap(), "file:/installation/product/client/nonexisting")
+                .getBodyAsStringDecoded());
+
+        // The absolute installation path must not leak to the client in production mode.
+        assertFalse(body.has("path"));
+        assertFalse(body.toString().contains("installation/product/client"));
+    }
+
+    @Test
+    void createResponseExposesPathInDevelopment() throws Exception {
+        JsonNode body = om.readTree(ws.createResponse(r.getResolverMap(), "file:/installation/product/client/nonexisting")
+                .getBodyAsStringDecoded());
+
+        // In development mode the path stays available to aid debugging.
+        assertEquals("file:/installation/product/client/nonexisting", body.get("path").asText());
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource-not-found error responses by limiting installation path details to development mode.
  * Production error messages no longer expose internal filesystem paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->