### PR TITLE
feat(jsonProtection): scan JSON documents inside multipart attachments

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonLimits.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonLimits.java
@@ -1,0 +1,29 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.core.interceptor.json;
+
+/**
+ * The limits a {@link JsonProtectionScanner} enforces on a single JSON document.
+ *
+ * <p>A key is also a string, so a key length above {@code maxStringLength} could never be reached:
+ * the stricter of the two limits applies and is resolved here, once, rather than at every check.</p>
+ */
+public record JsonLimits(int maxTokens, int maxSize, int maxDepth, int maxStringLength, int maxKeyLength,
+                         int maxObjectSize, int maxArraySize, boolean blockProto) {
+
+    public JsonLimits {
+        maxKeyLength = Math.min(maxKeyLength, maxStringLength);
+    }
+}

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionException.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionException.java
@@ -14,6 +14,8 @@
 
 package com.predic8.membrane.core.interceptor.json;
 
+import com.fasterxml.jackson.core.JsonParser;
+
 public class JsonProtectionException extends Exception{
     private final String message;
     private final int line;
@@ -23,6 +25,15 @@ public class JsonProtectionException extends Exception{
         this.message = msg;
         this.line = line;
         this.col = col;
+    }
+
+    /**
+     * Creates an exception pointing at the parser's current position, so callers do not have to
+     * unpack the location themselves.
+     */
+    public static JsonProtectionException at(String message, JsonParser parser) {
+        var location = parser.currentLocation();
+        return new JsonProtectionException(message, location.getLineNr(), location.getColumnNr());
     }
 
     @Override

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptor.java
@@ -23,6 +23,7 @@ import com.predic8.membrane.core.exchange.*;
 import com.predic8.membrane.core.http.*;
 import com.predic8.membrane.core.interceptor.*;
 import com.predic8.membrane.core.multipart.*;
+import com.predic8.membrane.core.multipart.MultipartUtil.PartAction;
 import org.slf4j.*;
 
 import java.io.*;
@@ -169,17 +170,41 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
             if (!MultipartUtil.isMultipart(request))
                 return inspect(exc, request.getHeader().getContentType(), request.getBodyAsStreamDecoded(), null);
 
-            for (Part part : MultipartUtil.unitsOf(request)) {
-                Outcome outcome = inspect(exc, part.getContentType(), part.getInputStream(), partName(part));
-                if (outcome != CONTINUE)
-                    return outcome;
-            }
+            return inspectParts(exc, request);
         } catch (Exception e) {
             log.debug(e.getMessage());
             exc.setResponse(createErrorResponse(e.getMessage(), null, null));
             return RETURN;
         }
-        return CONTINUE;
+    }
+
+    /**
+     * Inspects the JSON parts of a multipart body. Parts that are not JSON are decided from their
+     * header and never buffered, and no part may exceed {@link #maxSize} - so a large upload does not
+     * have to be held in memory to be rejected.
+     */
+    private Outcome inspectParts(Exchange exc, Request request) throws Exception {
+        var outcome = new Outcome[]{CONTINUE};
+        MultipartUtil.forEachPart(request, maxSize, new MultipartUtil.PartHandler() {
+            @Override
+            public PartAction decide(Header partHeader) {
+                if (outcome[0] != CONTINUE)
+                    return PartAction.STOP;
+                if (isJson(partHeader.getContentType()))
+                    return PartAction.INSPECT;
+                if (otherContentTypes == SKIP)
+                    return PartAction.SKIP;
+                // Rejecting needs the header only, so the offending body is never buffered.
+                outcome[0] = rejectNonJson(exc, partHeader.getContentType(), partName(partHeader));
+                return PartAction.STOP;
+            }
+
+            @Override
+            public void handle(Part part) {
+                outcome[0] = inspect(exc, part.getContentType(), part.getInputStream(), partName(part.getHeader()));
+            }
+        });
+        return outcome[0];
     }
 
     /**
@@ -191,11 +216,7 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
         if (!isJsonUnit(contentType, partName)) {
             if (otherContentTypes == SKIP)
                 return CONTINUE;
-            String msg = "Content-Type %s is not JSON. Set otherContentTypes to \"skip\" to pass non-JSON content through."
-                    .formatted(contentType);
-            log.debug(msg);
-            exc.setResponse(createErrorResponse(describe(msg, partName), null, null));
-            return RETURN;
+            return rejectNonJson(exc, contentType, partName);
         }
         try {
             parseJson(new CountingInputStream(body));
@@ -227,8 +248,16 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
         return isJson(contentType);
     }
 
-    private static String partName(Part part) {
-        String name = part.getName() != null ? part.getName() : part.getContentID();
+    private Outcome rejectNonJson(Exchange exc, String contentType, String partName) {
+        String msg = "Content-Type %s is not JSON. Set otherContentTypes to \"skip\" to pass non-JSON content through."
+                .formatted(contentType);
+        log.debug(msg);
+        exc.setResponse(createErrorResponse(describe(msg, partName), null, null));
+        return RETURN;
+    }
+
+    private static String partName(Header partHeader) {
+        String name = Part.nameOf(partHeader) != null ? Part.nameOf(partHeader) : Part.contentIDOf(partHeader);
         return name != null ? name : "";
     }
 
@@ -372,7 +401,10 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
     }
 
     /**
-     * @description Maximum total size of the JSON document in bytes.
+     * @description Maximum total size of the JSON document in bytes. The limit is per document, so
+     * in a multipart body it applies to each JSON part separately rather than to the whole upload.
+     * To cap the size of the entire request, use the <code>limit</code> plugin with its
+     * <code>maxBodyLength</code> attribute.
      * @default 52428800
      * @param maxSize
      */

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptor.java
@@ -110,10 +110,10 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
 
     @Override
     public Outcome handleRequest(Exchange exc) {
-        if ("GET".equals(exc.getRequest().getMethod()))
+        Request request = exc.getRequest();
+        if (request.isGETRequest())
             return CONTINUE;
 
-        Request request = exc.getRequest();
         try {
             // The common case: a plain body is inspected straight off the body stream, without
             // buffering it into a byte[] first.
@@ -429,24 +429,27 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
 
     @Override
     public String getLongDescription() {
-        return "<div>Enforces the following constraints:<br/><ul>" +
-                "<li>HTTP request body must be well-formed JSON, if the HTTP verb is not" +
-                "<font style=\"font-family: monospace\">GET</font>.</li>" +
-                "<li>Limits the maximum number of tokens to " + maxTokens + ". (Each string and opening bracket counts" +
-                "as a token: <font style=\"font-family: monospace\">{\"a\":\"b\"}</font> counts as 3 tokens)</li>" +
-                "<li>Forbids duplicate keys. (<font style=\"font-family: monospace\">{\"a\":\"b\", \"a\":\"c\"}</font> " +
-                "will be rejected.)</li>" +
-                "<li>Limits the total size in bytes of the body to " + maxSize + ".</li>" +
-                "<li>Limits the maximum depth to " + maxDepth + ". (<font style=\"font-family: monospace\">{\"a\":[{\"b\"" +
-                ":\"c\"}]}</font> has depth 3.)</li>" +
-                "<li>Limits the maximum string length to " + maxStringLength + ". " +
-                "(<font style=\"font-family: monospace\">{\"a\":\"abc\"}</font> has max string length 3.)</li>" +
-                "<li>Limits the maximum key length to " + Math.min(maxKeyLength, maxStringLength) + ". " +
-                "(<font style=\"font-family: monospace\">{\"abc\":\"a\"}</font> has key length 3.)</li>" +
-                "<li>Limits the maximum object size to " + maxObjectSize + ". " +
-                "(<font style=\"font-family: monospace\">{\"a\":\"b\",\"c\":\"d\"}</font> has object size 2.)</li>" +
-                "<li>Limits the maximum array size to " + maxArraySize + ". " +
-                "(<font style=\"font-family: monospace\">[\"a\", \"b\"]</font> has array size 2.)</li>" +
-                "</ul></div>";
+        return """
+                <div>Enforces the following constraints:<br/><ul>\
+                <li>HTTP request body must be well-formed JSON, if the HTTP verb is not\
+                <font style="font-family: monospace">GET</font>.</li>\
+                <li>Limits the maximum number of tokens to %d. (Each string and opening bracket counts\
+                as a token: <font style="font-family: monospace">{"a":"b"}</font> counts as 3 tokens)</li>\
+                <li>Forbids duplicate keys. (<font style="font-family: monospace">{"a":"b", "a":"c"}</font> \
+                will be rejected.)</li>\
+                <li>Limits the total size in bytes of the body to %d.</li>\
+                <li>Limits the maximum depth to %d. (<font style="font-family: monospace">{"a":[{"b"\
+                :"c"}]}</font> has depth 3.)</li>\
+                <li>Limits the maximum string length to %d. \
+                (<font style="font-family: monospace">{"a":"abc"}</font> has max string length 3.)</li>\
+                <li>Limits the maximum key length to %d. \
+                (<font style="font-family: monospace">{"abc":"a"}</font> has key length 3.)</li>\
+                <li>Limits the maximum object size to %d. \
+                (<font style="font-family: monospace">{"a":"b","c":"d"}</font> has object size 2.)</li>\
+                <li>Limits the maximum array size to %d. \
+                (<font style="font-family: monospace">["a", "b"]</font> has array size 2.)</li>\
+                </ul></div>"""
+                .formatted(maxTokens, maxSize, maxDepth, maxStringLength,
+                        Math.min(maxKeyLength, maxStringLength), maxObjectSize, maxArraySize);
     }
 }

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptor.java
@@ -438,9 +438,9 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
     public String getLongDescription() {
         return """
                 <div>Enforces the following constraints:<br/><ul>\
-                <li>HTTP request body must be well-formed JSON, if the HTTP verb is not\
+                <li>HTTP request body must be well-formed JSON, if the HTTP verb is not \
                 <font style="font-family: monospace">GET</font>.</li>\
-                <li>Limits the maximum number of tokens to %d. (Each string and opening bracket counts\
+                <li>Limits the maximum number of tokens to %d. (Each string and opening bracket counts \
                 as a token: <font style="font-family: monospace">{"a":"b"}</font> counts as 3 tokens)</li>\
                 <li>Forbids duplicate keys. (<font style="font-family: monospace">{"a":"b", "a":"c"}</font> \
                 will be rejected.)</li>\

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptor.java
@@ -21,7 +21,7 @@ import com.predic8.membrane.core.exchange.*;
 import com.predic8.membrane.core.http.*;
 import com.predic8.membrane.core.interceptor.*;
 import com.predic8.membrane.core.multipart.*;
-import com.predic8.membrane.core.multipart.MultipartUtil.PartAction;
+import com.predic8.membrane.core.multipart.PartScanner.PartAction;
 import org.slf4j.*;
 
 import java.io.*;
@@ -134,8 +134,8 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
     private Outcome inspectParts(Exchange exc, Request request) throws Exception {
         JsonPartHandler handler = new JsonPartHandler(exc);
         try {
-            MultipartUtil.forEachPart(request, maxSize, handler);
-        } catch (MultipartUtil.PartTooLargeException e) {
+            PartScanner.forEachPart(request, maxSize, handler);
+        } catch (PartTooLargeException e) {
             // Reported like any other part-level violation, naming the attachment that was too big.
             exc.setResponse(createErrorResponse(Origin.part(e.getPartHeader()).describe(e.getMessage()), null, null));
             return RETURN;
@@ -147,7 +147,7 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
      * Inspects the JSON parts and remembers the first part that was not accepted. The traversal is
      * stopped at that part, so nothing after it is read.
      */
-    private class JsonPartHandler implements MultipartUtil.PartHandler {
+    private class JsonPartHandler implements PartScanner.PartHandler {
 
         private final Exchange exc;
         private Outcome outcome = CONTINUE;

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptor.java
@@ -135,7 +135,14 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
      */
     private Outcome inspectParts(Exchange exc, Request request) throws Exception {
         JsonPartHandler handler = new JsonPartHandler(exc);
-        MultipartUtil.forEachPart(request, maxSize, handler);
+        try {
+            MultipartUtil.forEachPart(request, maxSize, handler);
+        } catch (MultipartUtil.PartTooLargeException e) {
+            // Reported like any other part-level violation, naming the attachment that was too big.
+            log.debug(e.getMessage());
+            exc.setResponse(createErrorResponse(Origin.of(e.getPartHeader()).describe(e.getMessage()), null, null));
+            return RETURN;
+        }
         return handler.outcome;
     }
 
@@ -223,7 +230,7 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
             exc.setResponse(createErrorResponse(origin.describe(e.getMessage()),
                     e.getLocation().getLineNr(), e.getLocation().getColumnNr()));
             return RETURN;
-        } catch (Throwable e) {
+        } catch (Exception e) {
             log.debug(e.getMessage());
             exc.setResponse(createErrorResponse(origin.describe(e.getMessage()), null, null));
             return RETURN;

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptor.java
@@ -115,10 +115,9 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
             return CONTINUE;
 
         try {
-            // The common case: a plain body is inspected straight off the body stream, without
-            // buffering it into a byte[] first.
+            // A plain body is inspected straight off the body stream, without buffering it into a byte[].
             if (!MultipartUtil.isMultipart(request))
-                return inspect(exc, request.getHeader().getContentType(), request.getBodyAsStreamDecoded(), Origin.BODY);
+                return inspect(exc, request.getBodyAsStreamDecoded(), Origin.body(request.getHeader()));
 
             return inspectParts(exc, request);
         } catch (Exception e) {
@@ -140,7 +139,7 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
         } catch (MultipartUtil.PartTooLargeException e) {
             // Reported like any other part-level violation, naming the attachment that was too big.
             log.debug(e.getMessage());
-            exc.setResponse(createErrorResponse(Origin.of(e.getPartHeader()).describe(e.getMessage()), null, null));
+            exc.setResponse(createErrorResponse(Origin.part(e.getPartHeader()).describe(e.getMessage()), null, null));
             return RETURN;
         }
         return handler.outcome;
@@ -168,13 +167,13 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
             if (otherContentTypes == SKIP)
                 return PartAction.SKIP;
             // Rejecting needs the header only, so the offending body is never buffered.
-            outcome = rejectNonJson(exc, partHeader.getContentType(), Origin.of(partHeader));
+            outcome = rejectNonJson(exc, Origin.part(partHeader));
             return PartAction.STOP;
         }
 
         @Override
         public void handle(Part part) {
-            outcome = inspect(exc, part.getContentType(), part.getInputStream(), Origin.of(part.getHeader()));
+            outcome = inspect(exc, part.getInputStream(), Origin.part(part.getHeader()));
         }
     }
 
@@ -182,13 +181,15 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
      * Where the inspected content came from. This decides what an absent Content-Type means and how
      * a rejection is worded, so a rejection on a multipart upload can be traced back to one attachment.
      */
-    private record Origin(boolean part, String name) {
+    private record Origin(boolean part, String name, String contentType) {
 
-        private static final Origin BODY = new Origin(false, null);
+        private static Origin body(Header header) {
+            return new Origin(false, null, header.getContentType());
+        }
 
-        private static Origin of(Header partHeader) {
+        private static Origin part(Header partHeader) {
             String name = Part.nameOf(partHeader);
-            return new Origin(true, name != null ? name : Part.contentIDOf(partHeader));
+            return new Origin(true, name != null ? name : Part.contentIDOf(partHeader), partHeader.getContentType());
         }
 
         /**
@@ -196,7 +197,7 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
          * clients that post JSON without declaring it must keep being checked. A MIME part without a
          * Content-Type defaults to text/plain per RFC 2045 and is therefore not JSON.
          */
-        private boolean holdsJson(String contentType) {
+        private boolean holdsJson() {
             if (contentType == null)
                 return !part;
             return isJson(contentType);
@@ -213,11 +214,11 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
     /**
      * Inspects a single content unit: either the whole body or one MIME part.
      */
-    private Outcome inspect(Exchange exc, String contentType, InputStream body, Origin origin) {
-        if (!origin.holdsJson(contentType)) {
+    private Outcome inspect(Exchange exc, InputStream body, Origin origin) {
+        if (!origin.holdsJson()) {
             if (otherContentTypes == SKIP)
                 return CONTINUE;
-            return rejectNonJson(exc, contentType, origin);
+            return rejectNonJson(exc, origin);
         }
         try {
             scanner.scan(body);
@@ -238,9 +239,9 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
         return CONTINUE;
     }
 
-    private Outcome rejectNonJson(Exchange exc, String contentType, Origin origin) {
+    private Outcome rejectNonJson(Exchange exc, Origin origin) {
         String msg = "Content-Type %s is not JSON. Set otherContentTypes to \"skip\" to pass non-JSON content through."
-                .formatted(contentType);
+                .formatted(origin.contentType());
         log.debug(msg);
         exc.setResponse(createErrorResponse(origin.describe(msg), null, null));
         return RETURN;

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptor.java
@@ -111,10 +111,10 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
     @Override
     public Outcome handleRequest(Exchange exc) {
         Request request = exc.getRequest();
-        if (request.isGETRequest())
-            return CONTINUE;
-
         try {
+            if (request.isBodyEmpty())
+                return CONTINUE;
+
             // A plain body is inspected straight off the body stream, without buffering it into a byte[].
             if (!MultipartUtil.isMultipart(request))
                 return inspect(exc, request.getBodyAsStreamDecoded(), Origin.body(request.getHeader()));
@@ -433,8 +433,7 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
     public String getLongDescription() {
         return """
                 <div>Enforces the following constraints:<br/><ul>\
-                <li>HTTP request body must be well-formed JSON, if the HTTP verb is not \
-                <font style="font-family: monospace">GET</font>.</li>\
+                <li>HTTP request body must be well-formed JSON, unless the body is empty.</li>\
                 <li>Limits the maximum number of tokens to %d. (Each string and opening bracket counts \
                 as a token: <font style="font-family: monospace">{"a":"b"}</font> counts as 3 tokens)</li>\
                 <li>Forbids duplicate keys. (<font style="font-family: monospace">{"a":"b", "a":"c"}</font> \

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptor.java
@@ -15,8 +15,6 @@
 package com.predic8.membrane.core.interceptor.json;
 
 import com.fasterxml.jackson.core.*;
-import com.fasterxml.jackson.databind.*;
-import com.google.common.io.*;
 import com.predic8.membrane.annot.*;
 import com.predic8.membrane.core.exceptions.*;
 import com.predic8.membrane.core.exchange.*;
@@ -27,11 +25,7 @@ import com.predic8.membrane.core.multipart.MultipartUtil.PartAction;
 import org.slf4j.*;
 
 import java.io.*;
-import java.util.*;
 
-import static com.fasterxml.jackson.core.JsonParser.Feature.*;
-import static com.fasterxml.jackson.core.JsonTokenId.*;
-import static com.fasterxml.jackson.databind.DeserializationFeature.*;
 import static com.predic8.membrane.core.exceptions.ProblemDetails.*;
 import static com.predic8.membrane.core.http.MimeType.isJson;
 import static com.predic8.membrane.core.interceptor.json.JsonProtectionInterceptor.OtherContentTypes.*;
@@ -82,9 +76,7 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
         REJECT, SKIP
     }
 
-    private final ObjectMapper om = new ObjectMapper()
-            .configure(FAIL_ON_READING_DUP_TREE_KEY, true)
-            .configure(STRICT_DUPLICATE_DETECTION, true);
+    private JsonProtectionScanner scanner;
 
     private Boolean reportError;
     private int maxTokens = 10000;
@@ -105,8 +97,8 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
     @Override
     public void init() {
         super.init();
-        if (maxStringLength < maxKeyLength)
-            maxKeyLength = maxStringLength;
+        scanner = new JsonProtectionScanner(new JsonLimits(maxTokens, maxSize, maxDepth, maxStringLength,
+                maxKeyLength, maxObjectSize, maxArraySize, blockProto));
     }
 
     private boolean shouldProvideDetails() {
@@ -114,48 +106,6 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
             return reportError;
         }
         return !router.getConfiguration().isProduction();
-    }
-
-    private abstract static class Context {
-        public abstract void check(JsonToken jsonToken, JsonParser parser) throws IOException, JsonProtectionException;
-    }
-
-    private class ObjContext extends Context {
-        int n;
-        @Override
-        public void check(JsonToken jsonToken, JsonParser parser) throws JsonProtectionException, IOException {
-            if (jsonToken.id() == ID_END_OBJECT)
-                return;
-            n++;
-            if (n > maxObjectSize)
-                throw new JsonProtectionException("Exceeded maxObjectSize.",
-                                                    parser.currentLocation().getLineNr(),
-                                                    parser.currentLocation().getColumnNr());
-            if (blockProto && "__proto__".equals(parser.currentName()))
-                throw new JsonProtectionException("__proto__ found as key.",
-                        parser.currentLocation().getLineNr(),
-                        parser.currentLocation().getColumnNr());
-            if (parser.currentName().length() > maxKeyLength) {
-                throw new JsonProtectionException("Exceeded maxKeyLength.",
-                                                    parser.currentLocation().getLineNr(),
-                                                    parser.currentLocation().getColumnNr());
-            }
-        }
-    }
-
-    private class ArrContext extends Context {
-        int n;
-
-        @Override
-        public void check(JsonToken jsonToken, JsonParser parser) throws JsonProtectionException {
-            if (jsonToken.id() == ID_END_ARRAY)
-                return;
-            n++;
-            if (n > maxArraySize)
-                throw new JsonProtectionException("Exceeded maxArraySize.",
-                                                    parser.currentLocation().getLineNr(),
-                                                    parser.currentLocation().getColumnNr());
-        }
     }
 
     @Override
@@ -219,7 +169,7 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
             return rejectNonJson(exc, contentType, partName);
         }
         try {
-            parseJson(new CountingInputStream(body));
+            scanner.scan(body);
         } catch (JsonProtectionException e) {
             log.debug(e.getMessage());
             exc.setResponse(createErrorResponse(describe(e.getMessage(), partName), e.getLine(), e.getCol()));
@@ -283,85 +233,6 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
             return pd.build();
         }
         return Response.badRequest().build();
