### PR TITLE
Fix matchesPath to prevent base path conflicts

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/wsdl2openapi/Wsdl2OpenapiInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/wsdl2openapi/Wsdl2OpenapiInterceptor.java
@@ -367,10 +367,13 @@ public class Wsdl2OpenapiInterceptor extends AbstractInterceptor {
      * Makes the OpenAPI document reachable next to the API's own path. Only base paths are added:
      * the key's path itself is never rewritten, so this stays safe when init() runs again on the
      * same proxy (APIProxy rebuilds its key on each init, so the list cannot accumulate either).
+     * PATH goes into the key's api docs paths so that it stays reachable even when the API has a
+     * custom path configured.
      */
     private void registerApiDocsPaths() {
         if (proxy.getKey() instanceof APIProxyKey apiKey) {
-            apiKey.addBasePaths(new ArrayList<>(List.of(PATH, basePath)));
+            apiKey.addApiDocsPaths(new ArrayList<>(List.of(PATH)));
+            apiKey.addBasePaths(new ArrayList<>(List.of(basePath)));
         }
     }
 

--- a/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/APIProxyKey.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/APIProxyKey.java
@@ -37,6 +37,13 @@ public class APIProxyKey extends ServiceProxyKey {
     private final ArrayList<String> basePaths = new ArrayList<>();
 
     /**
+     * Paths of the OpenAPIPublisherInterceptor (e.g. /api-docs). These stay reachable even when a
+     * custom path is configured, but - unlike {@link #basePaths} - they must not override the
+     * configured path when discriminating between several APIs sharing the same base path.
+     */
+    private final ArrayList<String> apiDocsPaths = new ArrayList<>();
+
+    /**
      * For complex matches use SpEL
      */
     private ExchangeExpression exchangeExpression;
@@ -63,11 +70,11 @@ public class APIProxyKey extends ServiceProxyKey {
         if (!openAPI)
             return;
 
-        // Add basePaths of OpenAPIPublisherInterceptor to accept them also
-        basePaths.add(PATH);    // new path
-        basePaths.add(PATH_UI); // "
-        basePaths.add("/api-doc");                          // old to stay compatible
-        basePaths.add("/api-doc/ui");                       // "
+        // Add paths of OpenAPIPublisherInterceptor to accept them also
+        apiDocsPaths.add(PATH);    // new path
+        apiDocsPaths.add(PATH_UI); // "
+        apiDocsPaths.add("/api-doc");                          // old to stay compatible
+        apiDocsPaths.add("/api-doc/ui");                       // "
     }
 
     @Override
@@ -80,10 +87,13 @@ public class APIProxyKey extends ServiceProxyKey {
             return false;
         }
 
-        if (basePaths.isEmpty())
+        if (basePaths.isEmpty() && apiDocsPaths.isEmpty())
             return true;
 
         var uri = exc.getRequest().getUri();
+        if (matchesApiDocsPath(uri))
+            return true;
+
         for (String basePath : basePaths) {
             if (!uri.startsWith(basePath))
                 continue;
@@ -91,6 +101,14 @@ public class APIProxyKey extends ServiceProxyKey {
             log.debug("Rule matches {}", uri);
             return true;
 
+        }
+        return false;
+    }
+
+    private boolean matchesApiDocsPath(String path) {
+        for (String apiDocsPath : apiDocsPaths) {
+            if (path.startsWith(apiDocsPath))
+                return true;
         }
         return false;
     }
@@ -135,10 +153,9 @@ public class APIProxyKey extends ServiceProxyKey {
 
     @Override
     public boolean matchesPath(String path) {
-        for (String basePath : basePaths) {
-            if (path.startsWith(basePath))
-                return true;
-        }
+        // OpenAPI docs stay reachable even when a custom path is configured, see issue #3173.
+        if (matchesApiDocsPath(path))
+            return true;
         try {
             matchTemplate(getPath(), path); // ignore result
             return true;

--- a/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/APIProxyKey.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/APIProxyKey.java
@@ -123,6 +123,15 @@ public class APIProxyKey extends ServiceProxyKey {
         basePaths.addAll(paths);
     }
 
+    /**
+     * Registers additional paths under which an OpenAPI document is published. Use this instead of
+     * {@link #addBasePaths(ArrayList)} for documentation paths: they stay reachable even when a
+     * custom path is configured.
+     */
+    public void addApiDocsPaths(ArrayList<String> paths) {
+        apiDocsPaths.addAll(paths);
+    }
+
     public String getKeyId() {
         return (
                 getMethod() + "-"

--- a/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/APIProxyKey.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/serviceproxy/APIProxyKey.java
@@ -155,6 +155,8 @@ public class APIProxyKey extends ServiceProxyKey {
         if (obj instanceof APIProxyKey other) {
             if (!basePaths.equals(other.basePaths))
                 return false;
+            if (!apiDocsPaths.equals(other.apiDocsPaths))
+                return false;
             return Objects.equals(exchangeExpression, other.exchangeExpression);
         }
         return false;
@@ -176,6 +178,6 @@ public class APIProxyKey extends ServiceProxyKey {
 
     @Override
     public int hashCode() {
-        return super.hashCode() + Objects.hashCode( exchangeExpression.hashCode()) + basePaths.hashCode();
+        return Objects.hash(super.hashCode(), basePaths, apiDocsPaths, exchangeExpression);
     }
 }

--- a/core/src/main/java/com/predic8/membrane/core/proxies/AbstractRuleKey.java
+++ b/core/src/main/java/com/predic8/membrane/core/proxies/AbstractRuleKey.java
@@ -16,6 +16,7 @@ package com.predic8.membrane.core.proxies;
 import com.predic8.membrane.core.exchange.*;
 import org.slf4j.*;
 
+import java.util.*;
 import java.util.regex.*;
 
 public abstract class AbstractRuleKey implements RuleKey {
@@ -55,6 +56,28 @@ public abstract class AbstractRuleKey implements RuleKey {
                 pathPattern = arKey.getPathPattern();
             }
         }
+    }
+
+    /**
+     * Identity of a rule key is its port, ip and path. Subclasses add their own discriminators
+     * (host, method, base paths, ...) on top and must call super.equals() first.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!(obj instanceof AbstractRuleKey other))
+            return false;
+        return port == other.port
+               && pathRegExp == other.pathRegExp
+               && usePathPattern == other.usePathPattern
+               && Objects.equals(ip, other.ip)
+               && Objects.equals(path, other.path);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(port, pathRegExp, usePathPattern, ip, path);
     }
 
     public String getHost() {

--- a/core/src/main/java/com/predic8/membrane/core/proxies/RuleManager.java
+++ b/core/src/main/java/com/predic8/membrane/core/proxies/RuleManager.java
@@ -69,7 +69,7 @@ public class RuleManager {
     }
 
     public synchronized void addProxyAndOpenPortIfNew(SSLableProxy proxy, RuleDefinitionSource source) throws IOException {
-        if (exists(proxy.getKey()))
+        if (skipDuplicate(proxy))
             return;
 
         router.getTransport().openPort(proxy);
@@ -78,7 +78,7 @@ public class RuleManager {
     }
 
     public synchronized void addProxy(Proxy proxy, RuleDefinitionSource source) {
-        if (exists(proxy.getKey()))
+        if (skipDuplicate(proxy))
             return;
 
         proxies.add(proxy);
@@ -137,6 +137,18 @@ public class RuleManager {
         return builder;
     }
 
+
+    /**
+     * An API whose key is indistinguishable from one that is already registered can never be
+     * reached, so it is dropped. Warn about it: silently ignoring it looks like a lost API.
+     */
+    private boolean skipDuplicate(Proxy proxy) {
+        if (!exists(proxy.getKey()))
+            return false;
+        log.warn("Ignoring API '{}': another API is already configured for {}. Give them different ports, hosts or paths.",
+                proxy.getName(), proxy.getKey());
+        return true;
+    }
 
     public boolean exists(RuleKey key) {
         return getRule(key) != null;

--- a/core/src/test/java/com/predic8/membrane/core/RuleManagerTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/RuleManagerTest.java
@@ -64,6 +64,30 @@ public class RuleManagerTest {
 	}
 
 	@Test
+	@DisplayName("An API with a key that is already registered is not added")
+	void duplicateKeyIsNotAdded() throws Exception {
+		var duplicate = new ServiceProxy(new ServiceProxyKey("localhost", "*", ".*", 3014), "thomas-bayer.com", 80);
+		duplicate.init(router);
+
+		manager.addProxyAndOpenPortIfNew(duplicate);
+
+		assertEquals(4, manager.getRules().size());
+		assertSame(forwardBlz, manager.getRules().get(1));
+	}
+
+	@Test
+	@DisplayName("Internal proxies are told apart by identity, not by their key")
+	void internalProxiesAreNotDeduplicated() {
+		var second = new InternalProxy();
+		second.setName("invoice");
+		second.init(router);
+
+		manager.addProxy(second, RuleManager.RuleDefinitionSource.MANUAL);
+
+		assertEquals(5, manager.getRules().size());
+	}
+
+	@Test
 	void getRules() {
 		assertEquals(4, manager.getRules().size());
 	}

--- a/core/src/test/java/com/predic8/membrane/core/openapi/serviceproxy/APIProxyKeyComplexMatchTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/serviceproxy/APIProxyKeyComplexMatchTest.java
@@ -105,6 +105,23 @@ class APIProxyKeyComplexMatchTest {
         assertFalse(key.matchesPath("/other"));
     }
 
+    @Test
+    @DisplayName("matchesPath honours the configured path and does not swallow a shared base path (#3173)")
+    void matchesPathDoesNotSwallowSharedBasePath() {
+        // Two APIs share the rewrite base path /jfa/api/ but are told apart by their configured path.
+        var key = new APIProxyKey("", "", 8443, "/jfa/api/housekeeping", "*", null, true) {{
+            addBasePaths(new ArrayList<>(List.of("/jfa/api/")));
+        }};
+
+        assertTrue(key.matchesPath("/jfa/api/housekeeping"));
+        assertTrue(key.matchesPath("/jfa/api/housekeeping/foo"));
+
+        assertFalse(key.matchesPath("/jfa/api/echo"));
+        assertFalse(key.matchesPath("/jfa/api/user"));
+
+        assertTrue(key.matchesPath("/api-docs"));
+    }
+
     private static Stream<Arguments> urls() {
         return Stream.of(
                 of("/api-docs",true),

--- a/core/src/test/java/com/predic8/membrane/core/openapi/serviceproxy/APIProxyKeyComplexMatchTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/serviceproxy/APIProxyKeyComplexMatchTest.java
@@ -122,6 +122,20 @@ class APIProxyKeyComplexMatchTest {
         assertTrue(key.matchesPath("/api-docs"));
     }
 
+    @Test
+    @DisplayName("Api docs paths stay reachable when the key was not built from OpenAPI specs, e.g. wsdl2openapi")
+    void matchesPathAllowsRegisteredApiDocsPaths() {
+        var key = new APIProxyKey("", "", 2000, "/service", "*", null, false) {{
+            addApiDocsPaths(new ArrayList<>(List.of("/api-docs")));
+            addBasePaths(new ArrayList<>(List.of("/service")));
+        }};
+
+        assertTrue(key.matchesPath("/api-docs"));
+        assertTrue(key.matchesPath("/api-docs/ui"));
+        assertTrue(key.matchesPath("/service/get-city"));
+        assertFalse(key.matchesPath("/other"));
+    }
+
     private static Stream<Arguments> urls() {
         return Stream.of(
                 of("/api-docs",true),

--- a/core/src/test/java/com/predic8/membrane/core/openapi/serviceproxy/APIProxyKeyComplexMatchTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/serviceproxy/APIProxyKeyComplexMatchTest.java
@@ -136,6 +136,24 @@ class APIProxyKeyComplexMatchTest {
         assertFalse(key.matchesPath("/other"));
     }
 
+    @Test
+    @DisplayName("Keys differing only in their api docs paths are not equal")
+    void keysWithDifferentApiDocsPathsAreNotEqual() {
+        var openAPIKey = new APIProxyKey("", "", 80, "/cities", "*", null, true);
+
+        assertEquals(openAPIKey, new APIProxyKey("", "", 80, "/cities", "*", null, true));
+        assertNotEquals(openAPIKey, new APIProxyKey("", "", 80, "/cities", "*", null, false));
+    }
+
+    @Test
+    @DisplayName("hashCode agrees with equals and works without an expression")
+    void hashCodeWithoutExchangeExpression() {
+        var key = new APIProxyKey("", "", 80, "/cities", "*", null, true);
+
+        assertEquals(key.hashCode(), new APIProxyKey("", "", 80, "/cities", "*", null, true).hashCode());
+        assertNotEquals(key.hashCode(), new APIProxyKey("", "", 80, "/cities", "*", null, false).hashCode());
+    }
+
     private static Stream<Arguments> urls() {
         return Stream.of(
                 of("/api-docs",true),

--- a/core/src/test/java/com/predic8/membrane/core/proxies/ServiceProxyKeyTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/proxies/ServiceProxyKeyTest.java
@@ -22,6 +22,27 @@ import static org.junit.jupiter.api.Assertions.*;
 public class ServiceProxyKeyTest {
 
 	@Test
+	@DisplayName("Keys with the same port, host, method and path are equal")
+	void equalsAndHashCodeOnValues() {
+		var key = new ServiceProxyKey("localhost", "GET", "/foo", 2000);
+		var same = new ServiceProxyKey("localhost", "GET", "/foo", 2000);
+
+		assertEquals(key, same);
+		assertEquals(key.hashCode(), same.hashCode());
+	}
+
+	@Test
+	@DisplayName("Port, host, method and path each discriminate")
+	void notEqualOnDifferingValues() {
+		var key = new ServiceProxyKey("localhost", "GET", "/foo", 2000);
+
+		assertNotEquals(key, new ServiceProxyKey("localhost", "GET", "/foo", 3000));
+		assertNotEquals(key, new ServiceProxyKey("other", "GET", "/foo", 2000));
+		assertNotEquals(key, new ServiceProxyKey("localhost", "POST", "/foo", 2000));
+		assertNotEquals(key, new ServiceProxyKey("localhost", "GET", "/bar", 2000));
+	}
+
+	@Test
 	void createHostPatternSimple() {
 		assertEquals("(\\Qmembrane\\E)", ServiceProxyKey.createHostPattern("membrane"));
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API documentation endpoints are now recognized reliably, including UI and alternate documentation paths.
  * API matching works correctly when multiple APIs share the same base path.
  * Requests to configured API paths continue to be matched accurately alongside documentation routes.
  * Duplicate API registrations are now prevented while distinct services remain supported.
  * API matching keys now compare consistently, improving duplicate detection and registration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->