### PR TITLE
fix(openapi): honour nullable when allOf/oneOf/anyOf is present (#3119)

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/SchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/SchemaValidator.java
@@ -110,6 +110,11 @@ public class SchemaValidator implements JsonSchemaValidator {
                 throw new RuntimeException("Should not happen!");
         }
 
+        // A nullable schema accepts null itself, so validation stops here instead of descending into
+        // allOf/anyOf/oneOf/not subschemas, which are typically not nullable and would reject it. See #3119.
+        if ((value == null || value instanceof NullNode) && isNullable())
+            return errors;
+
         if (schema.getAllOf() != null)
             errors.add(new AllOfValidator(api, schema).validate(ctx, obj));
 
@@ -126,9 +131,6 @@ public class SchemaValidator implements JsonSchemaValidator {
 
         if (schema.getNot() != null)
             errors.add(new NotValidator(api, schema).validate(ctx, obj));
-
-        if ((value == null || value instanceof NullNode) && isNullable())
-            return errors;
 
         errors.add(new NumberRestrictionValidator(schema).validate(ctx, value));
         errors.add(validateByType(ctx, value));

--- a/core/src/test/java/com/predic8/membrane/core/openapi/validators/NullableTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/validators/NullableTest.java
@@ -16,12 +16,13 @@
 
 package com.predic8.membrane.core.openapi.validators;
 
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
 
-import static com.predic8.membrane.core.openapi.model.Request.*;
-import static com.predic8.membrane.core.openapi.util.JsonTestUtil.*;
+import static com.predic8.membrane.core.openapi.model.Request.post;
+import static com.predic8.membrane.core.openapi.util.JsonTestUtil.mapToJson;
 import static org.junit.jupiter.api.Assertions.*;
 
 
@@ -101,6 +102,16 @@ protected String getOpenAPIFileName() {
 
         Map<String,Object> m = new HashMap<>();
         m.put("nullableAnyOf",null);
+
+        ValidationErrors errors = validator.validate(post().path("/composition").body(mapToJson(m)));
+        assertEquals(0,errors.size());
+    }
+
+    @Test
+    void nullableNotNullValid() {
+
+        Map<String,Object> m = new HashMap<>();
+        m.put("nullableNot",null);
 
         ValidationErrors errors = validator.validate(post().path("/composition").body(mapToJson(m)));
         assertEquals(0,errors.size());

--- a/core/src/test/java/com/predic8/membrane/core/openapi/validators/NullableTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/validators/NullableTest.java
@@ -33,7 +33,7 @@ protected String getOpenAPIFileName() {
     }
 
     @Test
-    public void emailNullValid() {
+    void emailNullValid() {
 
         Map<String,Object> m = new HashMap<>();
         m.put("email",null);
@@ -44,7 +44,7 @@ protected String getOpenAPIFileName() {
     }
 
     @Test
-    public void addressObjectNullValid() {
+    void addressObjectNullValid() {
 
         Map<String,Object> m = new HashMap<>();
         m.put("address",null);
@@ -54,7 +54,7 @@ protected String getOpenAPIFileName() {
     }
 
     @Test
-    public void contactNullableWithoutTypeInvalid() {
+    void contactNullableWithoutTypeInvalid() {
 
         Map<String,Object> m = new HashMap<>();
         m.put("contact",null);
@@ -64,7 +64,7 @@ protected String getOpenAPIFileName() {
     }
 
     @Test
-    public void telefonNotNullableInvalid() {
+    void telefonNotNullableInvalid() {
 
         Map<String,Object> m = new HashMap<>();
         m.put("telefon",null);
@@ -74,5 +74,65 @@ protected String getOpenAPIFileName() {
         ValidationError e = errors.get(0);
         assertEquals("/telefon", e.getContext().getJSONpointer());
         assertTrue(e.getMessage().toLowerCase().contains("null"));
+    }
+
+    @Test
+    void nullableAllOfNullValid() {
+
+        Map<String,Object> m = new HashMap<>();
+        m.put("nullableAllOf",null);
+
+        ValidationErrors errors = validator.validate(post().path("/composition").body(mapToJson(m)));
+        assertEquals(0,errors.size());
+    }
+
+    @Test
+    void nullableOneOfNullValid() {
+
+        Map<String,Object> m = new HashMap<>();
+        m.put("nullableOneOf",null);
+
+        ValidationErrors errors = validator.validate(post().path("/composition").body(mapToJson(m)));
+        assertEquals(0,errors.size());
+    }
+
+    @Test
+    void nullableAnyOfNullValid() {
+
+        Map<String,Object> m = new HashMap<>();
+        m.put("nullableAnyOf",null);
+
+        ValidationErrors errors = validator.validate(post().path("/composition").body(mapToJson(m)));
+        assertEquals(0,errors.size());
+    }
+
+    @Test
+    void nonNullableAllOfNullInvalid() {
+
+        Map<String,Object> m = new HashMap<>();
+        m.put("nonNullableAllOf",null);
+
+        ValidationErrors errors = validator.validate(post().path("/composition").body(mapToJson(m)));
+        assertFalse(errors.isEmpty());
+    }
+
+    @Test
+    void nullableAllOfObjectStillValidated() {
+
+        Map<String,Object> m = new HashMap<>();
+        m.put("nullableAllOf",Map.of("street","Main Street"));
+
+        ValidationErrors errors = validator.validate(post().path("/composition").body(mapToJson(m)));
+        assertFalse(errors.isEmpty());
+    }
+
+    @Test
+    void nullableAllOfValidObjectValid() {
+
+        Map<String,Object> m = new HashMap<>();
+        m.put("nullableAllOf",Map.of("street","Main Street","city","Berlin"));
+
+        ValidationErrors errors = validator.validate(post().path("/composition").body(mapToJson(m)));
+        assertEquals(0,errors.size());
     }
 }

--- a/core/src/test/resources/openapi/specs/nullable.yml
+++ b/core/src/test/resources/openapi/specs/nullable.yml
@@ -46,6 +46,11 @@ paths:
                   anyOf:
                     - $ref: '#/components/schemas/Address'
                   nullable: true
+                nullableNot:
+                  type: object
+                  not:
+                    $ref: '#/components/schemas/Address'
+                  nullable: true
 components:
   schemas:
     Address:

--- a/core/src/test/resources/openapi/specs/nullable.yml
+++ b/core/src/test/resources/openapi/specs/nullable.yml
@@ -27,3 +27,34 @@ paths:
                 address:
                   type: object
                   nullable: true
+                nullableAllOf:
+                  type: object
+                  allOf:
+                    - $ref: '#/components/schemas/Address'
+                  nullable: true
+                nonNullableAllOf:
+                  type: object
+                  allOf:
+                    - $ref: '#/components/schemas/Address'
+                nullableOneOf:
+                  type: object
+                  oneOf:
+                    - $ref: '#/components/schemas/Address'
+                  nullable: true
+                nullableAnyOf:
+                  type: object
+                  anyOf:
+                    - $ref: '#/components/schemas/Address'
+                  nullable: true
+components:
+  schemas:
+    Address:
+      type: object
+      required:
+        - street
+        - city
+      properties:
+        street:
+          type: string
+        city:
+          type: string


### PR DESCRIPTION
The null/nullable short-circuit in SchemaValidator ran after the composition keywords had already been validated, so a `nullable: true` schema carrying an `allOf`/`oneOf`/`anyOf`/`not` descended into subschemas that are typically not nullable and rejected `null` with "Value null is not an object." Without a composition keyword the short-circuit was reached first, which is why inlining the referenced properties made the same `null` pass.

The check now sits directly after $ref resolution, before the composition dispatch. isNullable() is unchanged, so OAS 3.1 `type: [..., "null"]` is covered as well. Request and response bodies share SchemaValidator.

Reported by @schiller-hank in #3119.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Nullable values now validate correctly with `allOf`, `oneOf`, `anyOf`, and `not` schemas.
  * Non-nullable schemas continue to reject null values.
  * Object values within nullable composed schemas are still fully validated.
  * Nullable request-body scenarios now behave consistently across composed schemas.

* **Tests**
  * Added coverage for nullable composition scenarios, non-nullable validation, and nested object validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->