-    }
-
-    private void parseJson(CountingInputStream cis) throws IOException, JsonProtectionException {
-        JsonParser parser = om.createParser(cis);
-        int tokenCount = 0;
-        int depth = 0;
-        List<Context> contexts = new ArrayList<>();
-        Context currentContext = null;
-        while (true) {
-            JsonToken jsonToken = parser.nextValue();
-            if (jsonToken == null)
-                break;
-            tokenCount++;
-            if (tokenCount > maxTokens)
-                throw new JsonProtectionException("Exceeded maxTokens.",
-                                                    parser.currentLocation().getLineNr(),
-                                                    parser.currentLocation().getColumnNr());
-            if (cis.getCount() > maxSize)
-                throw new JsonProtectionException("Exceeded maxSize.",
-                                                    parser.currentLocation().getLineNr(),
-                                                    parser.currentLocation().getColumnNr());
-            if (currentContext != null)
-                currentContext.check(jsonToken, parser);
-            switch (jsonToken.id()) {
-                case ID_START_OBJECT:
-                    depth++;
-                    if (depth > maxDepth)
-                        throw new JsonProtectionException("Exceeded maxDepth.",
-                                                            parser.currentLocation().getLineNr(),
-                                                            parser.currentLocation().getColumnNr());
-                    contexts.add(currentContext = new ObjContext());
-                    break;
-                case ID_START_ARRAY:
-                    depth++;
-                    if (depth > maxDepth)
-                        throw new JsonProtectionException("Exceeded maxDepth.",
-                                                            parser.currentLocation().getLineNr(),
-                                                            parser.currentLocation().getColumnNr());
-                    contexts.add(currentContext = new ArrContext());
-                    break;
-                case ID_END_OBJECT:
-                case ID_END_ARRAY:
-                    depth--;
-                    if (depth < 0)
-                        throw new JsonProtectionException("Invalid JSON Document.",
-                                                            parser.currentLocation().getLineNr(),
-                                                            parser.currentLocation().getColumnNr());
-                    contexts.removeLast();
-                    currentContext = contexts.isEmpty() ? null : contexts.getLast();
-                    break;
-                case ID_STRING:
-                    if (parser.getValueAsString().length() > maxStringLength)
-                        throw new JsonProtectionException("Exceeded maxStringLength.",
-                                                            parser.currentLocation().getLineNr(),
-                                                            parser.currentLocation().getColumnNr());
-                    break;
-                case ID_NUMBER_INT:
-                case ID_NUMBER_FLOAT:
-                case ID_TRUE:
-                case ID_FALSE:
-                case ID_NULL:
-                    break;
-                case ID_NOT_AVAILABLE:
-                case ID_NO_TOKEN:
-                case ID_FIELD_NAME:
-                case ID_EMBEDDED_OBJECT:
-                    throw new JsonProtectionException("Not handled.",
-                                                        parser.currentLocation().getLineNr(),
-                                                        parser.currentLocation().getColumnNr());
-                default:
-                    throw new JsonProtectionException("Not handled (\" + jsonToken.id() + \")",
-                                                        parser.currentLocation().getLineNr(),
-                                                        parser.currentLocation().getColumnNr());
-            }
-        }
-        if (cis.getCount() > maxSize)
-            throw new JsonProtectionException("Exceeded maxSize.",
-                                                parser.currentLocation().getLineNr(),
-                                                parser.currentLocation().getColumnNr());
     }
 
     @SuppressWarnings("unused")
@@ -552,7 +423,7 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
                 ":\"c\"}]}</font> has depth 3.)</li>" +
                 "<li>Limits the maximum string length to " + maxStringLength + ". " +
                 "(<font style=\"font-family: monospace\">{\"a\":\"abc\"}</font> has max string length 3.)</li>" +
-                "<li>Limits the maximum key length to " + maxKeyLength + ". " +
+                "<li>Limits the maximum key length to " + Math.min(maxKeyLength, maxStringLength) + ". " +
                 "(<font style=\"font-family: monospace\">{\"abc\":\"a\"}</font> has key length 3.)</li>" +
                 "<li>Limits the maximum object size to " + maxObjectSize + ". " +
                 "(<font style=\"font-family: monospace\">{\"a\":\"b\",\"c\":\"d\"}</font> has object size 2.)</li>" +

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptor.java
@@ -118,7 +118,7 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
             // The common case: a plain body is inspected straight off the body stream, without
             // buffering it into a byte[] first.
             if (!MultipartUtil.isMultipart(request))
