### PR TITLE
fix: check Content-Length/Transfer-Encoding before method in shouldNotContainBody()

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/http/Request.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/Request.java
@@ -143,6 +143,19 @@ public class Request extends Message {
         return uri;
     }
 
+    /**
+     * Per RFC 9112 &sect;6.3 a request whose <tt>Transfer-Encoding</tt> does not end in
+     * <tt>chunked</tt> has no reliably determinable body length. Reject it before selecting a body,
+     * rather than falling back to reading until EOF, which would hang a keep-alive connection and
+     * open the door to request smuggling.
+     */
+    @Override
+    protected void createBody(InputStream in) throws IOException {
+        if (header.getFirstValue(TRANSFER_ENCODING) != null && !header.isChunked())
+            throw new MalformedHeaderException("Transfer-Encoding does not end in \"chunked\". The body length of the request cannot be determined; rejecting to prevent request smuggling.");
+        super.createBody(in);
+    }
+
     @Override
     public boolean shouldNotContainBody() {
         if (header.hasContentLength())

--- a/core/src/main/java/com/predic8/membrane/core/http/Request.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/Request.java
@@ -145,13 +145,13 @@ public class Request extends Message {
 
     @Override
     public boolean shouldNotContainBody() {
-        if (methodsWithoutBody.contains(method)) // GET, HEAD, CONNECT
-            return true;
-        if (isHTTP10())
-            return false;
         if (header.hasContentLength())
             return header.getContentLength() == 0;
-        return header.getFirstValue(TRANSFER_ENCODING) == null;
+        if (header.getFirstValue(TRANSFER_ENCODING) != null)
+            return false;
+        if (methodsWithoutBody.contains(method)) // GET, HEAD, CONNECT
+            return true;
+        return !isHTTP10();
     }
 
     /**

--- a/core/src/main/java/com/predic8/membrane/core/http/Request.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/Request.java
@@ -151,8 +151,10 @@ public class Request extends Message {
      */
     @Override
     protected void createBody(InputStream in) throws IOException {
-        if (header.getFirstValue(TRANSFER_ENCODING) != null && !header.isChunked())
+        if (header.getFirstValue(TRANSFER_ENCODING) != null && !header.isChunked()) {
+            log.info("Request {} {} has Transfer-Encoding \"{}\", whose final coding is not \"chunked\". Rejecting to prevent request smuggling.", method, uri, header.getFirstValue(TRANSFER_ENCODING));
             throw new MalformedHeaderException("Transfer-Encoding does not end in \"chunked\". The body length of the request cannot be determined; rejecting to prevent request smuggling.");
+        }
         super.createBody(in);
     }
 

--- a/core/src/main/java/com/predic8/membrane/core/http/Request.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/Request.java
@@ -38,6 +38,7 @@ import static com.predic8.membrane.annot.Constants.CRLF;
 import static com.predic8.membrane.core.http.Header.*;
 import static com.predic8.membrane.core.http.MimeType.APPLICATION_JSON;
 import static com.predic8.membrane.core.http.MimeType.APPLICATION_XML;
+import static com.predic8.membrane.core.util.text.StringUtil.maskNonPrintableCharacters;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class Request extends Message {
@@ -151,9 +152,12 @@ public class Request extends Message {
      */
     @Override
     protected void createBody(InputStream in) throws IOException {
-        if (header.getFirstValue(TRANSFER_ENCODING) != null && !header.isChunked()) {
-            log.info("Request {} {} has Transfer-Encoding \"{}\", whose final coding is not \"chunked\". Rejecting to prevent request smuggling.", method, uri, header.getFirstValue(TRANSFER_ENCODING));
-            throw new MalformedHeaderException("Transfer-Encoding does not end in \"chunked\". The body length of the request cannot be determined; rejecting to prevent request smuggling.");
+        final String transferEncoding = header.getFirstValue(TRANSFER_ENCODING);
+        if (transferEncoding != null && !header.isChunked()) {
+            String message = "Transfer-Encoding \"%s\" does not end in \"chunked\". The body length of the request cannot be determined; rejecting to prevent request smuggling."
+                    .formatted(maskNonPrintableCharacters(transferEncoding));
+            log.info(message);
+            throw new MalformedHeaderException(message);
         }
         super.createBody(in);
     }

--- a/core/src/test/java/com/predic8/membrane/core/http/RequestTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/http/RequestTest.java
@@ -368,6 +368,74 @@ public class RequestTest {
                 """, true);
     }
 
+    /**
+     * RFC 9112 6.3: if a Transfer-Encoding is present in a request and "chunked" is not the final
+     * coding, the body length cannot be determined - the request must be rejected rather than read.
+     */
+    @Test
+    void transferEncodingNotEndingInChunkedIsRejected() {
+        assertThrows(MalformedHeaderException.class, () -> readRequest("""
+                POST /products HTTP/1.1
+                Host: example.com
+                Transfer-Encoding: gzip
+
+                """));
+    }
+
+    @Test
+    void transferEncodingNotEndingInChunkedIsRejectedDespiteContentLength() {
+        assertThrows(MalformedHeaderException.class, () -> readRequest("""
+                POST /products HTTP/1.1
+                Host: example.com
+                Transfer-Encoding: gzip
+                Content-Length: 0
+
+                """));
+    }
+
+    @Test
+    void transferEncodingWithChunkedNotFinalIsRejected() {
+        assertThrows(MalformedHeaderException.class, () -> readRequest("""
+                POST /products HTTP/1.1
+                Host: example.com
+                Transfer-Encoding: chunked, gzip
+
+                """));
+    }
+
+    /**
+     * Header.isChunked() only inspects the first Transfer-Encoding field, so a chunked coding
+     * split off into a second field line is not recognized as framing and must be rejected.
+     */
+    @Test
+    void transferEncodingSplitOverSeveralFieldsIsRejected() {
+        assertThrows(MalformedHeaderException.class, () -> readRequest("""
+                POST /products HTTP/1.1
+                Host: example.com
+                Transfer-Encoding: gzip
+                Transfer-Encoding: chunked
+
+                """));
+    }
+
+    @Test
+    void transferEncodingEndingInChunkedIsAccepted() throws Exception {
+        assertInstanceOf(ChunkedBody.class, readRequest("""
+                POST /products HTTP/1.1
+                Host: example.com
+                Transfer-Encoding: gzip, chunked
+
+                0
+
+                """).getBody());
+    }
+
+    private static Request readRequest(String message) throws IOException, EndOfStreamException {
+        Request req = new Request();
+        req.read(convertMessage(message), true);
+        return req;
+    }
+
     @Test
     void getWithoutBody() throws EndOfStreamException, IOException {
         shouldBodyBeRead("""

--- a/core/src/test/java/com/predic8/membrane/core/http/RequestTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/http/RequestTest.java
@@ -342,7 +342,38 @@ public class RequestTest {
         shouldBodyBeRead("""
                 OPTIONS /products HTTP/1.1
                 Origin: https://predic8.de
-                
+
+                """, false);
+    }
+
+    @Test
+    void getWithBodyContentLength() throws EndOfStreamException, IOException {
+        shouldBodyBeRead("""
+                GET /products HTTP/1.1
+                Content-Length: 5
+                Origin: https://predic8.de
+
+                Dummy
+                """, true);
+    }
+
+    @Test
+    void getWithBodyChunked() throws EndOfStreamException, IOException {
+        shouldBodyBeRead("""
+                GET /products HTTP/1.1
+                Transfer-Encoding: chunked
+                Origin: https://predic8.de
+
+                Dummy
+                """, true);
+    }
+
+    @Test
+    void getWithoutBody() throws EndOfStreamException, IOException {
+        shouldBodyBeRead("""
+                GET /products HTTP/1.1
+                Origin: https://predic8.de
+
                 """, false);
     }
 


### PR DESCRIPTION
## Summary

Fixes #3182.

`Request.shouldNotContainBody()` unconditionally treated GET, HEAD, and CONNECT as bodiless before ever checking `Content-Length`/`Transfer-Encoding`. This method gates whether the request body is actually read off the socket in `Message.createBody()` — for every other method, the header checks decide whether a body follows, but for GET/HEAD/CONNECT that logic was short-circuited before it could run.

HTTP doesn't forbid a body on GET; if a client sends one with an explicit `Content-Length` or chunked encoding, the bytes were left unread in the socket stream. On a keep-alive connection, the next read loop would then misparse those leftover bytes as the start line of the next request, corrupting or hanging the connection.

## Fix

Reordered the checks in `Request.shouldNotContainBody()` so `Content-Length`/`Transfer-Encoding` take priority, falling back to the method-based default (and the HTTP/1.0 default) only when no header indicates a body. Behavior for GET/HEAD/CONNECT with no body headers is unchanged.

## Testing

Added `getWithBodyContentLength`, `getWithBodyChunked`, and `getWithoutBody` to `RequestTest`, mirroring the existing `optionsWith*` coverage. All 33 tests in `RequestTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP request body detection for requests using `Content-Length` or `Transfer-Encoding`.
  * Requests with incomplete or improperly terminated transfer encoding are now rejected instead of being read indefinitely.
  * Valid chained transfer encodings ending in `chunked` are accepted correctly.
  * GET requests with declared body content continue to be handled correctly.

* **Tests**
  * Added coverage for transfer-encoding validation and request body detection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->