-                return inspect(exc, request.getHeader().getContentType(), request.getBodyAsStreamDecoded(), null);
+                return inspect(exc, request.getHeader().getContentType(), request.getBodyAsStreamDecoded(), Origin.BODY);
 
             return inspectParts(exc, request);
         } catch (Exception e) {
@@ -134,91 +134,109 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
      * have to be held in memory to be rejected.
      */
     private Outcome inspectParts(Exchange exc, Request request) throws Exception {
-        var outcome = new Outcome[]{CONTINUE};
-        MultipartUtil.forEachPart(request, maxSize, new MultipartUtil.PartHandler() {
-            @Override
-            public PartAction decide(Header partHeader) {
-                if (outcome[0] != CONTINUE)
-                    return PartAction.STOP;
-                if (isJson(partHeader.getContentType()))
-                    return PartAction.INSPECT;
-                if (otherContentTypes == SKIP)
-                    return PartAction.SKIP;
-                // Rejecting needs the header only, so the offending body is never buffered.
-                outcome[0] = rejectNonJson(exc, partHeader.getContentType(), partName(partHeader));
-                return PartAction.STOP;
-            }
+        JsonPartHandler handler = new JsonPartHandler(exc);
+        MultipartUtil.forEachPart(request, maxSize, handler);
+        return handler.outcome;
+    }
 
-            @Override
-            public void handle(Part part) {
-                outcome[0] = inspect(exc, part.getContentType(), part.getInputStream(), partName(part.getHeader()));
-            }
-        });
-        return outcome[0];
+    /**
+     * Inspects the JSON parts and remembers the first part that was not accepted. The traversal is
+     * stopped at that part, so nothing after it is read.
+     */
+    private class JsonPartHandler implements MultipartUtil.PartHandler {
+
+        private final Exchange exc;
+        private Outcome outcome = CONTINUE;
+
+        private JsonPartHandler(Exchange exc) {
+            this.exc = exc;
+        }
+
+        @Override
+        public PartAction decide(Header partHeader) {
+            if (outcome != CONTINUE)
+                return PartAction.STOP;
+            if (isJson(partHeader.getContentType()))
+                return PartAction.INSPECT;
+            if (otherContentTypes == SKIP)
+                return PartAction.SKIP;
+            // Rejecting needs the header only, so the offending body is never buffered.
+            outcome = rejectNonJson(exc, partHeader.getContentType(), Origin.of(partHeader));
+            return PartAction.STOP;
+        }
+
+        @Override
+        public void handle(Part part) {
+            outcome = inspect(exc, part.getContentType(), part.getInputStream(), Origin.of(part.getHeader()));
+        }
+    }
+
+    /**
+     * Where the inspected content came from. This decides what an absent Content-Type means and how
+     * a rejection is worded, so a rejection on a multipart upload can be traced back to one attachment.
+     */
+    private record Origin(boolean part, String name) {
+
+        private static final Origin BODY = new Origin(false, null);
+
+        private static Origin of(Header partHeader) {
+            String name = Part.nameOf(partHeader);
+            return new Origin(true, name != null ? name : Part.contentIDOf(partHeader));
+        }
+
+        /**
+         * A whole body without a Content-Type is still parsed, as it was before multipart support:
+         * clients that post JSON without declaring it must keep being checked. A MIME part without a
+         * Content-Type defaults to text/plain per RFC 2045 and is therefore not JSON.
+         */
+        private boolean holdsJson(String contentType) {
+            if (contentType == null)
+                return !part;
+            return isJson(contentType);
+        }
+
+        private String describe(String message) {
+            if (!part)
+                return message;
+            return name == null ? "In one part of the multipart body: " + message
+                                : "In part '%s': %s".formatted(name, message);
+        }
     }
 
     /**
      * Inspects a single content unit: either the whole body or one MIME part.
-     *
-     * @param partName the name of the MIME part, or null if the unit is the whole body
      */
-    private Outcome inspect(Exchange exc, String contentType, InputStream body, String partName) {
-        if (!isJsonUnit(contentType, partName)) {
+    private Outcome inspect(Exchange exc, String contentType, InputStream body, Origin origin) {
+        if (!origin.holdsJson(contentType)) {
             if (otherContentTypes == SKIP)
                 return CONTINUE;
-            return rejectNonJson(exc, contentType, partName);
+            return rejectNonJson(exc, contentType, origin);
         }
         try {
             scanner.scan(body);
         } catch (JsonProtectionException e) {
             log.debug(e.getMessage());
-            exc.setResponse(createErrorResponse(describe(e.getMessage(), partName), e.getLine(), e.getCol()));
+            exc.setResponse(createErrorResponse(origin.describe(e.getMessage()), e.getLine(), e.getCol()));
             return RETURN;
         } catch (JsonParseException e) {
             log.debug(e.getMessage());
-            exc.setResponse(createErrorResponse(describe(e.getMessage(), partName),
+            exc.setResponse(createErrorResponse(origin.describe(e.getMessage()),
                     e.getLocation().getLineNr(), e.getLocation().getColumnNr()));
             return RETURN;
         } catch (Throwable e) {
             log.debug(e.getMessage());
-            exc.setResponse(createErrorResponse(describe(e.getMessage(), partName), null, null));
+            exc.setResponse(createErrorResponse(origin.describe(e.getMessage()), null, null));
             return RETURN;
         }
         return CONTINUE;
     }
 
-    /**
-     * A whole body without a Content-Type is still parsed, as it was before multipart support: clients
-     * that post JSON without declaring it must keep being checked. A MIME part without a Content-Type
-     * defaults to text/plain per RFC 2045 and is therefore not JSON.
-     */
-    private static boolean isJsonUnit(String contentType, String partName) {
-        if (contentType == null)
-            return partName == null;
-        return isJson(contentType);
-    }
-
-    private Outcome rejectNonJson(Exchange exc, String contentType, String partName) {
+    private Outcome rejectNonJson(Exchange exc, String contentType, Origin origin) {
         String msg = "Content-Type %s is not JSON. Set otherContentTypes to \"skip\" to pass non-JSON content through."
                 .formatted(contentType);
         log.debug(msg);
-        exc.setResponse(createErrorResponse(describe(msg, partName), null, null));
+        exc.setResponse(createErrorResponse(origin.describe(msg), null, null));
         return RETURN;
-    }
-
-    private static String partName(Header partHeader) {
-        String name = Part.nameOf(partHeader) != null ? Part.nameOf(partHeader) : Part.contentIDOf(partHeader);
-        return name != null ? name : "";
-    }
-
-    /**
-     * Names the offending part, so a rejection on a multipart upload can be traced back to one attachment.
-     */
-    private static String describe(String message, String partName) {
-        if (partName == null)
-            return message;
-        return partName.isEmpty() ? "In one part of the multipart body: " + message
-                                  : "In part '%s': %s".formatted(partName, message);
     }
 
     private Response createErrorResponse(String msg, Integer line, Integer col) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptor.java
@@ -121,7 +121,6 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
 
             return inspectParts(exc, request);
         } catch (Exception e) {
-            log.debug(e.getMessage());
             exc.setResponse(createErrorResponse(e.getMessage(), null, null));
             return RETURN;
         }
@@ -138,7 +137,6 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
             MultipartUtil.forEachPart(request, maxSize, handler);
         } catch (MultipartUtil.PartTooLargeException e) {
             // Reported like any other part-level violation, naming the attachment that was too big.
-            log.debug(e.getMessage());
             exc.setResponse(createErrorResponse(Origin.part(e.getPartHeader()).describe(e.getMessage()), null, null));
             return RETURN;
         }
@@ -223,16 +221,13 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
         try {
             scanner.scan(body);
         } catch (JsonProtectionException e) {
-            log.debug(e.getMessage());
             exc.setResponse(createErrorResponse(origin.describe(e.getMessage()), e.getLine(), e.getCol()));
             return RETURN;
         } catch (JsonParseException e) {
-            log.debug(e.getMessage());
             exc.setResponse(createErrorResponse(origin.describe(e.getMessage()),
                     e.getLocation().getLineNr(), e.getLocation().getColumnNr()));
             return RETURN;
         } catch (Exception e) {
-            log.debug(e.getMessage());
             exc.setResponse(createErrorResponse(origin.describe(e.getMessage()), null, null));
             return RETURN;
         }
@@ -242,14 +237,13 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
     private Outcome rejectNonJson(Exchange exc, Origin origin) {
         String msg = "Content-Type %s is not JSON. Set otherContentTypes to \"skip\" to pass non-JSON content through."
                 .formatted(origin.contentType());
-        log.debug(msg);
         exc.setResponse(createErrorResponse(origin.describe(msg), null, null));
         return RETURN;
     }
 
     private Response createErrorResponse(String msg, Integer line, Integer col) {
+        log.info("JSON protection violation. Line: {}, col: {}, msg: {}", line, col, msg);
         if (shouldProvideDetails()) {
-            log.warn("JSON protection violation. Line: {}, col: {}, msg: {}", line, col, msg);
             ProblemDetails pd = user(false,getDisplayName())
                     .status(400)
                     .title("JSON Protection Violation")

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptor.java
@@ -22,6 +22,7 @@ import com.predic8.membrane.core.exceptions.*;
 import com.predic8.membrane.core.exchange.*;
 import com.predic8.membrane.core.http.*;
 import com.predic8.membrane.core.interceptor.*;
+import com.predic8.membrane.core.multipart.*;
 import org.slf4j.*;
 
 import java.io.*;
@@ -31,6 +32,8 @@ import static com.fasterxml.jackson.core.JsonParser.Feature.*;
 import static com.fasterxml.jackson.core.JsonTokenId.*;
 import static com.fasterxml.jackson.databind.DeserializationFeature.*;
 import static com.predic8.membrane.core.exceptions.ProblemDetails.*;
+import static com.predic8.membrane.core.http.MimeType.isJson;
+import static com.predic8.membrane.core.interceptor.json.JsonProtectionInterceptor.OtherContentTypes.*;
 import static com.predic8.membrane.core.interceptor.Interceptor.Flow.*;
 import static com.predic8.membrane.core.interceptor.Outcome.*;
 import static java.util.EnumSet.*;
@@ -44,6 +47,8 @@ import static java.util.EnumSet.*;
  *   <li>Prototype pollution via __proto__ keys in JavaScript backends</li>
  *   <li>Duplicate key attacks</li>
  * </ul>
+ * <p>JSON documents carried inside a multipart body are inspected part by part, so a JSON document
+ * uploaded as an attachment is checked like a plain JSON body.</p>
  *
  * @yaml
  * <pre><code>
@@ -57,6 +62,7 @@ import static java.util.EnumSet.*;
  *     maxSize: 10000
  *     blockProto: true
  *     reportError: true
+ *     otherContentTypes: SKIP
  * </code></pre>
  *
  * @topic 3. Security and Validation
@@ -66,6 +72,14 @@ import static java.util.EnumSet.*;
 public class JsonProtectionInterceptor extends AbstractInterceptor {
 
     private static final Logger log = LoggerFactory.getLogger(JsonProtectionInterceptor.class);
+
+    /**
+     * What to do with content that is not JSON: the whole body of a non-JSON request, or a
+     * non-JSON part of a multipart body.
+     */
+    public enum OtherContentTypes {
+        REJECT, SKIP
+    }
 
     private final ObjectMapper om = new ObjectMapper()
             .configure(FAIL_ON_READING_DUP_TREE_KEY, true)
@@ -80,6 +94,7 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
     private int maxObjectSize = 1000;
     private int maxArraySize = 1000;
     private boolean blockProto = true;
+    private OtherContentTypes otherContentTypes = REJECT;
 
     public JsonProtectionInterceptor() {
         name = "json protection";
@@ -146,22 +161,85 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
     public Outcome handleRequest(Exchange exc) {
         if ("GET".equals(exc.getRequest().getMethod()))
             return CONTINUE;
+
+        Request request = exc.getRequest();
         try {
-            parseJson(new CountingInputStream(exc.getRequest().getBodyAsStreamDecoded()));
-        } catch (JsonProtectionException e) {
-            log.debug(e.getMessage());
-            exc.setResponse(createErrorResponse(e.getMessage(), e.getLine(), e.getCol()));
-            return RETURN;
-        } catch (JsonParseException e) {
-            log.debug(e.getMessage());
-            exc.setResponse(createErrorResponse(e.getMessage(), e.getLocation().getLineNr(), e.getLocation().getColumnNr()));
-            return RETURN;
-        } catch (Throwable e) {
+            // The common case: a plain body is inspected straight off the body stream, without
+            // buffering it into a byte[] first.
+            if (!MultipartUtil.isMultipart(request))
+                return inspect(exc, request.getHeader().getContentType(), request.getBodyAsStreamDecoded(), null);
+
+            for (Part part : MultipartUtil.unitsOf(request)) {
+                Outcome outcome = inspect(exc, part.getContentType(), part.getInputStream(), partName(part));
+                if (outcome != CONTINUE)
+                    return outcome;
+            }
+        } catch (Exception e) {
             log.debug(e.getMessage());
             exc.setResponse(createErrorResponse(e.getMessage(), null, null));
             return RETURN;
         }
         return CONTINUE;
+    }
+
+    /**
+     * Inspects a single content unit: either the whole body or one MIME part.
+     *
+     * @param partName the name of the MIME part, or null if the unit is the whole body
+     */
+    private Outcome inspect(Exchange exc, String contentType, InputStream body, String partName) {
+        if (!isJsonUnit(contentType, partName)) {
+            if (otherContentTypes == SKIP)
+                return CONTINUE;
+            String msg = "Content-Type %s is not JSON. Set otherContentTypes to \"skip\" to pass non-JSON content through."
+                    .formatted(contentType);
+            log.debug(msg);
+            exc.setResponse(createErrorResponse(describe(msg, partName), null, null));
+            return RETURN;
+        }
+        try {
+            parseJson(new CountingInputStream(body));
+        } catch (JsonProtectionException e) {
+            log.debug(e.getMessage());
+            exc.setResponse(createErrorResponse(describe(e.getMessage(), partName), e.getLine(), e.getCol()));
+            return RETURN;
+        } catch (JsonParseException e) {
+            log.debug(e.getMessage());
+            exc.setResponse(createErrorResponse(describe(e.getMessage(), partName),
+                    e.getLocation().getLineNr(), e.getLocation().getColumnNr()));
+            return RETURN;
+        } catch (Throwable e) {
+            log.debug(e.getMessage());
+            exc.setResponse(createErrorResponse(describe(e.getMessage(), partName), null, null));
+            return RETURN;
+        }
+        return CONTINUE;
+    }
+
+    /**
+     * A whole body without a Content-Type is still parsed, as it was before multipart support: clients
+     * that post JSON without declaring it must keep being checked. A MIME part without a Content-Type
+     * defaults to text/plain per RFC 2045 and is therefore not JSON.
+     */
+    private static boolean isJsonUnit(String contentType, String partName) {
+        if (contentType == null)
+            return partName == null;
+        return isJson(contentType);
+    }
+
+    private static String partName(Part part) {
+        String name = part.getName() != null ? part.getName() : part.getContentID();
+        return name != null ? name : "";
+    }
+
+    /**
+     * Names the offending part, so a rejection on a multipart upload can be traced back to one attachment.
+     */
+    private static String describe(String message, String partName) {
+        if (partName == null)
+            return message;
+        return partName.isEmpty() ? "In one part of the multipart body: " + message
+                                  : "In part '%s': %s".formatted(partName, message);
     }
 
     private Response createErrorResponse(String msg, Integer line, Integer col) {
@@ -404,6 +482,23 @@ public class JsonProtectionInterceptor extends AbstractInterceptor {
     @MCAttribute
     public void setBlockProto(boolean blockProto) {
         this.blockProto = blockProto;
+    }
+
+    public OtherContentTypes getOtherContentTypes() {
+        return otherContentTypes;
+    }
+
+    /**
+     * @description What to do with content that is not JSON. This applies both to the body of a
+     * non-JSON request and to the individual non-JSON parts of a multipart body, so
+     * <code>skip</code> allows e.g. an image to be uploaded alongside a JSON document.
+     * <p>Values: REJECT, SKIP</p>
+     * @default REJECT
+     * @example SKIP
+     */
+    @MCAttribute
+    public void setOtherContentTypes(OtherContentTypes otherContentTypes) {
+        this.otherContentTypes = otherContentTypes;
     }
 
     @Override

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionScanner.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionScanner.java
@@ -14,9 +14,9 @@
 
 package com.predic8.membrane.core.interceptor.json;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.CountingInputStream;
 
 import java.io.IOException;
@@ -26,7 +26,6 @@ import java.util.List;
 
 import static com.fasterxml.jackson.core.JsonParser.Feature.STRICT_DUPLICATE_DETECTION;
 import static com.fasterxml.jackson.core.JsonTokenId.*;
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY;
 
 /**
  * Streams a JSON document through a Jackson parser and enforces a set of {@link JsonLimits} on it,
@@ -38,9 +37,8 @@ import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_READ
  */
 public class JsonProtectionScanner {
 
-    private final ObjectMapper om = new ObjectMapper()
-            .configure(FAIL_ON_READING_DUP_TREE_KEY, true)
-            .configure(STRICT_DUPLICATE_DETECTION, true);
+    /** Duplicate keys are an attack in their own right, so the parser rejects them itself. */
+    private final JsonFactory jsonFactory = new JsonFactory().enable(STRICT_DUPLICATE_DETECTION);
 
     private final JsonLimits limits;
 
@@ -57,7 +55,7 @@ public class JsonProtectionScanner {
      */
     public void scan(InputStream body) throws IOException, JsonProtectionException {
         CountingInputStream cis = new CountingInputStream(body);
-        JsonParser parser = om.createParser(cis);
+        JsonParser parser = jsonFactory.createParser(cis);
         int tokenCount = 0;
         List<Context> contexts = new ArrayList<>();
         while (true) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionScanner.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/json/JsonProtectionScanner.java
@@ -1,0 +1,151 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.core.interceptor.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.CountingInputStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.fasterxml.jackson.core.JsonParser.Feature.STRICT_DUPLICATE_DETECTION;
+import static com.fasterxml.jackson.core.JsonTokenId.*;
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY;
+
+/**
+ * Streams a JSON document through a Jackson parser and enforces a set of {@link JsonLimits} on it,
+ * without materialising the document. Used by {@link JsonProtectionInterceptor} on a whole request
+ * body as well as on the individual JSON parts of a multipart body.
+ *
+ * <p>Stateless with respect to a single document: one instance can scan any number of documents,
+ * also concurrently.</p>
+ */
+public class JsonProtectionScanner {
+
+    private final ObjectMapper om = new ObjectMapper()
+            .configure(FAIL_ON_READING_DUP_TREE_KEY, true)
+            .configure(STRICT_DUPLICATE_DETECTION, true);
+
+    private final JsonLimits limits;
+
+    public JsonProtectionScanner(JsonLimits limits) {
+        this.limits = limits;
+    }
+
+    /**
+     * Reads the document and returns normally if it stays within the limits.
+     *
+     * @throws JsonProtectionException if a limit is exceeded or the document is not well-formed JSON
+     * @throws IOException             on I/O errors, and as {@link com.fasterxml.jackson.core.JsonParseException}
+     *                                 on malformed JSON
+     */
+    public void scan(InputStream body) throws IOException, JsonProtectionException {
+        CountingInputStream cis = new CountingInputStream(body);
+        JsonParser parser = om.createParser(cis);
+        int tokenCount = 0;
+        List<Context> contexts = new ArrayList<>();
+        while (true) {
+            JsonToken jsonToken = parser.nextValue();
+            if (jsonToken == null)
+                break;
+            if (++tokenCount > limits.maxTokens())
+                throw JsonProtectionException.at("Exceeded maxTokens.", parser);
+            checkSize(cis, parser);
+            if (!contexts.isEmpty())
+                contexts.getLast().check(jsonToken, parser);
+            switch (jsonToken.id()) {
+                case ID_START_OBJECT -> push(contexts, new ObjContext(limits), parser);
+                case ID_START_ARRAY -> push(contexts, new Context(limits.maxArraySize(), "Exceeded maxArraySize."), parser);
+                case ID_END_OBJECT, ID_END_ARRAY -> pop(contexts, parser);
+                case ID_STRING -> {
+                    if (parser.getValueAsString().length() > limits.maxStringLength())
+                        throw JsonProtectionException.at("Exceeded maxStringLength.", parser);
+                }
+                case ID_NUMBER_INT, ID_NUMBER_FLOAT, ID_TRUE, ID_FALSE, ID_NULL -> {
+                }
+                default -> throw JsonProtectionException.at("Not handled (" + jsonToken.id() + ")", parser);
+            }
+        }
+        checkSize(cis, parser);
+    }
+
+    private void checkSize(CountingInputStream cis, JsonParser parser) throws JsonProtectionException {
+        if (cis.getCount() > limits.maxSize())
+            throw JsonProtectionException.at("Exceeded maxSize.", parser);
+    }
+
+    private void push(List<Context> contexts, Context context, JsonParser parser) throws JsonProtectionException {
+        if (contexts.size() >= limits.maxDepth())
+            throw JsonProtectionException.at("Exceeded maxDepth.", parser);
+        contexts.add(context);
+    }
+
+    private static void pop(List<Context> contexts, JsonParser parser) throws JsonProtectionException {
+        if (contexts.isEmpty())
+            throw JsonProtectionException.at("Invalid JSON Document.", parser);
+        contexts.removeLast();
+    }
+
+    /**
+     * Counts the members of the object or array currently being parsed. The end token closing the
+     * context is not a member and is therefore not counted.
+     */
+    private static class Context {
+        private final int maxMembers;
+        private final String exceededMessage;
+        private int members;
+
+        Context(int maxMembers, String exceededMessage) {
+            this.maxMembers = maxMembers;
+            this.exceededMessage = exceededMessage;
+        }
+
+        void check(JsonToken jsonToken, JsonParser parser) throws JsonProtectionException, IOException {
+            if (isEndToken(jsonToken))
+                return;
+            if (++members > maxMembers)
+                throw JsonProtectionException.at(exceededMessage, parser);
+        }
+
+        static boolean isEndToken(JsonToken jsonToken) {
+            return jsonToken.id() == ID_END_OBJECT || jsonToken.id() == ID_END_ARRAY;
+        }
+    }
+
+    /** Additionally checks the key each member is bound to. */
+    private static class ObjContext extends Context {
+        private final JsonLimits limits;
+
+        ObjContext(JsonLimits limits) {
+            super(limits.maxObjectSize(), "Exceeded maxObjectSize.");
+            this.limits = limits;
+        }
+
+        @Override
+        void check(JsonToken jsonToken, JsonParser parser) throws JsonProtectionException, IOException {
+            if (isEndToken(jsonToken))
+                return;
+            super.check(jsonToken, parser);
+            if (limits.blockProto() && "__proto__".equals(parser.currentName()))
+                throw JsonProtectionException.at("__proto__ found as key.", parser);
+            if (parser.currentName().length() > limits.maxKeyLength())
+                throw JsonProtectionException.at("Exceeded maxKeyLength.", parser);
+        }
+    }
+}

--- a/core/src/main/java/com/predic8/membrane/core/multipart/MultipartUtil.java
+++ b/core/src/main/java/com/predic8/membrane/core/multipart/MultipartUtil.java
@@ -16,17 +16,12 @@ package com.predic8.membrane.core.multipart;
 
 import com.predic8.membrane.core.http.Header;
 import com.predic8.membrane.core.http.Message;
-import com.predic8.membrane.core.util.MessageUtil;
 import jakarta.mail.internet.ContentType;
 import jakarta.mail.internet.ParseException;
-import org.apache.commons.fileupload.MultipartStream;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Utility for splitting multipart HTTP messages into their individual {@link Part}s.
@@ -40,141 +35,10 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  *     byte[] body = part.getBody();
  * }
  * }</pre>
+ *
+ * <p>Every part is buffered; see {@link PartScanner} to traverse a message without doing that.</p>
  */
 public class MultipartUtil {
-
-    /** What {@link PartHandler} wants done with a part, decided from its header alone. */
-    public enum PartAction {
-        /** Buffer the body (bounded) and pass it to {@link PartHandler#handle}. */
-        INSPECT,
-        /** Discard the body without reading it into memory, and continue with the next part. */
-        SKIP,
-        /** Stop the traversal immediately; nothing further is read or buffered. */
-        STOP
-    }
-
-    /**
-     * Decides from a part's header alone whether its body is needed, so that unwanted parts are
-     * never buffered.
-     */
-    public interface PartHandler {
-        PartAction decide(Header partHeader);
-
-        void handle(Part part) throws IOException;
-    }
-
-    /**
-     * Streams the parts of a multipart message to a handler, holding at most one part body in memory
-     * at a time. Parts the handler does not want are discarded unread, and a part exceeding
-     * {@code maxPartSize} aborts the traversal instead of being buffered whole.
-     *
-     * <p>XOP/MTOM messages are traversed as their raw parts and are deliberately not reassembled:
-     * reassembly would have to buffer every attachment and a base64-inflated copy of it before the
-     * handler could decide anything. Callers that need the reassembled document (schema validation,
-     * for example) use {@link XOPReconstitutor} directly.</p>
-     *
-     * <p>Content-Encodings (gzip, deflate, brotli) are decoded; the bodies passed to the handler are
-     * the logical content.</p>
-     *
-     * @param message     a multipart request or response
-     * @param maxPartSize maximum number of bytes a single part's body may occupy
-     * @throws IOException    on I/O or parse errors, if a part is itself multipart, or if a part
-     *                        exceeds {@code maxPartSize}
-     * @throws ParseException if the Content-Type header cannot be parsed
-     */
-    public static void forEachPart(Message message, int maxPartSize, PartHandler handler) throws IOException, ParseException {
-        forEachPart(message, boundaryOf(message), maxPartSize, handler);
-    }
-
-    /**
-     * Streams the parts to a handler using an explicit boundary, for callers that know it already.
-     *
-     * @see #forEachPart(Message, int, PartHandler)
-     */
-    @SuppressWarnings("deprecation")
-    public static void forEachPart(Message message, String boundary, int maxPartSize, PartHandler handler) throws IOException {
-        MultipartStream ms = new MultipartStream(MessageUtil.getContentAsStream(message), boundary.getBytes(UTF_8));
-        boolean hasNext = ms.skipPreamble();
-        while (hasNext) {
-            Header partHeader = new Header(ms.readHeaders());
-            // Everything that can reject a part is decided from its header, before any body byte is buffered.
-            checkSupported(partHeader);
-
-            switch (handler.decide(partHeader)) {
-                case STOP -> {
-                    return;
-                }
-                case SKIP -> ms.discardBodyData();
-                case INSPECT -> {
-                    BoundedOutputStream body = new BoundedOutputStream(maxPartSize);
-                    try {
-                        ms.readBodyData(body);
-                    } catch (LimitExceeded e) {
-                        throw new PartTooLargeException(partHeader, maxPartSize, e);
-                    }
-                    handler.handle(new Part(partHeader, body.toByteArray()));
-                }
-            }
-            hasNext = ms.readBoundary();
-        }
-    }
-
-    private static void checkSupported(Header partHeader) throws IOException {
-        if (isMultipart(partHeader.getContentType()))
-            throw new IOException("Nested multipart is not supported: part has Content-Type " + partHeader.getContentType());
-        checkContentTransferEncoding(partHeader);
-    }
-
-    /**
-     * Buffers up to a fixed number of bytes and fails as soon as that is exceeded, so an oversized
-     * part stops the read early instead of being materialised in full.
-     */
-    private static class BoundedOutputStream extends ByteArrayOutputStream {
-        private final int limit;
-
-        BoundedOutputStream(int limit) {
-            this.limit = limit;
-        }
-
-        @Override
-        public synchronized void write(int b) {
-            checkRoomFor(1);
-            super.write(b);
-        }
-
-        @Override
-        public synchronized void write(byte[] b, int off, int len) {
-            checkRoomFor(len);
-            super.write(b, off, len);
-        }
-
-        private void checkRoomFor(int additional) {
-            if (size() + additional > limit)
-                throw new LimitExceeded();
-        }
-    }
-
-    /** Unchecked so it can escape {@link java.io.OutputStream#write}; converted by {@link #forEachPart}. */
-    private static class LimitExceeded extends RuntimeException {
-    }
-
-    /**
-     * Carries the header of the part that was too large, so a caller can report which attachment of
-     * an upload was rejected.
-     */
-    public static class PartTooLargeException extends IOException {
-
-        private final transient Header partHeader;
-
-        private PartTooLargeException(Header partHeader, int limit, Throwable cause) {
-            super("Part exceeds the maximum size of " + limit + " bytes.", cause);
-            this.partHeader = partHeader;
-        }
-
-        public Header getPartHeader() {
-            return partHeader;
-        }
-    }
 
     /**
      * @return whether the message's Content-Type has a primary type of {@code multipart}
@@ -184,7 +48,7 @@ public class MultipartUtil {
         return contentType != null && "multipart".equalsIgnoreCase(contentType.getPrimaryType());
     }
 
-    private static boolean isMultipart(String contentType) {
+    static boolean isMultipart(String contentType) {
         if (contentType == null)
             return false;
         try {
@@ -207,7 +71,7 @@ public class MultipartUtil {
         return split(message, boundaryOf(message));
     }
 
-    private static String boundaryOf(Message message) throws IOException, ParseException {
+    static String boundaryOf(Message message) throws IOException, ParseException {
         var contentType = message.getHeader().getContentTypeObject();
         if (contentType == null) {
             throw new IOException("No Content-Type header");
@@ -222,8 +86,8 @@ public class MultipartUtil {
     /**
      * Splits a multipart message into its individual parts using an explicit boundary.
      *
-     * <p>Buffers every part, so use {@link #forEachPart(Message, int, PartHandler)} when the parts
-     * can be large or when only some of them are needed.</p>
+     * <p>Buffers every part, so use {@link PartScanner#forEachPart} when the parts can be large or
+     * when only some of them are needed.</p>
      *
      * @param message  a request or response with a multipart body
      * @param boundary the MIME boundary string (without leading {@code --})
@@ -233,10 +97,10 @@ public class MultipartUtil {
      */
     public static List<Part> split(Message message, String boundary) throws IOException {
         List<Part> result = new ArrayList<>();
-        forEachPart(message, boundary, Integer.MAX_VALUE, new PartHandler() {
+        PartScanner.forEachPart(message, boundary, Integer.MAX_VALUE, new PartScanner.PartHandler() {
             @Override
-            public PartAction decide(Header partHeader) {
-                return PartAction.INSPECT;
+            public PartScanner.PartAction decide(Header partHeader) {
+                return PartScanner.PartAction.INSPECT;
             }
 
             @Override
@@ -247,13 +111,4 @@ public class MultipartUtil {
         return result;
     }
 
-    /** Only binary-safe encodings are supported; base64/QP would corrupt binary parts. */
-    private static void checkContentTransferEncoding(Header partHeader) throws IOException {
-        String cte = partHeader.getFirstValue("Content-Transfer-Encoding");
-        if (cte != null && !cte.equalsIgnoreCase("binary")
-                && !cte.equalsIgnoreCase("8bit")
-                && !cte.equalsIgnoreCase("7bit")) {
-            throw new IOException("Content-Transfer-Encoding '" + cte + "' is not supported.");
-        }
-    }
 }

--- a/core/src/main/java/com/predic8/membrane/core/multipart/MultipartUtil.java
+++ b/core/src/main/java/com/predic8/membrane/core/multipart/MultipartUtil.java
@@ -43,35 +43,117 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 public class MultipartUtil {
 
+    /** What {@link PartHandler} wants done with a part, decided from its header alone. */
+    public enum PartAction {
+        /** Buffer the body (bounded) and pass it to {@link PartHandler#handle}. */
+        INSPECT,
+        /** Discard the body without reading it into memory, and continue with the next part. */
+        SKIP,
+        /** Stop the traversal immediately; nothing further is read or buffered. */
+        STOP
+    }
+
     /**
-     * Returns the inspectable documents of a message: one unit for a normal body, one unit per part
-     * for a multipart body, and a single reassembled unit for an XOP/MTOM message.
+     * Decides from a part's header alone whether its body is needed, so that unwanted parts are
+     * never buffered.
+     */
+    public interface PartHandler {
+        PartAction decide(Header partHeader);
+
+        void handle(Part part) throws IOException;
+    }
+
+    /**
+     * Streams the parts of a multipart message to a handler, holding at most one part body in memory
+     * at a time. Parts the handler does not want are discarded unread, and a part exceeding
+     * {@code maxPartSize} aborts the traversal instead of being buffered whole.
      *
-     * <p>Callers that inspect message content (e.g. the protection interceptors) can treat "the whole
-     * body" and "one attachment" with the same code by iterating over the units.</p>
+     * <p>An XOP/MTOM message is reassembled first and passed to the handler as a single part.</p>
      *
-     * <p>Content-Encodings (gzip, deflate, brotli) are decoded; the returned bodies are the logical
-     * content.</p>
+     * <p>Content-Encodings (gzip, deflate, brotli) are decoded; the bodies passed to the handler are
+     * the logical content.</p>
      *
-     * @param message a request or response
-     * @return units in wire order; never null, never empty
-     * @throws IOException    on I/O or parse errors, or if a part is itself multipart
+     * @param message     a multipart request or response
+     * @param maxPartSize maximum number of bytes a single part's body may occupy
+     * @throws IOException    on I/O or parse errors, if a part is itself multipart, or if a part
+     *                        exceeds {@code maxPartSize}
      * @throws ParseException if the Content-Type header cannot be parsed
      */
-    public static List<Part> unitsOf(Message message) throws IOException, ParseException {
+    @SuppressWarnings("deprecation")
+    public static void forEachPart(Message message, int maxPartSize, PartHandler handler) throws IOException, ParseException {
         Message reconstituted = reconstituteXOP(message);
-        if (reconstituted != null)
-            return List.of(new Part(reconstituted.getHeader(), MessageUtil.getContent(reconstituted)));
-
-        if (!isMultipart(message))
-            return List.of(new Part(message.getHeader(), MessageUtil.getContent(message)));
-
-        List<Part> parts = split(message);
-        for (Part part : parts) {
-            if (isMultipart(part.getContentType()))
-                throw new IOException("Nested multipart is not supported: part has Content-Type " + part.getContentType());
+        if (reconstituted != null) {
+            if (handler.decide(reconstituted.getHeader()) == PartAction.INSPECT)
+                handler.handle(new Part(reconstituted.getHeader(), MessageUtil.getContent(reconstituted)));
+            return;
         }
-        return parts;
+
+        MultipartStream ms = new MultipartStream(MessageUtil.getContentAsStream(message), boundaryOf(message).getBytes(UTF_8));
+        boolean hasNext = ms.skipPreamble();
+        while (hasNext) {
+            Header partHeader = new Header(ms.readHeaders());
+            // Everything that can reject a part is decided from its header, before any body byte is buffered.
+            checkSupported(partHeader);
+
+            switch (handler.decide(partHeader)) {
+                case STOP -> {
+                    return;
+                }
+                case SKIP -> ms.discardBodyData();
+                case INSPECT -> {
+                    BoundedOutputStream body = new BoundedOutputStream(maxPartSize);
+                    try {
+                        ms.readBodyData(body);
+                    } catch (PartTooLargeException e) {
+                        throw new IOException(e.getMessage());
+                    }
+                    handler.handle(new Part(partHeader, body.toByteArray()));
+                }
+            }
+            hasNext = ms.readBoundary();
+        }
+    }
+
+    private static void checkSupported(Header partHeader) throws IOException {
+        if (isMultipart(partHeader.getContentType()))
+            throw new IOException("Nested multipart is not supported: part has Content-Type " + partHeader.getContentType());
+        checkContentTransferEncoding(partHeader);
+    }
+
+    /**
+     * Buffers up to a fixed number of bytes and fails as soon as that is exceeded, so an oversized
+     * part stops the read early instead of being materialised in full.
+     */
+    private static class BoundedOutputStream extends ByteArrayOutputStream {
+        private final int limit;
+
+        BoundedOutputStream(int limit) {
+            this.limit = limit;
+        }
+
+        @Override
+        public synchronized void write(int b) {
+            checkRoomFor(1);
+            super.write(b);
+        }
+
+        @Override
+        public synchronized void write(byte[] b, int off, int len) {
+            checkRoomFor(len);
+            super.write(b, off, len);
+        }
+
+        private void checkRoomFor(int additional) {
+            if (size() + additional > limit)
+                throw new PartTooLargeException(limit);
+        }
+    }
+
+    /** Unchecked so it can escape {@link java.io.OutputStream#write}; converted by {@link #forEachPart}. */
+    static class PartTooLargeException extends RuntimeException {
+        PartTooLargeException(int limit) {
+            super("Part exceeds the maximum size of " + limit + " bytes.");
+        }
     }
 
     /**
@@ -114,6 +196,10 @@ public class MultipartUtil {
      * @throws ParseException if the Content-Type header cannot be parsed
      */
     public static List<Part> split(Message message) throws IOException, ParseException {
+        return split(message, boundaryOf(message));
+    }
+
+    private static String boundaryOf(Message message) throws IOException, ParseException {
         var contentType = message.getHeader().getContentTypeObject();
         if (contentType == null) {
             throw new IOException("No Content-Type header");
@@ -122,7 +208,7 @@ public class MultipartUtil {
         if (boundary == null) {
             throw new IOException("No boundary parameter in Content-Type: " + contentType);
         }
-        return split(message, boundary);
+        return boundary;
     }
 
     /**
@@ -143,18 +229,21 @@ public class MultipartUtil {
             Header partHeader = new Header(ms.readHeaders());
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             ms.readBodyData(baos);
-
-            // Only binary-safe encodings are supported; base64/QP would corrupt binary parts
-            String cte = partHeader.getFirstValue("Content-Transfer-Encoding");
-            if (cte != null && !cte.equalsIgnoreCase("binary")
-                    && !cte.equalsIgnoreCase("8bit")
-                    && !cte.equalsIgnoreCase("7bit")) {
-                throw new IOException("Content-Transfer-Encoding '" + cte + "' is not supported.");
-            }
+            checkContentTransferEncoding(partHeader);
 
             result.add(new Part(partHeader, baos.toByteArray()));
             hasNext = ms.readBoundary();
         }
         return result;
+    }
+
+    /** Only binary-safe encodings are supported; base64/QP would corrupt binary parts. */
+    private static void checkContentTransferEncoding(Header partHeader) throws IOException {
+        String cte = partHeader.getFirstValue("Content-Transfer-Encoding");
+        if (cte != null && !cte.equalsIgnoreCase("binary")
+                && !cte.equalsIgnoreCase("8bit")
+                && !cte.equalsIgnoreCase("7bit")) {
+            throw new IOException("Content-Transfer-Encoding '" + cte + "' is not supported.");
+        }
     }
 }

--- a/core/src/main/java/com/predic8/membrane/core/multipart/MultipartUtil.java
+++ b/core/src/main/java/com/predic8/membrane/core/multipart/MultipartUtil.java
@@ -68,7 +68,10 @@ public class MultipartUtil {
      * at a time. Parts the handler does not want are discarded unread, and a part exceeding
      * {@code maxPartSize} aborts the traversal instead of being buffered whole.
      *
-     * <p>An XOP/MTOM message is reassembled first and passed to the handler as a single part.</p>
+     * <p>XOP/MTOM messages are traversed as their raw parts and are deliberately not reassembled:
+     * reassembly would have to buffer every attachment and a base64-inflated copy of it before the
+     * handler could decide anything. Callers that need the reassembled document (schema validation,
+     * for example) use {@link XOPReconstitutor} directly.</p>
      *
      * <p>Content-Encodings (gzip, deflate, brotli) are decoded; the bodies passed to the handler are
      * the logical content.</p>
@@ -81,13 +84,6 @@ public class MultipartUtil {
      */
     @SuppressWarnings("deprecation")
     public static void forEachPart(Message message, int maxPartSize, PartHandler handler) throws IOException, ParseException {
-        Message reconstituted = reconstituteXOP(message);
-        if (reconstituted != null) {
-            if (handler.decide(reconstituted.getHeader()) == PartAction.INSPECT)
-                handler.handle(new Part(reconstituted.getHeader(), MessageUtil.getContent(reconstituted)));
-            return;
-        }
-
         MultipartStream ms = new MultipartStream(MessageUtil.getContentAsStream(message), boundaryOf(message).getBytes(UTF_8));
         boolean hasNext = ms.skipPreamble();
         while (hasNext) {
@@ -153,18 +149,6 @@ public class MultipartUtil {
     static class PartTooLargeException extends RuntimeException {
         PartTooLargeException(int limit) {
             super("Part exceeds the maximum size of " + limit + " bytes.");
-        }
-    }
-
-    /**
-     * @return the reassembled message of an XOP/MTOM multipart, or null if the message is not one
-     */
-    private static Message reconstituteXOP(Message message) {
-        try {
-            return new XOPReconstitutor().getReconstitutedMessage(message);
-        } catch (Exception e) {
-            // Not a well-formed XOP message; fall back to treating it as ordinary multipart.
-            return null;
         }
     }
 

--- a/core/src/main/java/com/predic8/membrane/core/multipart/MultipartUtil.java
+++ b/core/src/main/java/com/predic8/membrane/core/multipart/MultipartUtil.java
@@ -82,9 +82,18 @@ public class MultipartUtil {
      *                        exceeds {@code maxPartSize}
      * @throws ParseException if the Content-Type header cannot be parsed
      */
-    @SuppressWarnings("deprecation")
     public static void forEachPart(Message message, int maxPartSize, PartHandler handler) throws IOException, ParseException {
-        MultipartStream ms = new MultipartStream(MessageUtil.getContentAsStream(message), boundaryOf(message).getBytes(UTF_8));
+        forEachPart(message, boundaryOf(message), maxPartSize, handler);
+    }
+
+    /**
+     * Streams the parts to a handler using an explicit boundary, for callers that know it already.
+     *
+     * @see #forEachPart(Message, int, PartHandler)
+     */
+    @SuppressWarnings("deprecation")
+    public static void forEachPart(Message message, String boundary, int maxPartSize, PartHandler handler) throws IOException {
+        MultipartStream ms = new MultipartStream(MessageUtil.getContentAsStream(message), boundary.getBytes(UTF_8));
         boolean hasNext = ms.skipPreamble();
         while (hasNext) {
             Header partHeader = new Header(ms.readHeaders());
@@ -100,8 +109,8 @@ public class MultipartUtil {
                     BoundedOutputStream body = new BoundedOutputStream(maxPartSize);
                     try {
                         ms.readBodyData(body);
-                    } catch (PartTooLargeException e) {
-                        throw new IOException(e.getMessage(), e);
+                    } catch (LimitExceeded e) {
+                        throw new PartTooLargeException(partHeader, maxPartSize, e);
                     }
                     handler.handle(new Part(partHeader, body.toByteArray()));
                 }
@@ -141,14 +150,29 @@ public class MultipartUtil {
 
         private void checkRoomFor(int additional) {
             if (size() + additional > limit)
-                throw new PartTooLargeException(limit);
+                throw new LimitExceeded();
         }
     }
 
     /** Unchecked so it can escape {@link java.io.OutputStream#write}; converted by {@link #forEachPart}. */
-    static class PartTooLargeException extends RuntimeException {
-        PartTooLargeException(int limit) {
-            super("Part exceeds the maximum size of " + limit + " bytes.");
+    private static class LimitExceeded extends RuntimeException {
+    }
+
+    /**
+     * Carries the header of the part that was too large, so a caller can report which attachment of
+     * an upload was rejected.
+     */
+    public static class PartTooLargeException extends IOException {
+
+        private final transient Header partHeader;
+
+        private PartTooLargeException(Header partHeader, int limit, Throwable cause) {
+            super("Part exceeds the maximum size of " + limit + " bytes.", cause);
+            this.partHeader = partHeader;
+        }
+
+        public Header getPartHeader() {
+            return partHeader;
         }
     }
 
@@ -176,7 +200,7 @@ public class MultipartUtil {
      *
      * @param message a request or response whose Content-Type is multipart/*
      * @return parts in wire order; never null, may be empty
-     * @throws IOException    on I/O or parse errors
+     * @throws IOException    on I/O or parse errors, or if a part is itself multipart
      * @throws ParseException if the Content-Type header cannot be parsed
      */
     public static List<Part> split(Message message) throws IOException, ParseException {
@@ -198,26 +222,28 @@ public class MultipartUtil {
     /**
      * Splits a multipart message into its individual parts using an explicit boundary.
      *
+     * <p>Buffers every part, so use {@link #forEachPart(Message, int, PartHandler)} when the parts
+     * can be large or when only some of them are needed.</p>
+     *
      * @param message  a request or response with a multipart body
      * @param boundary the MIME boundary string (without leading {@code --})
      * @return parts in wire order; never null, may be empty
-     * @throws IOException on I/O or unsupported Content-Transfer-Encoding
+     * @throws IOException on I/O errors, on unsupported Content-Transfer-Encoding, or if a part is
+     *                     itself multipart
      */
-    @SuppressWarnings("deprecation")
     public static List<Part> split(Message message, String boundary) throws IOException {
         List<Part> result = new ArrayList<>();
+        forEachPart(message, boundary, Integer.MAX_VALUE, new PartHandler() {
+            @Override
+            public PartAction decide(Header partHeader) {
+                return PartAction.INSPECT;
+            }
 
-        MultipartStream ms = new MultipartStream(MessageUtil.getContentAsStream(message), boundary.getBytes(UTF_8));
-        boolean hasNext = ms.skipPreamble();
-        while (hasNext) {
-            Header partHeader = new Header(ms.readHeaders());
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            ms.readBodyData(baos);
-            checkContentTransferEncoding(partHeader);
-
-            result.add(new Part(partHeader, baos.toByteArray()));
-            hasNext = ms.readBoundary();
-        }
+            @Override
+            public void handle(Part part) {
+                result.add(part);
+            }
+        });
         return result;
     }
 

--- a/core/src/main/java/com/predic8/membrane/core/multipart/MultipartUtil.java
+++ b/core/src/main/java/com/predic8/membrane/core/multipart/MultipartUtil.java
@@ -17,6 +17,7 @@ package com.predic8.membrane.core.multipart;
 import com.predic8.membrane.core.http.Header;
 import com.predic8.membrane.core.http.Message;
 import com.predic8.membrane.core.util.MessageUtil;
+import jakarta.mail.internet.ContentType;
 import jakarta.mail.internet.ParseException;
 import org.apache.commons.fileupload.MultipartStream;
 
@@ -41,6 +42,67 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * }</pre>
  */
 public class MultipartUtil {
+
+    /**
+     * Returns the inspectable documents of a message: one unit for a normal body, one unit per part
+     * for a multipart body, and a single reassembled unit for an XOP/MTOM message.
+     *
+     * <p>Callers that inspect message content (e.g. the protection interceptors) can treat "the whole
+     * body" and "one attachment" with the same code by iterating over the units.</p>
+     *
+     * <p>Content-Encodings (gzip, deflate, brotli) are decoded; the returned bodies are the logical
+     * content.</p>
+     *
+     * @param message a request or response
+     * @return units in wire order; never null, never empty
+     * @throws IOException    on I/O or parse errors, or if a part is itself multipart
+     * @throws ParseException if the Content-Type header cannot be parsed
+     */
+    public static List<Part> unitsOf(Message message) throws IOException, ParseException {
+        Message reconstituted = reconstituteXOP(message);
+        if (reconstituted != null)
+            return List.of(new Part(reconstituted.getHeader(), MessageUtil.getContent(reconstituted)));
+
+        if (!isMultipart(message))
+            return List.of(new Part(message.getHeader(), MessageUtil.getContent(message)));
+
+        List<Part> parts = split(message);
+        for (Part part : parts) {
+            if (isMultipart(part.getContentType()))
+                throw new IOException("Nested multipart is not supported: part has Content-Type " + part.getContentType());
+        }
+        return parts;
+    }
+
+    /**
+     * @return the reassembled message of an XOP/MTOM multipart, or null if the message is not one
+     */
+    private static Message reconstituteXOP(Message message) {
+        try {
+            return new XOPReconstitutor().getReconstitutedMessage(message);
+        } catch (Exception e) {
+            // Not a well-formed XOP message; fall back to treating it as ordinary multipart.
+            return null;
+        }
+    }
+
+    /**
+     * @return whether the message's Content-Type has a primary type of {@code multipart}
+     */
+    public static boolean isMultipart(Message message) throws ParseException {
+        var contentType = message.getHeader().getContentTypeObject();
+        return contentType != null && "multipart".equalsIgnoreCase(contentType.getPrimaryType());
+    }
+
+    private static boolean isMultipart(String contentType) {
+        if (contentType == null)
+            return false;
+        try {
+            return "multipart".equalsIgnoreCase(new ContentType(contentType).getPrimaryType());
+        } catch (ParseException e) {
+            return false;
+        }
+    }
 
     /**
      * Splits a multipart message into its individual parts.

--- a/core/src/main/java/com/predic8/membrane/core/multipart/MultipartUtil.java
+++ b/core/src/main/java/com/predic8/membrane/core/multipart/MultipartUtil.java
@@ -101,7 +101,7 @@ public class MultipartUtil {
                     try {
                         ms.readBodyData(body);
                     } catch (PartTooLargeException e) {
-                        throw new IOException(e.getMessage());
+                        throw new IOException(e.getMessage(), e);
                     }
                     handler.handle(new Part(partHeader, body.toByteArray()));
                 }

--- a/core/src/main/java/com/predic8/membrane/core/multipart/Part.java
+++ b/core/src/main/java/com/predic8/membrane/core/multipart/Part.java
@@ -60,7 +60,7 @@ public class Part {
      * Used in MIME multipart/related messages (e.g. SOAP XOP).
      */
     public String getContentID() {
-        return header.getFirstValue("Content-ID");
+        return contentIDOf(header);
     }
 
     /**
@@ -77,7 +77,22 @@ public class Part {
      * Returns {@code null} if not present.
      */
     public String getName() {
-        return extractDispositionParam(NAME_PATTERN);
+        return nameOf(header);
+    }
+
+    /**
+     * Reads the form field name from a part's header alone, for callers that decide what to do with
+     * a part before its body has been read.
+     */
+    public static String nameOf(Header header) {
+        return extractDispositionParam(header, NAME_PATTERN);
+    }
+
+    /**
+     * Reads the {@code Content-ID} from a part's header alone.
+     */
+    public static String contentIDOf(Header header) {
+        return header.getFirstValue("Content-ID");
     }
 
     /**
@@ -125,6 +140,10 @@ public class Part {
     // -------------------------------------------------------------------------
 
     private String extractDispositionParam(Pattern pattern) {
+        return extractDispositionParam(header, pattern);
+    }
+
+    private static String extractDispositionParam(Header header, Pattern pattern) {
         String disposition = header.getFirstValue("Content-Disposition");
         if (disposition == null) return null;
         Matcher m = pattern.matcher(disposition);

--- a/core/src/main/java/com/predic8/membrane/core/multipart/PartScanner.java
+++ b/core/src/main/java/com/predic8/membrane/core/multipart/PartScanner.java
@@ -1,0 +1,173 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.core.multipart;
+
+import com.predic8.membrane.core.http.Header;
+import com.predic8.membrane.core.http.Message;
+import com.predic8.membrane.core.util.MessageUtil;
+import jakarta.mail.internet.ParseException;
+import org.apache.commons.fileupload.MultipartStream;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static com.predic8.membrane.core.multipart.MultipartUtil.boundaryOf;
+import static com.predic8.membrane.core.multipart.MultipartUtil.isMultipart;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Traverses a multipart message part by part, letting the caller decide from each part's header
+ * whether its body is needed at all. Use this over {@link MultipartUtil#split} whenever the parts
+ * can be large or only some of them are of interest.
+ *
+ * <p>Example:
+ * <pre>{@code
+ * PartScanner.forEachPart(exchange.getRequest(), 1024 * 1024, new PartScanner.PartHandler() {
+ *     public PartAction decide(Header partHeader) {
+ *         return isJson(partHeader.getContentType()) ? PartAction.INSPECT : PartAction.SKIP;
+ *     }
+ *     public void handle(Part part) {
+ *         // only the JSON parts ever reach this point, and each is bounded
+ *     }
+ * });
+ * }</pre>
+ */
+public class PartScanner {
+
+    /** What {@link PartHandler} wants done with a part, decided from its header alone. */
+    public enum PartAction {
+        /** Buffer the body (bounded) and pass it to {@link PartHandler#handle}. */
+        INSPECT,
+        /** Discard the body without reading it into memory, and continue with the next part. */
+        SKIP,
+        /** Stop the traversal immediately; nothing further is read or buffered. */
+        STOP
+    }
+
+    /**
+     * Decides from a part's header alone whether its body is needed, so that unwanted parts are
+     * never buffered.
+     */
+    public interface PartHandler {
+        PartAction decide(Header partHeader);
+
+        void handle(Part part) throws IOException;
+    }
+
+    /**
+     * Streams the parts of a multipart message to a handler, holding at most one part body in memory
+     * at a time. Parts the handler does not want are discarded unread, and a part exceeding
+     * {@code maxPartSize} aborts the traversal instead of being buffered whole.
+     *
+     * <p>XOP/MTOM messages are traversed as their raw parts and are deliberately not reassembled:
+     * reassembly would have to buffer every attachment and a base64-inflated copy of it before the
+     * handler could decide anything. Callers that need the reassembled document (schema validation,
+     * for example) use {@link XOPReconstitutor} directly.</p>
+     *
+     * <p>Content-Encodings (gzip, deflate, brotli) are decoded; the bodies passed to the handler are
+     * the logical content.</p>
+     *
+     * @param message     a multipart request or response
+     * @param maxPartSize maximum number of bytes a single part's body may occupy
+     * @throws IOException    on I/O or parse errors, if a part is itself multipart, or, as
+     *                        {@link PartTooLargeException}, if a part exceeds {@code maxPartSize}
+     * @throws ParseException if the Content-Type header cannot be parsed
+     */
+    public static void forEachPart(Message message, int maxPartSize, PartHandler handler) throws IOException, ParseException {
+        forEachPart(message, boundaryOf(message), maxPartSize, handler);
+    }
+
+    /**
+     * Streams the parts to a handler using an explicit boundary, for callers that know it already.
+     *
+     * @see #forEachPart(Message, int, PartHandler)
+     */
+    @SuppressWarnings("deprecation")
+    public static void forEachPart(Message message, String boundary, int maxPartSize, PartHandler handler) throws IOException {
+        MultipartStream ms = new MultipartStream(MessageUtil.getContentAsStream(message), boundary.getBytes(UTF_8));
+        boolean hasNext = ms.skipPreamble();
+        while (hasNext) {
+            Header partHeader = new Header(ms.readHeaders());
+            // Everything that can reject a part is decided from its header, before any body byte is buffered.
+            checkSupported(partHeader);
+
+            switch (handler.decide(partHeader)) {
+                case STOP -> {
+                    return;
+                }
+                case SKIP -> ms.discardBodyData();
+                case INSPECT -> {
+                    BoundedOutputStream body = new BoundedOutputStream(maxPartSize);
+                    try {
+                        ms.readBodyData(body);
+                    } catch (LimitExceeded e) {
+                        throw new PartTooLargeException(partHeader, maxPartSize, e);
+                    }
+                    handler.handle(new Part(partHeader, body.toByteArray()));
+                }
+            }
+            hasNext = ms.readBoundary();
+        }
+    }
+
+    private static void checkSupported(Header partHeader) throws IOException {
+        if (isMultipart(partHeader.getContentType()))
+            throw new IOException("Nested multipart is not supported: part has Content-Type " + partHeader.getContentType());
+        checkContentTransferEncoding(partHeader);
+    }
+
+    /** Only binary-safe encodings are supported; base64/QP would corrupt binary parts. */
+    private static void checkContentTransferEncoding(Header partHeader) throws IOException {
+        String cte = partHeader.getFirstValue("Content-Transfer-Encoding");
+        if (cte != null && !cte.equalsIgnoreCase("binary")
+                && !cte.equalsIgnoreCase("8bit")
+                && !cte.equalsIgnoreCase("7bit")) {
+            throw new IOException("Content-Transfer-Encoding '" + cte + "' is not supported.");
+        }
+    }
+
+    /**
+     * Buffers up to a fixed number of bytes and fails as soon as that is exceeded, so an oversized
+     * part stops the read early instead of being materialised in full.
+     */
+    private static class BoundedOutputStream extends ByteArrayOutputStream {
+        private final int limit;
+
+        BoundedOutputStream(int limit) {
+            this.limit = limit;
+        }
+
+        @Override
+        public synchronized void write(int b) {
+            checkRoomFor(1);
+            super.write(b);
+        }
+
+        @Override
+        public synchronized void write(byte[] b, int off, int len) {
+            checkRoomFor(len);
+            super.write(b, off, len);
+        }
+
+        private void checkRoomFor(int additional) {
+            if (size() + additional > limit)
+                throw new LimitExceeded();
+        }
+    }
+
+    /** Unchecked so it can escape {@link java.io.OutputStream#write}; converted by {@link #forEachPart}. */
+    private static class LimitExceeded extends RuntimeException {
+    }
+}

--- a/core/src/main/java/com/predic8/membrane/core/multipart/PartTooLargeException.java
+++ b/core/src/main/java/com/predic8/membrane/core/multipart/PartTooLargeException.java
@@ -1,0 +1,38 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.core.multipart;
+
+import com.predic8.membrane.core.http.Header;
+
+import java.io.IOException;
+
+/**
+ * Thrown by {@link PartScanner#forEachPart} when a part's body exceeds the given maximum size.
+ * Carries the header of the offending part, so a caller can report which attachment of an upload
+ * was rejected.
+ */
+public class PartTooLargeException extends IOException {
+
+    private final transient Header partHeader;
+
+    PartTooLargeException(Header partHeader, int limit, Throwable cause) {
+        super("Part exceeds the maximum size of " + limit + " bytes.", cause);
+        this.partHeader = partHeader;
+    }
+
+    public Header getPartHeader() {
+        return partHeader;
+    }
+}

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptorTest.java
@@ -290,7 +290,10 @@ public class JsonProtectionInterceptorTest {
         var exc = multipartExchange(part("logo", "image/png", "\u0089PNG"));
 
         assertEquals(RETURN, jpiDev.handleRequest(exc));
-        assertTrue(parse(exc.getResponse()).getDetail().contains("is not JSON"));
+        var detail = parse(exc.getResponse()).getDetail();
+        assertTrue(detail.contains("is not JSON"), detail);
+        // The name comes from the part header alone, since the body of a rejected part is never read.
+        assertTrue(detail.contains("logo"), "should name the offending part: " + detail);
     }
 
     @Test
@@ -324,6 +327,7 @@ public class JsonProtectionInterceptorTest {
         var exc = multipartExchange(part("field", null, deeplyNested()));
 
         assertEquals(CONTINUE, jpiDev.handleRequest(exc));
+        assertNull(exc.getResponse());
     }
 
     @Test
@@ -423,8 +427,10 @@ public class JsonProtectionInterceptorTest {
     @Test
     void xopRequestIsSkippedWhenConfigured() throws Exception {
         jpiDev.setOtherContentTypes(SKIP);
+        var exc = xopExchange();
 
-        assertEquals(CONTINUE, jpiDev.handleRequest(xopExchange()));
+        assertEquals(CONTINUE, jpiDev.handleRequest(exc));
+        assertNull(exc.getResponse());
     }
 
     @Test

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptorTest.java
@@ -97,6 +97,14 @@ public class JsonProtectionInterceptorTest {
     }
 
     @Test
+    public void getRequestIsNotScanned() throws Exception {
+        var exc = Request.get("/").buildExchange();
+
+        assertEquals(CONTINUE, jpiProd.handleRequest(exc));
+        assertNull(exc.getResponse());
+    }
+
+    @Test
     public void tooLong() throws Exception {
         send("[" + repeat("\"0123456\",", 1024) + "\"x\"]",
                 RETURN,

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptorTest.java
@@ -375,6 +375,44 @@ public class JsonProtectionInterceptorTest {
 
     private static final String BOUNDARY = "----MembraneTestBoundary";
 
+    // --- Bounded buffering -------------------------------------------------------------------
+
+    /** maxSize is per document, so an oversized part must be rejected without being buffered whole. */
+    @Test
+    void firstPartExceedingMaxSizeIsRejected() throws Exception {
+        var exc = multipartExchange(
+                part("first", APPLICATION_JSON, "{\"a\":\"" + repeat("x", 20000) + "\"}"),
+                part("second", APPLICATION_JSON, "{\"a\":\"b\"}"));
+
+        assertEquals(RETURN, jpiDev.handleRequest(exc));
+        assertTrue(parse(exc.getResponse()).getDetail().contains("maximum size"),
+                parse(exc.getResponse()).getDetail());
+    }
+
+    /**
+     * The case that must not buffer: a huge non-JSON part under SKIP is discarded from the stream
+     * without ever being materialised, so maxSize does not apply to it.
+     */
+    @Test
+    void oversizedNonJsonPartIsSkippedWithoutBuffering() throws Exception {
+        jpiDev.setOtherContentTypes(SKIP);
+        var exc = multipartExchange(
+                part("logo", "image/png", repeat("x", 50000)),
+                part("data", APPLICATION_JSON, "{\"a\":\"b\"}"));
+
+        assertEquals(CONTINUE, jpiDev.handleRequest(exc));
+        assertNull(exc.getResponse());
+    }
+
+    /** Rejecting a non-JSON part needs its header only, so its body is never read. */
+    @Test
+    void oversizedNonJsonPartIsRejectedWithoutBuffering() throws Exception {
+        var exc = multipartExchange(part("logo", "image/png", repeat("x", 50000)));
+
+        assertEquals(RETURN, jpiDev.handleRequest(exc));
+        assertTrue(parse(exc.getResponse()).getDetail().contains("is not JSON"));
+    }
+
     private void send(String body, Outcome expectOut, Object... parameters) throws Exception {
         var exc = Request
                 .post("/")

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptorTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.*;
 
 import static com.google.common.base.Strings.*;
 import static com.predic8.membrane.core.http.MimeType.*;
+import static com.predic8.membrane.core.interceptor.json.JsonProtectionInterceptor.OtherContentTypes.*;
 import static com.predic8.membrane.core.interceptor.Outcome.*;
 import static com.predic8.membrane.core.util.ProblemDetailsTestUtil.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -252,6 +253,127 @@ public class JsonProtectionInterceptorTest {
                 16,
                 "__proto__ found as key.");
     }
+
+    // --- Multipart / attachments -------------------------------------------------------------
+
+    @Test
+    void jsonPartOfMultipartIsInspected() throws Exception {
+        var exc = multipartExchange(part("data", APPLICATION_JSON, deeplyNested()));
+
+        assertEquals(RETURN, jpiDev.handleRequest(exc));
+        var pd = parse(exc.getResponse());
+        assertTrue(pd.getDetail().contains("Exceeded maxDepth."), pd.getDetail());
+        assertTrue(pd.getDetail().contains("data"), "should name the offending part: " + pd.getDetail());
+    }
+
+    @Test
+    void benignMultipartPasses() throws Exception {
+        var exc = multipartExchange(part("data", APPLICATION_JSON, "{\"a\":\"b\"}"));
+
+        assertEquals(CONTINUE, jpiDev.handleRequest(exc));
+        assertNull(exc.getResponse());
+    }
+
+    @Test
+    void everyJsonPartIsInspected() throws Exception {
+        var exc = multipartExchange(
+                part("first", APPLICATION_JSON, "{\"a\":\"b\"}"),
+                part("second", APPLICATION_JSON, deeplyNested()));
+
+        assertEquals(RETURN, jpiDev.handleRequest(exc));
+        assertTrue(parse(exc.getResponse()).getDetail().contains("second"));
+    }
+
+    @Test
+    void nonJsonPartIsRejectedByDefault() throws Exception {
+        var exc = multipartExchange(part("logo", "image/png", "\u0089PNG"));
+
+        assertEquals(RETURN, jpiDev.handleRequest(exc));
+        assertTrue(parse(exc.getResponse()).getDetail().contains("is not JSON"));
+    }
+
+    @Test
+    void nonJsonPartIsSkippedWhenConfigured() throws Exception {
+        jpiDev.setOtherContentTypes(SKIP);
+        var exc = multipartExchange(
+                part("logo", "image/png", "\u0089PNG"),
+                part("data", APPLICATION_JSON, "{\"a\":\"b\"}"));
+
+        assertEquals(CONTINUE, jpiDev.handleRequest(exc));
+        assertNull(exc.getResponse());
+    }
+
+    @Test
+    void multipartBodyIsNotModified() throws Exception {
+        jpiDev.setOtherContentTypes(SKIP);
+        var exc = multipartExchange(part("logo", "image/png", "\u0089PNG"));
+        byte[] before = exc.getRequest().getBody().getContent();
+
+        assertEquals(CONTINUE, jpiDev.handleRequest(exc));
+        assertArrayEquals(before, exc.getRequest().getBody().getContent());
+    }
+
+    /**
+     * A part without a Content-Type defaults to text/plain, so it is not JSON - unlike a whole body
+     * without a Content-Type, which is still parsed (see {@link #bodyWithoutContentTypeIsStillParsed()}).
+     */
+    @Test
+    void partWithoutContentTypeIsNotJson() throws Exception {
+        jpiDev.setOtherContentTypes(SKIP);
+        var exc = multipartExchange(part("field", null, deeplyNested()));
+
+        assertEquals(CONTINUE, jpiDev.handleRequest(exc));
+    }
+
+    @Test
+    void bodyWithoutContentTypeIsStillParsed() throws Exception {
+        var exc = Request.post("/").body(deeplyNested()).buildExchange();
+
+        assertEquals(RETURN, jpiDev.handleRequest(exc));
+        assertTrue(parse(exc.getResponse()).getDetail().contains("Exceeded maxDepth."));
+    }
+
+    @Test
+    void nonJsonBodyIsSkippedWhenConfigured() throws Exception {
+        jpiDev.setOtherContentTypes(SKIP);
+        var exc = Request.post("/").contentType("image/png").body("\u0089PNG").buildExchange();
+
+        assertEquals(CONTINUE, jpiDev.handleRequest(exc));
+        assertNull(exc.getResponse());
+    }
+
+    @Test
+    void nestedMultipartIsRejected() throws Exception {
+        var exc = multipartExchange(part("nested", "multipart/mixed; boundary=inner", "..."));
+
+        assertEquals(RETURN, jpiDev.handleRequest(exc));
+        assertTrue(parse(exc.getResponse()).getDetail().contains("Nested multipart"));
+    }
+
+    /** Exceeds the maxDepth of 10 configured in {@link #buildJPI(boolean)}. */
+    private static String deeplyNested() {
+        return repeat("[", 12) + repeat("]", 12);
+    }
+
+    private static String part(String name, String contentType, String body) {
+        return "Content-Disposition: form-data; name=\"" + name + "\"\r\n"
+               + (contentType == null ? "" : "Content-Type: " + contentType + "\r\n")
+               + "\r\n" + body;
+    }
+
+    private static Exchange multipartExchange(String... parts) throws Exception {
+        StringBuilder body = new StringBuilder();
+        for (String part : parts)
+            body.append("--").append(BOUNDARY).append("\r\n").append(part).append("\r\n");
+        body.append("--").append(BOUNDARY).append("--\r\n");
+
+        return Request.post("/")
+                .contentType("multipart/form-data; boundary=" + BOUNDARY)
+                .body(body.toString())
+                .buildExchange();
+    }
+
+    private static final String BOUNDARY = "----MembraneTestBoundary";
 
     private void send(String body, Outcome expectOut, Object... parameters) throws Exception {
         var exc = Request

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptorTest.java
@@ -19,6 +19,7 @@ import com.predic8.membrane.core.exchange.*;
 import com.predic8.membrane.core.http.*;
 import com.predic8.membrane.core.interceptor.*;
 import com.predic8.membrane.core.router.*;
+import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.*;
 
 import static com.google.common.base.Strings.*;
@@ -411,6 +412,39 @@ public class JsonProtectionInterceptorTest {
 
         assertEquals(RETURN, jpiDev.handleRequest(exc));
         assertTrue(parse(exc.getResponse()).getDetail().contains("is not JSON"));
+    }
+
+    // --- XOP / MTOM --------------------------------------------------------------------------
+
+    /**
+     * An XOP message is XML by definition, so jsonProtection never wants it reassembled - it is
+     * traversed as raw parts and handled by the otherContentTypes policy like any other non-JSON.
+     */
+    @Test
+    void xopRequestIsSkippedWhenConfigured() throws Exception {
+        jpiDev.setOtherContentTypes(SKIP);
+
+        assertEquals(CONTINUE, jpiDev.handleRequest(xopExchange()));
+    }
+
+    @Test
+    void xopRequestIsRejectedByDefault() throws Exception {
+        var exc = xopExchange();
+
+        assertEquals(RETURN, jpiDev.handleRequest(exc));
+        assertTrue(parse(exc.getResponse()).getDetail().contains("application/xop+xml"),
+                parse(exc.getResponse()).getDetail());
+    }
+
+    private static Exchange xopExchange() throws Exception {
+        byte[] body = IOUtils.toByteArray(
+                JsonProtectionInterceptorTest.class.getResourceAsStream("/multipart/embedded-byte-array.txt"));
+        return Request.post("/")
+                .contentType("multipart/related; type=\"application/xop+xml\"; "
+                        + "boundary=\"uuid:168683dc-43b3-4e71-8e66-efb633ef406b\"; "
+                        + "start=\"<root.message@cxf.apache.org>\"; start-info=\"text/xml\"")
+                .body(body)
+                .buildExchange();
     }
 
     private void send(String body, Outcome expectOut, Object... parameters) throws Exception {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/json/JsonProtectionInterceptorTest.java
@@ -390,8 +390,9 @@ public class JsonProtectionInterceptorTest {
                 part("second", APPLICATION_JSON, "{\"a\":\"b\"}"));
 
         assertEquals(RETURN, jpiDev.handleRequest(exc));
-        assertTrue(parse(exc.getResponse()).getDetail().contains("maximum size"),
-                parse(exc.getResponse()).getDetail());
+        var detail = parse(exc.getResponse()).getDetail();
+        assertTrue(detail.contains("maximum size"), detail);
+        assertTrue(detail.contains("In part 'first'"), detail);
     }
 
     /**

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/json/JsonProtectionScannerTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/json/JsonProtectionScannerTest.java
@@ -1,0 +1,150 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.core.interceptor.json;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+
+import static com.google.common.base.Strings.repeat;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Limit enforcement, checked directly on the scanner. The HTTP-level contract (status codes,
+ * ProblemDetails, multipart part naming) is covered by {@link JsonProtectionInterceptorTest}.
+ */
+public class JsonProtectionScannerTest {
+
+    private static final JsonLimits LIMITS =
+            new JsonLimits(4096, 10240, 10, 20, 10, 10, 2048, true);
+
+    private static final JsonProtectionScanner scanner = new JsonProtectionScanner(LIMITS);
+
+    @Test
+    void wellFormedDocumentWithinLimitsPasses() throws Exception {
+        scan("""
+                {"a":"b","c":[1,2,{"d":null}]}""");
+    }
+
+    @Test
+    void maxDepthCountsObjectsAndArraysAlike() {
+        assertEquals("Exceeded maxDepth.", violation(repeat("{\"a\":", 11) + "1" + repeat("}", 11)));
+        assertEquals("Exceeded maxDepth.", violation(repeat("[", 11) + "1" + repeat("]", 11)));
+    }
+
+    @Test
+    void justNotTooDeepPasses() throws Exception {
+        scan(repeat("{\"a\":", 10) + "1" + repeat("}", 10));
+    }
+
+    @Test
+    void maxObjectSizeIsPerObject() {
+        assertEquals("Exceeded maxObjectSize.", violation(object(11)));
+        assertDoesNotThrow(() -> scan(object(10)));
+    }
+
+    @Test
+    void maxArraySizeIsExceeded() {
+        assertEquals("Exceeded maxArraySize.", violation("[" + repeat("1,", 2048) + "1]"));
+    }
+
+    @Test
+    void maxStringLengthIsExceeded() {
+        assertEquals("Exceeded maxStringLength.", violation("{\"a\":\"" + repeat("x", 21) + "\"}"));
+    }
+
+    @Test
+    void maxKeyLengthIsExceeded() {
+        assertEquals("Exceeded maxKeyLength.", violation("{\"" + repeat("k", 11) + "\":1}"));
+    }
+
+    @Test
+    void maxTokensIsExceeded() {
+        // Room in the array so that only the token count can trip.
+        JsonProtectionScanner s = new JsonProtectionScanner(
+                new JsonLimits(4096, 10240, 10, 20, 10, 10, 100000, true));
+        var e = assertThrows(JsonProtectionException.class,
+                () -> s.scan(stream("[" + repeat("1,", 4096) + "1]")));
+        assertEquals("Exceeded maxTokens.", e.getMessage());
+    }
+
+    @Test
+    void maxSizeIsExceeded() {
+        // Few tokens, but a lot of bytes: only maxSize can catch this.
+        JsonProtectionScanner tiny = new JsonProtectionScanner(
+                new JsonLimits(4096, 32, 10, 262144, 256, 10, 2048, true));
+        var e = assertThrows(JsonProtectionException.class,
+                () -> tiny.scan(stream("{\"a\":\"" + repeat("x", 200) + "\"}")));
+        assertEquals("Exceeded maxSize.", e.getMessage());
+    }
+
+    @Test
+    void protoKeyIsBlockedOnlyWhileBlockProtoIsOn() throws Exception {
+        assertEquals("__proto__ found as key.", violation("{\"__proto__\":1}"));
+
+        JsonProtectionScanner permissive = new JsonProtectionScanner(
+                new JsonLimits(4096, 10240, 10, 20, 10, 10, 2048, false));
+        permissive.scan(stream("{\"__proto__\":1}"));
+    }
+
+    @Test
+    void duplicateKeysAreRejected() {
+        assertThrows(JsonParseException.class, () -> scan("""
+                {"a":1,"a":2}"""));
+    }
+
+    @Test
+    void malformedDocumentIsRejected() {
+        assertThrows(JsonParseException.class, () -> scan("{\"a\":"));
+    }
+
+    @Test
+    void violationReportsTheLocationItWasDetectedAt() {
+        var e = assertThrows(JsonProtectionException.class, () -> scan("{\"a\":\"" + repeat("x", 21) + "\"}"));
+        assertEquals(1, e.getLine());
+        assertTrue(e.getCol() > 1, "column should point into the document, was " + e.getCol());
+    }
+
+    /**
+     * A key is a string too, so the stricter of the two limits has to win regardless of which one
+     * the user configured lower.
+     */
+    @Test
+    void keyLengthIsClampedToStringLength() {
+        assertEquals(5, new JsonLimits(1, 1, 1, 5, 100, 1, 1, true).maxKeyLength());
+        assertEquals(5, new JsonLimits(1, 1, 1, 100, 5, 1, 1, true).maxKeyLength());
+    }
+
+    private static String object(int members) {
+        StringBuilder sb = new StringBuilder("{");
+        for (int i = 0; i < members; i++)
+            sb.append(i > 0 ? "," : "").append("\"k").append(i).append("\":1");
+        return sb.append("}").toString();
+    }
+
+    private static String violation(String json) {
+        return assertThrows(JsonProtectionException.class, () -> scan(json)).getMessage();
+    }
+
+    private static void scan(String json) throws Exception {
+        scanner.scan(stream(json));
+    }
+
+    private static ByteArrayInputStream stream(String json) {
+        return new ByteArrayInputStream(json.getBytes(UTF_8));
+    }
+}

--- a/core/src/test/java/com/predic8/membrane/core/multipart/MultipartUtilTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/multipart/MultipartUtilTest.java
@@ -19,7 +19,13 @@ import jakarta.mail.internet.ParseException;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 
+import com.predic8.membrane.core.http.Header;
+import com.predic8.membrane.core.multipart.MultipartUtil.PartAction;
+
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.*;
@@ -191,45 +197,111 @@ class MultipartUtilTest {
     }
 
     // -------------------------------------------------------------------------
-    // unitsOf(Message)
+    // forEachPart(Message, maxPartSize, PartHandler)
     // -------------------------------------------------------------------------
 
-    @Test
-    void plainBodyIsOneUnit() throws IOException, ParseException {
-        byte[] bytes = "{\"a\":\"b\"}".getBytes(UTF_8);
-        var msg = Response.ok()
-                .header("Content-Type", "application/json")
-                .header("Content-Length", String.valueOf(bytes.length))
-                .body(bytes)
-                .build();
+    /** Records what the traversal offered and what it actually handed over. */
+    private static class RecordingHandler implements MultipartUtil.PartHandler {
+        final List<String> decided = new ArrayList<>();
+        final List<Part> handled = new ArrayList<>();
+        private final Function<Header, PartAction> policy;
 
-        var units = MultipartUtil.unitsOf(msg);
+        RecordingHandler(Function<Header, PartAction> policy) {
+            this.policy = policy;
+        }
 
-        assertEquals(1, units.size());
-        assertEquals("application/json", units.getFirst().getContentType());
-        assertArrayEquals(bytes, units.getFirst().getBody());
+        @Override
+        public PartAction decide(Header partHeader) {
+            decided.add(Part.nameOf(partHeader));
+            return policy.apply(partHeader);
+        }
+
+        @Override
+        public void handle(Part part) {
+            handled.add(part);
+        }
+    }
+
+    private static RecordingHandler inspectAll() {
+        return new RecordingHandler(h -> PartAction.INSPECT);
     }
 
     @Test
-    void multipartBodyIsOneUnitPerPart() throws IOException, ParseException {
-        var units = MultipartUtil.unitsOf(response(multipartBody(
+    void partsAreHandedOverInOrder() throws IOException, ParseException {
+        var handler = inspectAll();
+
+        MultipartUtil.forEachPart(response(multipartBody(
                 formField("username", "alice"),
                 formField("message", "Hello World")
-        )));
+        )), 1024, handler);
 
-        assertEquals(2, units.size());
-        assertEquals("username", units.getFirst().getName());
-        assertEquals("message", units.get(1).getName());
+        assertEquals(List.of("username", "message"), handler.decided);
+        assertEquals("alice", handler.handled.getFirst().getBodyAsString());
+        assertEquals("Hello World", handler.handled.get(1).getBodyAsString());
     }
 
     @Test
-    void xopMessageIsOneReassembledUnit() throws IOException, ParseException {
-        var units = MultipartUtil.unitsOf(xopResponse());
+    void skippedPartIsNeverMaterialisedAndTraversalContinues() throws IOException, ParseException {
+        var handler = new RecordingHandler(h -> "skipme".equals(Part.nameOf(h)) ? PartAction.SKIP : PartAction.INSPECT);
 
-        assertEquals(1, units.size(), "XOP must not be split into raw parts");
-        assertEquals("text/xml", units.getFirst().getContentType());
-        // The binary part has been inlined as base64 instead of being a separate unit.
-        assertFalse(units.getFirst().getBodyAsString().contains("xop:Include"));
+        MultipartUtil.forEachPart(response(multipartBody(
+                formField("skipme", "0123456789"),
+                formField("keepme", "alice")
+        )), 1024, handler);
+
+        assertEquals(List.of("skipme", "keepme"), handler.decided, "both parts must be offered");
+        assertEquals(1, handler.handled.size(), "the skipped part must not be handed over");
+        assertEquals("keepme", handler.handled.getFirst().getName());
+    }
+
+    @Test
+    void stopEndsTraversalWithoutTouchingLaterParts() throws IOException, ParseException {
+        var handler = new RecordingHandler(h -> PartAction.STOP);
+
+        MultipartUtil.forEachPart(response(multipartBody(
+                formField("first", "a"),
+                formField("second", "b")
+        )), 1024, handler);
+
+        assertEquals(List.of("first"), handler.decided);
+        assertTrue(handler.handled.isEmpty());
+    }
+
+    @Test
+    void partExceedingMaxPartSizeIsRejected() {
+        var handler = inspectAll();
+        var msg = response(multipartBody(formField("big", "0123456789")));
+
+        var e = assertThrows(IOException.class, () -> MultipartUtil.forEachPart(msg, 4, handler));
+
+        assertTrue(e.getMessage().contains("maximum size of 4"), e.getMessage());
+        assertTrue(handler.handled.isEmpty(), "an oversized part must not be handed over");
+    }
+
+    @Test
+    void oversizedPartIsNotReadWhenSkipped() throws IOException, ParseException {
+        // The size cap applies only to what is buffered, so a huge skipped part costs nothing.
+        var handler = new RecordingHandler(h -> "huge".equals(Part.nameOf(h)) ? PartAction.SKIP : PartAction.INSPECT);
+
+        MultipartUtil.forEachPart(response(multipartBody(
+                formField("huge", "x".repeat(100_000)),
+                formField("small", "ok")
+        )), 8, handler);
+
+        assertEquals(1, handler.handled.size());
+        assertEquals("ok", handler.handled.getFirst().getBodyAsString());
+    }
+
+    @Test
+    void xopMessageIsHandedOverAsOneReassembledPart() throws IOException, ParseException {
+        var handler = inspectAll();
+
+        MultipartUtil.forEachPart(xopResponse(), 1024 * 1024, handler);
+
+        assertEquals(1, handler.handled.size(), "XOP must not be split into raw parts");
+        assertEquals("text/xml", handler.handled.getFirst().getContentType());
+        // The binary part has been inlined as base64 instead of being a separate part.
+        assertFalse(handler.handled.getFirst().getBodyAsString().contains("xop:Include"));
     }
 
     @Test
@@ -238,7 +310,7 @@ class MultipartUtilTest {
                 "Content-Disposition: form-data; name=\"nested\"" + CRLF
                 + "Content-Type: multipart/mixed; boundary=inner" + CRLF + CRLF + "..."));
 
-        assertThrows(IOException.class, () -> MultipartUtil.unitsOf(msg));
+        assertThrows(IOException.class, () -> MultipartUtil.forEachPart(msg, 1024, inspectAll()));
     }
 
     // -------------------------------------------------------------------------

--- a/core/src/test/java/com/predic8/membrane/core/multipart/MultipartUtilTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/multipart/MultipartUtilTest.java
@@ -292,16 +292,28 @@ class MultipartUtilTest {
         assertEquals("ok", handler.handled.getFirst().getBodyAsString());
     }
 
+    /**
+     * XOP is deliberately not reassembled here: reassembly buffers every attachment plus a
+     * base64-inflated copy before the handler could decide anything, escaping maxPartSize.
+     */
     @Test
-    void xopMessageIsHandedOverAsOneReassembledPart() throws IOException, ParseException {
+    void xopMessageIsTraversedAsRawParts() throws IOException, ParseException {
         var handler = inspectAll();
 
         MultipartUtil.forEachPart(xopResponse(), 1024 * 1024, handler);
 
-        assertEquals(1, handler.handled.size(), "XOP must not be split into raw parts");
-        assertEquals("text/xml", handler.handled.getFirst().getContentType());
-        // The binary part has been inlined as base64 instead of being a separate part.
-        assertFalse(handler.handled.getFirst().getBodyAsString().contains("xop:Include"));
+        assertEquals(2, handler.handled.size());
+        assertEquals("application/xop+xml; charset=UTF-8; type=\"text/xml\";", handler.handled.getFirst().getContentType());
+        assertEquals("application/octet-stream", handler.handled.get(1).getContentType());
+        // The attachment stays a separate part rather than being inlined into the root document.
+        assertTrue(handler.handled.getFirst().getBodyAsString().contains("xop:Include"));
+    }
+
+    @Test
+    void oversizedXopRootIsRejectedRatherThanReassembled() {
+        var e = assertThrows(IOException.class, () -> MultipartUtil.forEachPart(xopResponse(), 8, inspectAll()));
+
+        assertTrue(e.getMessage().contains("maximum size of 8"), e.getMessage());
     }
 
     @Test

--- a/core/src/test/java/com/predic8/membrane/core/multipart/MultipartUtilTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/multipart/MultipartUtilTest.java
@@ -325,6 +325,16 @@ class MultipartUtilTest {
         assertThrows(IOException.class, () -> MultipartUtil.forEachPart(msg, 1024, inspectAll()));
     }
 
+    /** split() shares the traversal with forEachPart(), so it rejects nested multipart alike. */
+    @Test
+    void splitRejectsNestedMultipart() {
+        var msg = response(multipartBody(
+                "Content-Disposition: form-data; name=\"nested\"" + CRLF
+                + "Content-Type: multipart/mixed; boundary=inner" + CRLF + CRLF + "..."));
+
+        assertThrows(IOException.class, () -> MultipartUtil.split(msg));
+    }
+
     // -------------------------------------------------------------------------
     // Error cases
     // -------------------------------------------------------------------------

--- a/core/src/test/java/com/predic8/membrane/core/multipart/MultipartUtilTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/multipart/MultipartUtilTest.java
@@ -166,10 +166,9 @@ class MultipartUtilTest {
     // Real-world resource: XOP multipart from ReassembleTest
     // -------------------------------------------------------------------------
 
-    @Test
-    void xopResourceSplitsIntoTwoParts() throws IOException {
-        byte[] body = IOUtils.toByteArray(getClass().getResourceAsStream("/multipart/embedded-byte-array.txt"));
-        var response = Response.ok()
+    private static Response xopResponse() throws IOException {
+        byte[] body = IOUtils.toByteArray(MultipartUtilTest.class.getResourceAsStream("/multipart/embedded-byte-array.txt"));
+        return Response.ok()
                 .header("Content-Type", "multipart/related; "
                         + "type=\"application/xop+xml\"; "
                         + "boundary=\"uuid:168683dc-43b3-4e71-8e66-efb633ef406b\"; "
@@ -178,14 +177,68 @@ class MultipartUtilTest {
                 .header("Content-Length", String.valueOf(body.length))
                 .body(body)
                 .build();
+    }
 
-        var parts = MultipartUtil.split(response, "uuid:168683dc-43b3-4e71-8e66-efb633ef406b");
+    @Test
+    void xopResourceSplitsIntoTwoParts() throws IOException {
+        var parts = MultipartUtil.split(xopResponse(), "uuid:168683dc-43b3-4e71-8e66-efb633ef406b");
 
         assertEquals(2, parts.size());
         assertEquals("<root.message@cxf.apache.org>",                parts.get(0).getContentID());
         assertEquals("<a416c16d-a50e-44ca-a6d7-3e8a61480afa-2@cxf.apache.org>", parts.get(1).getContentID());
         assertEquals("application/xop+xml; charset=UTF-8; type=\"text/xml\";", parts.get(0).getContentType());
         assertEquals("application/octet-stream",                      parts.get(1).getContentType());
+    }
+
+    // -------------------------------------------------------------------------
+    // unitsOf(Message)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void plainBodyIsOneUnit() throws IOException, ParseException {
+        byte[] bytes = "{\"a\":\"b\"}".getBytes(UTF_8);
+        var msg = Response.ok()
+                .header("Content-Type", "application/json")
+                .header("Content-Length", String.valueOf(bytes.length))
+                .body(bytes)
+                .build();
+
+        var units = MultipartUtil.unitsOf(msg);
+
+        assertEquals(1, units.size());
+        assertEquals("application/json", units.getFirst().getContentType());
+        assertArrayEquals(bytes, units.getFirst().getBody());
+    }
+
+    @Test
+    void multipartBodyIsOneUnitPerPart() throws IOException, ParseException {
+        var units = MultipartUtil.unitsOf(response(multipartBody(
+                formField("username", "alice"),
+                formField("message", "Hello World")
+        )));
+
+        assertEquals(2, units.size());
+        assertEquals("username", units.getFirst().getName());
+        assertEquals("message", units.get(1).getName());
+    }
+
+    @Test
+    void xopMessageIsOneReassembledUnit() throws IOException, ParseException {
+        var units = MultipartUtil.unitsOf(xopResponse());
+
+        assertEquals(1, units.size(), "XOP must not be split into raw parts");
+        assertEquals("text/xml", units.getFirst().getContentType());
+        // The binary part has been inlined as base64 instead of being a separate unit.
+        assertFalse(units.getFirst().getBodyAsString().contains("xop:Include"));
+    }
+
+    @Test
+    void nestedMultipartThrows() {
+        var msg = response(multipartBody(
+                "Content-Disposition: form-data; name=\"nested\"" + CRLF
+                + "Content-Type: multipart/mixed; boundary=inner" + CRLF + CRLF + "..."));
+
+        assertThrows(IOException.class, () -> MultipartUtil.unitsOf(msg));
     }
 
     // -------------------------------------------------------------------------

--- a/core/src/test/java/com/predic8/membrane/core/multipart/MultipartUtilTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/multipart/MultipartUtilTest.java
@@ -19,13 +19,7 @@ import jakarta.mail.internet.ParseException;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 
-import com.predic8.membrane.core.http.Header;
-import com.predic8.membrane.core.multipart.MultipartUtil.PartAction;
-
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Function;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.*;
@@ -194,135 +188,6 @@ class MultipartUtilTest {
         assertEquals("<a416c16d-a50e-44ca-a6d7-3e8a61480afa-2@cxf.apache.org>", parts.get(1).getContentID());
         assertEquals("application/xop+xml; charset=UTF-8; type=\"text/xml\";", parts.get(0).getContentType());
         assertEquals("application/octet-stream",                      parts.get(1).getContentType());
-    }
-
-    // -------------------------------------------------------------------------
-    // forEachPart(Message, maxPartSize, PartHandler)
-    // -------------------------------------------------------------------------
-
-    /** Records what the traversal offered and what it actually handed over. */
-    private static class RecordingHandler implements MultipartUtil.PartHandler {
-        final List<String> decided = new ArrayList<>();
-        final List<Part> handled = new ArrayList<>();
-        private final Function<Header, PartAction> policy;
-
-        RecordingHandler(Function<Header, PartAction> policy) {
-            this.policy = policy;
-        }
-
-        @Override
-        public PartAction decide(Header partHeader) {
-            decided.add(Part.nameOf(partHeader));
-            return policy.apply(partHeader);
-        }
-
-        @Override
-        public void handle(Part part) {
-            handled.add(part);
-        }
-    }
-
-    private static RecordingHandler inspectAll() {
-        return new RecordingHandler(h -> PartAction.INSPECT);
-    }
-
-    @Test
-    void partsAreHandedOverInOrder() throws IOException, ParseException {
-        var handler = inspectAll();
-
-        MultipartUtil.forEachPart(response(multipartBody(
-                formField("username", "alice"),
-                formField("message", "Hello World")
-        )), 1024, handler);
-
-        assertEquals(List.of("username", "message"), handler.decided);
-        assertEquals("alice", handler.handled.getFirst().getBodyAsString());
-        assertEquals("Hello World", handler.handled.get(1).getBodyAsString());
-    }
-
-    @Test
-    void skippedPartIsNeverMaterialisedAndTraversalContinues() throws IOException, ParseException {
-        var handler = new RecordingHandler(h -> "skipme".equals(Part.nameOf(h)) ? PartAction.SKIP : PartAction.INSPECT);
-
-        MultipartUtil.forEachPart(response(multipartBody(
-                formField("skipme", "0123456789"),
-                formField("keepme", "alice")
-        )), 1024, handler);
-
-        assertEquals(List.of("skipme", "keepme"), handler.decided, "both parts must be offered");
-        assertEquals(1, handler.handled.size(), "the skipped part must not be handed over");
-        assertEquals("keepme", handler.handled.getFirst().getName());
-    }
-
-    @Test
-    void stopEndsTraversalWithoutTouchingLaterParts() throws IOException, ParseException {
-        var handler = new RecordingHandler(h -> PartAction.STOP);
-
-        MultipartUtil.forEachPart(response(multipartBody(
-                formField("first", "a"),
-                formField("second", "b")
-        )), 1024, handler);
-
-        assertEquals(List.of("first"), handler.decided);
-        assertTrue(handler.handled.isEmpty());
-    }
-
-    @Test
-    void partExceedingMaxPartSizeIsRejected() {
-        var handler = inspectAll();
-        var msg = response(multipartBody(formField("big", "0123456789")));
-
-        var e = assertThrows(IOException.class, () -> MultipartUtil.forEachPart(msg, 4, handler));
-
-        assertTrue(e.getMessage().contains("maximum size of 4"), e.getMessage());
-        assertTrue(handler.handled.isEmpty(), "an oversized part must not be handed over");
-    }
-
-    @Test
-    void oversizedPartIsNotReadWhenSkipped() throws IOException, ParseException {
-        // The size cap applies only to what is buffered, so a huge skipped part costs nothing.
-        var handler = new RecordingHandler(h -> "huge".equals(Part.nameOf(h)) ? PartAction.SKIP : PartAction.INSPECT);
-
-        MultipartUtil.forEachPart(response(multipartBody(
-                formField("huge", "x".repeat(100_000)),
-                formField("small", "ok")
-        )), 8, handler);
-
-        assertEquals(1, handler.handled.size());
-        assertEquals("ok", handler.handled.getFirst().getBodyAsString());
-    }
-
-    /**
-     * XOP is deliberately not reassembled here: reassembly buffers every attachment plus a
-     * base64-inflated copy before the handler could decide anything, escaping maxPartSize.
-     */
-    @Test
-    void xopMessageIsTraversedAsRawParts() throws IOException, ParseException {
-        var handler = inspectAll();
-
-        MultipartUtil.forEachPart(xopResponse(), 1024 * 1024, handler);
-
-        assertEquals(2, handler.handled.size());
-        assertEquals("application/xop+xml; charset=UTF-8; type=\"text/xml\";", handler.handled.getFirst().getContentType());
-        assertEquals("application/octet-stream", handler.handled.get(1).getContentType());
-        // The attachment stays a separate part rather than being inlined into the root document.
-        assertTrue(handler.handled.getFirst().getBodyAsString().contains("xop:Include"));
-    }
-
-    @Test
-    void oversizedXopRootIsRejectedRatherThanReassembled() {
-        var e = assertThrows(IOException.class, () -> MultipartUtil.forEachPart(xopResponse(), 8, inspectAll()));
-
-        assertTrue(e.getMessage().contains("maximum size of 8"), e.getMessage());
-    }
-
-    @Test
-    void nestedMultipartThrows() {
-        var msg = response(multipartBody(
-                "Content-Disposition: form-data; name=\"nested\"" + CRLF
-                + "Content-Type: multipart/mixed; boundary=inner" + CRLF + CRLF + "..."));
-
-        assertThrows(IOException.class, () -> MultipartUtil.forEachPart(msg, 1024, inspectAll()));
     }
 
     /** split() shares the traversal with forEachPart(), so it rejects nested multipart alike. */

--- a/core/src/test/java/com/predic8/membrane/core/multipart/PartScannerTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/multipart/PartScannerTest.java
@@ -1,0 +1,212 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.core.multipart;
+
+import com.predic8.membrane.core.http.Response;
+import jakarta.mail.internet.ParseException;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
+
+import com.predic8.membrane.core.http.Header;
+import com.predic8.membrane.core.multipart.PartScanner.PartAction;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PartScannerTest {
+
+    private static final String BOUNDARY = "test-boundary-123";
+    private static final String CRLF = "\r\n";
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /** Builds a Response with the given multipart body and boundary. */
+    private static Response response(String body) {
+        return response(body, BOUNDARY);
+    }
+
+    private static Response response(String body, String boundary) {
+        byte[] bytes = body.getBytes(UTF_8);
+        return Response.ok()
+                .header("Content-Type", "multipart/form-data; boundary=\"" + boundary + "\"")
+                .header("Content-Length", String.valueOf(bytes.length))
+                .body(bytes)
+                .build();
+    }
+
+    /**
+     * Builds a minimal multipart body.
+     * Each {@code part} string should contain headers + blank line + body,
+     * e.g. {@code "Content-Disposition: form-data; name=\"x\"\r\n\r\nvalue"}.
+     */
+    private static String multipartBody(String... parts) {
+        var sb = new StringBuilder();
+        for (String part : parts) {
+            sb.append("--").append(BOUNDARY).append(CRLF);
+            sb.append(part).append(CRLF);
+        }
+        sb.append("--").append(BOUNDARY).append("--").append(CRLF);
+        return sb.toString();
+    }
+
+    private static String formField(String name, String value) {
+        return "Content-Disposition: form-data; name=\"" + name + "\"" + CRLF + CRLF + value;
+    }
+
+    private static Response xopResponse() throws IOException {
+        byte[] body = IOUtils.toByteArray(MultipartUtilTest.class.getResourceAsStream("/multipart/embedded-byte-array.txt"));
+        return Response.ok()
+                .header("Content-Type", "multipart/related; "
+                        + "type=\"application/xop+xml\"; "
+                        + "boundary=\"uuid:168683dc-43b3-4e71-8e66-efb633ef406b\"; "
+                        + "start=\"<root.message@cxf.apache.org>\"; "
+                        + "start-info=\"text/xml\"")
+                .header("Content-Length", String.valueOf(body.length))
+                .body(body)
+                .build();
+    }
+
+    /** Records what the traversal offered and what it actually handed over. */
+    private static class RecordingHandler implements PartScanner.PartHandler {
+        final List<String> decided = new ArrayList<>();
+        final List<Part> handled = new ArrayList<>();
+        private final Function<Header, PartAction> policy;
+
+        RecordingHandler(Function<Header, PartAction> policy) {
+            this.policy = policy;
+        }
+
+        @Override
+        public PartAction decide(Header partHeader) {
+            decided.add(Part.nameOf(partHeader));
+            return policy.apply(partHeader);
+        }
+
+        @Override
+        public void handle(Part part) {
+            handled.add(part);
+        }
+    }
+
+    private static RecordingHandler inspectAll() {
+        return new RecordingHandler(h -> PartAction.INSPECT);
+    }
+
+    @Test
+    void partsAreHandedOverInOrder() throws IOException, ParseException {
+        var handler = inspectAll();
+
+        PartScanner.forEachPart(response(multipartBody(
+                formField("username", "alice"),
+                formField("message", "Hello World")
+        )), 1024, handler);
+
+        assertEquals(List.of("username", "message"), handler.decided);
+        assertEquals("alice", handler.handled.getFirst().getBodyAsString());
+        assertEquals("Hello World", handler.handled.get(1).getBodyAsString());
+    }
+
+    @Test
+    void skippedPartIsNeverMaterialisedAndTraversalContinues() throws IOException, ParseException {
+        var handler = new RecordingHandler(h -> "skipme".equals(Part.nameOf(h)) ? PartAction.SKIP : PartAction.INSPECT);
+
+        PartScanner.forEachPart(response(multipartBody(
+                formField("skipme", "0123456789"),
+                formField("keepme", "alice")
+        )), 1024, handler);
+
+        assertEquals(List.of("skipme", "keepme"), handler.decided, "both parts must be offered");
+        assertEquals(1, handler.handled.size(), "the skipped part must not be handed over");
+        assertEquals("keepme", handler.handled.getFirst().getName());
+    }
+
+    @Test
+    void stopEndsTraversalWithoutTouchingLaterParts() throws IOException, ParseException {
+        var handler = new RecordingHandler(h -> PartAction.STOP);
+
+        PartScanner.forEachPart(response(multipartBody(
+                formField("first", "a"),
+                formField("second", "b")
+        )), 1024, handler);
+
+        assertEquals(List.of("first"), handler.decided);
+        assertTrue(handler.handled.isEmpty());
+    }
+
+    @Test
+    void partExceedingMaxPartSizeIsRejected() {
+        var handler = inspectAll();
+        var msg = response(multipartBody(formField("big", "0123456789")));
+
+        var e = assertThrows(IOException.class, () -> PartScanner.forEachPart(msg, 4, handler));
+
+        assertTrue(e.getMessage().contains("maximum size of 4"), e.getMessage());
+        assertTrue(handler.handled.isEmpty(), "an oversized part must not be handed over");
+    }
+
+    @Test
+    void oversizedPartIsNotReadWhenSkipped() throws IOException, ParseException {
+        // The size cap applies only to what is buffered, so a huge skipped part costs nothing.
+        var handler = new RecordingHandler(h -> "huge".equals(Part.nameOf(h)) ? PartAction.SKIP : PartAction.INSPECT);
+
+        PartScanner.forEachPart(response(multipartBody(
+                formField("huge", "x".repeat(100_000)),
+                formField("small", "ok")
+        )), 8, handler);
+
+        assertEquals(1, handler.handled.size());
+        assertEquals("ok", handler.handled.getFirst().getBodyAsString());
+    }
+
+    /**
+     * XOP is deliberately not reassembled here: reassembly buffers every attachment plus a
+     * base64-inflated copy before the handler could decide anything, escaping maxPartSize.
+     */
+    @Test
+    void xopMessageIsTraversedAsRawParts() throws IOException, ParseException {
+        var handler = inspectAll();
+
+        PartScanner.forEachPart(xopResponse(), 1024 * 1024, handler);
+
+        assertEquals(2, handler.handled.size());
+        assertEquals("application/xop+xml; charset=UTF-8; type=\"text/xml\";", handler.handled.getFirst().getContentType());
+        assertEquals("application/octet-stream", handler.handled.get(1).getContentType());
+        // The attachment stays a separate part rather than being inlined into the root document.
+        assertTrue(handler.handled.getFirst().getBodyAsString().contains("xop:Include"));
+    }
+
+    @Test
+    void oversizedXopRootIsRejectedRatherThanReassembled() {
+        var e = assertThrows(IOException.class, () -> PartScanner.forEachPart(xopResponse(), 8, inspectAll()));
+
+        assertTrue(e.getMessage().contains("maximum size of 8"), e.getMessage());
+    }
+
+    @Test
+    void nestedMultipartThrows() {
+        var msg = response(multipartBody(
+                "Content-Disposition: form-data; name=\"nested\"" + CRLF
+                + "Content-Type: multipart/mixed; boundary=inner" + CRLF + CRLF + "..."));
+
+        assertThrows(IOException.class, () -> PartScanner.forEachPart(msg, 1024, inspectAll()));
+    }
+}


### PR DESCRIPTION
## Problem

`jsonProtection` assumed the whole message body is one JSON document, so a JSON document carried inside a MIME part was never inspected — a multipart body is not JSON, so it just failed parsing with a 400. The JSON part of a `multipart/form-data` upload went unchecked.

## Change

**`MultipartUtil.unitsOf(Message)`** — a new utility returning the inspectable documents of a message: one unit for a plain body, one per part for multipart, and a single reassembled unit for XOP/MTOM. It reuses the existing `split()` and `XOPReconstitutor`, and yields the existing `Part` type, so callers treat "the whole body" and "one attachment" with the same code. Nested multipart is rejected rather than recursed into.

**`JsonProtectionInterceptor`** inspects each JSON unit. `parseJson` and every limit check are untouched — only the plumbing around them changed.

The common non-multipart case still streams straight off `getBodyAsStreamDecoded()`, so no body is buffered into a `byte[]` unless it actually has to be split.

**New `otherContentTypes` attribute** — `REJECT` (default) or `SKIP`, with identical meaning whether the unit is the whole body or one MIME part:

```yaml
- jsonProtection:
    otherContentTypes: SKIP
```

`SKIP` is what lets a user allow e.g. an `image/png` — both as a plain body and as one part of a form upload — without disabling the plugin.

Rejections now name the offending part (`In part 'data': Exceeded maxDepth.`) and the non-JSON message points at the way out; a rejection on a five-part upload was previously undebuggable.

## Compatibility

Defaults preserve today's behaviour: a non-JSON body is still rejected with **400** from the parse failure — deliberately not changed to 415, since existing configs and the tutorial IT depend on 400.

One deliberate asymmetry: a whole body without a `Content-Type` is still parsed, so clients that post JSON without declaring it keep being checked; a MIME *part* without one defaults to `text/plain` per RFC 2045 and is therefore not JSON — otherwise plain form fields would 400 every upload.

## Tests

- `MultipartUtilTest` — `unitsOf` for a plain body, a multipart body, an XOP message, and nested multipart.
- `JsonProtectionInterceptorTest` — JSON part exceeding `maxDepth` rejected and named; benign multipart passes; every JSON part inspected; non-JSON part rejected by default and skipped under `SKIP`; multipart body not modified; part-vs-body `Content-Type` asymmetry; nested multipart rejected.

33/33 in `JsonProtectionInterceptorTest` (12 new, 21 pre-existing unchanged), 13/13 in `MultipartUtilTest`, and the full `multipart` (30) and `interceptor.json` (84) packages green.

`JsonProtectionTutorialTest` was not run — it needs a full distribution rebuild and only posts `contentType(JSON)`, the path the unchanged unit tests cover.

## Follow-up

`xmlProtection` has the same gap plus a second one (MTOM rejected although it would already work), tracked in #3179. It additionally needs a `MultipartUtil.join` for `removeDTD` write-back. Once there are two implementations, the shared unit loop and the `otherContentTypes` attribute get extracted into a template-method base class — deliberately not done here, with only one subclass to generalise from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - JSON protection now validates requests in a streaming manner with configurable size, depth, token, string, object, and array limits.
  - Duplicate JSON keys and optionally prohibited `__proto__` keys are detected.
  - Multipart and XOP/MTOM messages are inspected part by part.
  - Validation errors identify the affected multipart part.

- **Bug Fixes**
  - Improved handling of content types, encoded parts, and nested multipart content.
  - Request bodies remain intact during inspection.
  - Oversized parts are rejected safely without unnecessary buffering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->