### PR TITLE
Add support for validating $ref siblings in OpenAPI 3.1

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/ObjectValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/ObjectValidator.java
@@ -16,22 +16,24 @@
 
 package com.predic8.membrane.core.openapi.validators;
 
-import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.databind.node.*;
-import com.predic8.membrane.core.openapi.util.*;
-import io.swagger.v3.oas.models.*;
-import io.swagger.v3.oas.models.media.*;
-import org.jetbrains.annotations.*;
-import org.slf4j.*;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.predic8.membrane.core.openapi.util.SchemaUtil;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
-import java.util.regex.*;
+import java.util.regex.Pattern;
 
-import static com.predic8.membrane.core.openapi.util.Utils.*;
+import static com.predic8.membrane.core.openapi.util.Utils.joinByComma;
 import static com.predic8.membrane.core.openapi.validators.ValidationError.v;
 import static com.predic8.membrane.core.openapi.validators.ValidationErrors.error;
-import static java.lang.String.*;
-import static java.util.Collections.*;
+import static java.lang.String.format;
+import static java.util.Collections.emptySet;
 
 /**
  * Not supported:
@@ -234,14 +236,26 @@ public class ObjectValidator implements JsonSchemaValidator {
 
     @SuppressWarnings("rawtypes")
     private boolean isPropertyReadOnly(String propertyName) {
-        Schema propSchema = (Schema) schema.getProperties().get(propertyName);
-        return propSchema.getReadOnly() != null && propSchema.getReadOnly();
+        Schema propSchema = getPropertySchema(propertyName);
+        return propSchema != null && propSchema.getReadOnly() != null && propSchema.getReadOnly();
     }
 
     @SuppressWarnings("rawtypes")
     private boolean isPropertyWriteOnly(String propertyName) {
-        Schema propSchema = (Schema) schema.getProperties().get(propertyName);
-        return propSchema.getWriteOnly() != null && propSchema.getWriteOnly();
+        Schema propSchema = getPropertySchema(propertyName);
+        return propSchema != null && propSchema.getWriteOnly() != null && propSchema.getWriteOnly();
+    }
+
+    /**
+     * @return the schema of the property, or null if the schema declares no properties at all or
+     * none for this name. A schema can require a property without declaring it, e.g. next to a
+     * $ref. See #3188.
+     */
+    @SuppressWarnings("rawtypes")
+    private @Nullable Schema getPropertySchema(String propertyName) {
+        if (schema.getProperties() == null)
+            return null;
+        return (Schema) schema.getProperties().get(propertyName);
     }
 
     private ValidationErrors createErrorsForMissingRequiredProperties(ValidationContext ctx, List<String> missingProperties) {

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/SchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/SchemaValidator.java
@@ -112,8 +112,11 @@ public class SchemaValidator implements JsonSchemaValidator {
                 ? validateKeywords(ctx.visitRef(name), schema, obj, value)
                 : null;
 
-        // Already on this branch: stop descending instead of recursing forever. Recursive
-        // schemas are legal, so the truncated branch contributes no errors.
+        // This schema was already resolved for this very value, so resolving it again cannot make
+        // progress: stop descending instead of recursing forever. A recursive schema that follows
+        // the instance (Node.next -> Node) reaches a new value on every level and is validated
+        // there; only a cycle that closes on the same value is truncated, and it contributes no
+        // errors.
         if (ctx.hasVisited(name))
             return errors.add(siblingErrors);
 

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/SchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/SchemaValidator.java
@@ -22,6 +22,7 @@ import com.predic8.membrane.core.openapi.model.Body;
 import com.predic8.membrane.core.openapi.util.SchemaUtil;
 import com.predic8.membrane.core.util.xml.parser.XmlParseException;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.SpecVersion;
 import io.swagger.v3.oas.models.media.Schema;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -35,9 +36,9 @@ import java.util.List;
 import java.util.Objects;
 
 import static com.predic8.membrane.core.openapi.util.SchemaUtil.getSchemaNameFromRef;
-import static com.predic8.membrane.core.openapi.validators.ValidationError.v;
 import static com.predic8.membrane.core.openapi.validators.ValidationContext.ValidatedEntityType.BODY;
 import static com.predic8.membrane.core.openapi.validators.ValidationContext.ValidatedEntityType.QUERY_PARAMETER;
+import static com.predic8.membrane.core.openapi.validators.ValidationError.v;
 
 public class SchemaValidator implements JsonSchemaValidator {
 
@@ -46,7 +47,7 @@ public class SchemaValidator implements JsonSchemaValidator {
     private static final com.fasterxml.jackson.databind.ObjectMapper CONTENT_MAPPER = new com.fasterxml.jackson.databind.ObjectMapper();
 
     @SuppressWarnings("rawtypes")
-    private Schema schema;
+    final private Schema schema;
     final private OpenAPI api;
 
     @SuppressWarnings("rawtypes")
@@ -96,23 +97,71 @@ public class SchemaValidator implements JsonSchemaValidator {
 
         // The $ref has to be resolved before the composition keywords are read: a schema object that
         // is just a $ref carries none of them, they belong to the schema it points at. See #3119.
-        if (schema.get$ref() != null) {
-            String name = getSchemaNameFromRef(schema);
+        if (schema.get$ref() == null)
+            return errors.add(validateKeywords(ctx, schema, obj, value));
 
-            // Already on this branch: stop descending instead of recursing forever. Recursive
-            // schemas are legal, so the truncated branch contributes no errors.
-            if (ctx.hasVisited(name))
-                return errors;
+        String name = getSchemaNameFromRef(schema);
 
-            ctx = ctx.complexType(name).visitRef(name);
-            schema = SchemaUtil.getSchemaFromRef(api, schema.get$ref());
-            if (schema == null)
-                throw new RuntimeException("Should not happen!");
-        }
+        // In JSON Schema 2020-12 (OAS 3.1 and later) $ref is an ordinary applicator: keywords next
+        // to it are applied alongside the schema it points at. Validating both and adding up the
+        // errors is exactly that. OAS 3.0 ignores them instead. See #3188.
+        //
+        // They belong to the referring schema, not to the referenced component: they keep the
+        // context of the reference, and they are validated even when the branch is truncated below.
+        ValidationErrors siblingErrors = appliesSiblings(schema)
+                ? validateKeywords(ctx.visitRef(name), schema, obj, value)
+                : null;
+
+        // Already on this branch: stop descending instead of recursing forever. Recursive
+        // schemas are legal, so the truncated branch contributes no errors.
+        if (ctx.hasVisited(name))
+            return errors.add(siblingErrors);
+
+        Schema target = SchemaUtil.getSchemaFromRef(api, schema.get$ref());
+        if (target == null)
+            throw new RuntimeException("Should not happen!");
+
+        errors.add(validateKeywords(ctx.complexType(name).visitRef(name), target, obj, value));
+        return errors.add(notReportedYet(errors, siblingErrors));
+    }
+
+    /**
+     * A keyword next to a $ref can repeat an assertion of the schema it points at, e.g. require the
+     * same property. Reporting the identical error once per schema would only be noise.
+     *
+     * @return the errors that are not already in reported
+     */
+    private static @Nullable ValidationErrors notReportedYet(ValidationErrors reported, @Nullable ValidationErrors errors) {
+        if (errors == null)
+            return null;
+        var result = new ValidationErrors();
+        errors.getErrors().stream()
+                .filter(error -> reported.getErrors().stream().noneMatch(r -> isSame(r, error)))
+                .forEach(result::add);
+        return result;
+    }
+
+    private static boolean isSame(ValidationError a, ValidationError b) {
+        return Objects.equals(a.getMessage(), b.getMessage())
+               && Objects.equals(location(a), location(b));
+    }
+
+    private static @Nullable String location(ValidationError error) {
+        return error.getContext() != null ? error.getContext().getLocationForRequest() : null;
+    }
+
+    /**
+     * Validates the value against every keyword of the schema except $ref, which the caller has
+     * resolved already.
+     */
+    @SuppressWarnings("rawtypes")
+    private ValidationErrors validateKeywords(ValidationContext ctx, Schema schema, Object obj, Object value) {
+
+        var errors = new ValidationErrors();
 
         // A nullable schema accepts null itself, so validation stops here instead of descending into
         // allOf/anyOf/oneOf/not subschemas, which are typically not nullable and would reject it. See #3119.
-        if ((value == null || value instanceof NullNode) && isNullable())
+        if ((value == null || value instanceof NullNode) && isNullable(schema))
             return errors;
 
         if (schema.getAllOf() != null)
@@ -133,8 +182,8 @@ public class SchemaValidator implements JsonSchemaValidator {
             errors.add(new NotValidator(api, schema).validate(ctx, obj));
 
         errors.add(new NumberRestrictionValidator(schema).validate(ctx, value));
-        errors.add(validateByType(ctx, value));
-        errors.add(validateContentSchema(ctx, value));
+        errors.add(validateByType(ctx, schema, value));
+        errors.add(validateContentSchema(ctx, schema, value));
         return errors;
     }
 
@@ -144,7 +193,8 @@ public class SchemaValidator implements JsonSchemaValidator {
      * {@code contentEncoding: base64}) the decoded content is parsed and validated against
      * {@code contentSchema}. Only JSON content media types are validated; others are left untouched.
      */
-    private ValidationErrors validateContentSchema(ValidationContext ctx, Object value) {
+    @SuppressWarnings("rawtypes")
+    private ValidationErrors validateContentSchema(ValidationContext ctx, Schema schema, Object value) {
         if (schema.getContentSchema() == null || schema.getContentMediaType() == null)
             return null;
         String text = asString(value);
@@ -183,36 +233,73 @@ public class SchemaValidator implements JsonSchemaValidator {
         return mt.equals("application/json") || mt.endsWith("+json");
     }
 
-    private boolean isNullable() {
+    /**
+     * @return true if keywords next to the $ref have to be validated. Only from OAS 3.1 on: 3.0
+     * ignores them, and the parser is no help there because it keeps a sibling type while dropping
+     * a sibling nullable, readOnly or required.
+     */
+    @SuppressWarnings("rawtypes")
+    private static boolean appliesSiblings(Schema schema) {
+        return schema.getSpecVersion() != SpecVersion.V30 && hasSiblings(schema);
+    }
+
+    /**
+     * @return true if the schema carries keywords besides the $ref. Compares against a schema of
+     * the same class that has nothing but the same $ref, because Schema does not expose its keywords
+     * as a map and Schema.equals() compares the class. A schema that cannot be instantiated counts
+     * as having siblings, which validates more rather than less.
+     * <p>
+     * Keywords a no-arg constructor sets itself are invisible to the comparison, e.g. the type of a
+     * StringSchema. That only affects OAS 3.0, where such subclasses are used and keywords next to a
+     * $ref are ignored anyway; 3.1 and later parse into JsonSchema, which starts out empty.
+     */
+    @SuppressWarnings("rawtypes")
+    static boolean hasSiblings(Schema schema) {
+        Schema bare;
+        try {
+            bare = schema.getClass().getDeclaredConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
+            log.debug("Cannot instantiate {} to look for keywords next to a $ref.", schema.getClass(), e);
+            return true;
+        }
+        bare.setSpecVersion(schema.getSpecVersion());
+        bare.set$ref(schema.get$ref());
+        return !bare.equals(schema);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static boolean isNullable(Schema schema) {
         return (schema.getNullable() != null && schema.getNullable()) || (schema.getTypes() != null && schema.getTypes().contains("null")) ||
                (schema.getType() != null && schema.getType().equals("null"));
     }
 
-    private ValidationErrors validateByType(ValidationContext ctx, Object value) {
+    @SuppressWarnings("rawtypes")
+    private ValidationErrors validateByType(ValidationContext ctx, Schema schema, Object value) {
 
         // For the same OpenAPI content version 3.0.X and 3.1.X can deliver different values
         // e.g. an array in the QueryParameter
         var type = schema.getType();
 
-        if (schemaHasNoTypeAndTypes(type)) {
-            return validateMultipleTypes(List.of(STRING, NUMBER, INTEGER, BOOLEAN, ARRAY, OBJECT, NULL), ctx, value);
+        if (schemaHasNoTypeAndTypes(schema, type)) {
+            return validateMultipleTypes(List.of(STRING, NUMBER, INTEGER, BOOLEAN, ARRAY, OBJECT, NULL), ctx, schema, value);
         }
 
         // type in schema has only one type
         if (type != null)
-            return validateSingleType(ctx, value, type);
+            return validateSingleType(ctx, schema, value, type);
 
         // At that point: schema.types is used
-        return validateMultipleTypes(new ArrayList<String>(schema.getTypes()), ctx, value);
+        return validateMultipleTypes(new ArrayList<String>(schema.getTypes()), ctx, schema, value);
     }
 
-    private @Nullable ValidationErrors validateMultipleTypes(List<String> types, ValidationContext ctx, Object value) {
+    @SuppressWarnings("rawtypes")
+    private @Nullable ValidationErrors validateMultipleTypes(List<String> types, ValidationContext ctx, Schema schema, Object value) {
         var typeOfValue = getTypeOfValue(types, value);
 
         var errors = getTypeNotMatchError(types, ctx, value, typeOfValue);
         if (errors != null) return errors;
 
-        return validateSingleType(ctx, value, typeOfValue);
+        return validateSingleType(ctx, schema, value, typeOfValue);
 
     }
 
@@ -270,7 +357,8 @@ public class SchemaValidator implements JsonSchemaValidator {
     }
 
 
-    private ValidationErrors validateSingleType(ValidationContext ctx, Object value, String type) {
+    @SuppressWarnings("rawtypes")
+    private ValidationErrors validateSingleType(ValidationContext ctx, Schema schema, Object value, String type) {
         try {
             return switch (type) {
                 case NULL -> new NullValidator().validate(ctx, value);
@@ -287,7 +375,8 @@ public class SchemaValidator implements JsonSchemaValidator {
         }
     }
 
-    private boolean schemaHasNoTypeAndTypes(String type) {
+    @SuppressWarnings("rawtypes")
+    private static boolean schemaHasNoTypeAndTypes(Schema schema, String type) {
         return type == null && (schema.getTypes() == null || schema.getTypes().isEmpty());
     }
 

--- a/core/src/main/java/com/predic8/membrane/core/openapi/validators/ValidationContext.java
+++ b/core/src/main/java/com/predic8/membrane/core/openapi/validators/ValidationContext.java
@@ -43,12 +43,22 @@ public class ValidationContext {
     private int statusCode;
 
     /**
-     * Names of the component schemas whose $ref has already been resolved on the current branch of
-     * the validation. Used solely to break reference cycles; unlike {@link #complexType} it is never
-     * reported to the caller. Immutable and copied on write, so it is scoped to the branch rather
-     * than to the whole validation run.
+     * The component schemas whose $ref has already been resolved on the current branch of the
+     * validation, each paired with the JSON pointer of the value it was resolved for. Used solely
+     * to break reference cycles; unlike {@link #complexType} it is never reported to the caller.
+     * Immutable and copied on write, so it is scoped to the branch rather than to the whole
+     * validation run.
+     * <p>
+     * The pointer is part of the key because a recursive schema is not a cycle: {@code Node.next}
+     * pointing back at {@code Node} has to be validated again for every nested node. Only a
+     * reference that returns to the same schema for the same value cannot make progress.
      */
-    private Set<String> visitedRefs = Set.of();
+    private Set<VisitedRef> visitedRefs = Set.of();
+
+    /**
+     * A resolved $ref, identified by the referenced schema and the value it was resolved for.
+     */
+    private record VisitedRef(String name, String jsonPointer) {}
 
     public enum Content { JSON, XML }
 
@@ -210,16 +220,25 @@ public class ValidationContext {
     }
 
     /**
-     * Marks the component schema {@code name} as resolved on this branch, see {@link #visitedRefs}.
+     * Marks the component schema {@code name} as resolved for the value at the current JSON
+     * pointer, see {@link #visitedRefs}.
      */
     public ValidationContext visitRef(String name) {
         ValidationContext ctx = this.deepCopy();
-        ctx.visitedRefs = Stream.concat(visitedRefs.stream(), Stream.of(name)).collect(toUnmodifiableSet());
+        ctx.visitedRefs = Stream.concat(visitedRefs.stream(), Stream.of(visitedRef(name))).collect(toUnmodifiableSet());
         return ctx;
     }
 
+    /**
+     * @return whether {@code name} has already been resolved for the value at the current JSON
+     * pointer, which means resolving it again cannot make progress
+     */
     public boolean hasVisited(String name) {
-        return visitedRefs.contains(name);
+        return visitedRefs.contains(visitedRef(name));
+    }
+
+    private VisitedRef visitedRef(String name) {
+        return new VisitedRef(name, jsonPointer);
     }
 
     public ValidationContext content(Content content) {

--- a/core/src/test/java/com/predic8/membrane/core/openapi/validators/CompositionTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/validators/CompositionTest.java
@@ -16,14 +16,16 @@
 
 package com.predic8.membrane.core.openapi.validators;
 
-import com.predic8.membrane.core.openapi.model.*;
-import org.junit.jupiter.api.*;
+import com.predic8.membrane.core.openapi.model.Request;
+import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.predic8.membrane.core.http.MimeType.APPLICATION_XML;
-import static com.predic8.membrane.core.openapi.util.JsonTestUtil.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static com.predic8.membrane.core.openapi.util.JsonTestUtil.mapToJson;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
@@ -363,6 +365,33 @@ protected String getOpenAPIFileName() {
 
         ValidationErrors errors = validator.validate(Request.post().path("/composition-ref-cycle").body(mapToJson(m)));
         assertEquals(0,errors.size());
+    }
+
+    /**
+     * A recursive schema is not a cycle as long as the validation descends into the instance:
+     * RefRecursiveNode.next points back at RefRecursiveNode, and every nested node has to be
+     * validated against it.
+     */
+    @Test
+    void refRecursiveIsValidatedAtEveryLevel() {
+
+        Map<String,Object> node = Map.of("id","1","next",Map.of("id","2","next",Map.of()));
+
+        ValidationErrors errors = validator.validate(Request.post().path("/composition-ref-recursive").body(mapToJson(node)));
+
+        assertEquals(1, errors.size(), () -> "Unexpected errors: " + errors);
+        assertEquals("Required property id is missing.", errors.getFirst().getMessage());
+        assertEquals("REQUEST/BODY#/next/next/id", errors.getFirst().getContext().getLocationForRequest());
+    }
+
+    @Test
+    void refRecursiveValid() {
+
+        Map<String,Object> node = Map.of("id","1","next",Map.of("id","2","next",Map.of("id","3")));
+
+        ValidationErrors errors = validator.validate(Request.post().path("/composition-ref-recursive").body(mapToJson(node)));
+
+        assertEquals(0, errors.size(), () -> "Unexpected errors: " + errors);
     }
 
     /**

--- a/core/src/test/java/com/predic8/membrane/core/openapi/validators/RefSiblingsOAS30Test.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/validators/RefSiblingsOAS30Test.java
@@ -1,0 +1,100 @@
+/*
+ *  Copyright 2026 predic8 GmbH, www.predic8.com
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.predic8.membrane.core.openapi.validators;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.predic8.membrane.core.openapi.model.Request.post;
+import static com.predic8.membrane.core.openapi.util.JsonTestUtil.mapToJson;
+import static com.predic8.membrane.core.openapi.validators.ValidationContext.ValidatedEntityType.BODY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * OAS 3.0 ignores keywords sitting next to a $ref, so discarding them is the specified
+ * behaviour here. This is the control group for {@link RefSiblingsOAS31Test} (#3188): a fix for
+ * 3.1 must not change any of these results.
+ */
+class RefSiblingsOAS30Test extends AbstractValidatorTest {
+
+    private static final Map<String, Object> ADDRESS = Map.of("street", "Koblenzer Str. 65", "city", "Bonn");
+
+    @Override
+    protected String getOpenAPIFileName() {
+        return "/openapi/specs/ref-siblings.yaml";
+    }
+
+    @Test
+    void refIsResolvedAndApplied() {
+        assertEquals(List.of(), messages(validate("nullableRef", ADDRESS)));
+
+        ValidationError error = single(validate("nullableRef", Map.of()));
+        assertEquals("Required properties city,street are missing in object /nullableRef.", error.getMessage());
+        assertEquals("REQUEST/BODY#/nullableRef", error.getContext().getLocationForRequest());
+        assertEquals("Address", error.getContext().getComplexType());
+        assertEquals(BODY, error.getContext().getValidatedEntityType());
+        assertEquals(400, error.getContext().getStatusCode());
+    }
+
+    @Test
+    void siblingNullableIsIgnoredAsSpecified() {
+        ValidationError error = single(validate("nullableRef", null));
+        assertEquals("Value null is not an object.", error.getMessage());
+        assertEquals("REQUEST/BODY#/nullableRef", error.getContext().getLocationForRequest());
+        assertEquals("object", error.getContext().getSchemaType());
+    }
+
+    @Test
+    void siblingReadOnlyIsIgnoredAsSpecified() {
+        assertEquals(List.of(), messages(validate("readOnlyRef", ADDRESS)));
+    }
+
+    @Test
+    void siblingRequiredIsIgnoredAsSpecified() {
+        // "zip" is required next to the $ref only, so it is not demanded ...
+        assertEquals(List.of(), messages(validate("extraRequiredRef", ADDRESS)));
+
+        // ... while "city" from the referenced schema still is
+        ValidationError error = single(validate("extraRequiredRef", Map.of("street", "Koblenzer Str. 65")));
+        assertEquals("Required property city is missing.", error.getMessage());
+        assertEquals("REQUEST/BODY#/extraRequiredRef/city", error.getContext().getLocationForRequest());
+    }
+
+    @Test
+    void siblingTypeIsIgnoredAsSpecified() {
+        // AnyValue has no type and the sibling `type: string` is dropped, so anything goes
+        assertEquals(List.of(), messages(validate("narrowedRef", 42)));
+    }
+
+    private ValidationErrors validate(String property, Object value) {
+        Map<String, Object> body = new HashMap<>();
+        body.put(property, value);
+        return validator.validate(post().path("/siblings").body(mapToJson(body)));
+    }
+
+    private static ValidationError single(ValidationErrors errors) {
+        assertEquals(1, errors.size(), () -> "Expected exactly one error but got " + messages(errors));
+        return errors.getFirst();
+    }
+
+    private static List<String> messages(ValidationErrors errors) {
+        return errors.getErrors().stream().map(ValidationError::getMessage).toList();
+    }
+}

--- a/core/src/test/java/com/predic8/membrane/core/openapi/validators/RefSiblingsOAS31Test.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/validators/RefSiblingsOAS31Test.java
@@ -122,17 +122,32 @@ class RefSiblingsOAS31Test extends AbstractValidatorTest {
     }
 
     /**
-     * Descending into Node stops where it repeats, but the keywords next to that $ref are not
-     * recursive and still have to be applied at the truncation boundary.
+     * Node.next points back at Node, so both the referenced schema and the keywords next to that
+     * $ref apply again at every nested node. The recursion follows the instance, it does not stop
+     * at the first repetition of the schema.
      */
     @Test
-    void siblingIsAppliedWhereRecursionIsTruncated() {
-        Map<String, Object> node = Map.of("id", "1", "next", Map.of("id", "2"));
-        assertEquals(List.of(), messages(validate("nodeRef", node)));
+    void siblingIsAppliedOnEveryLevelOfRecursion() {
+        assertEquals(List.of(), messages(validate("nodeRef", Map.of("id", "1", "next", Map.of("id", "2")))));
 
-        // "next" requires an id next to its $ref, and nothing else is validated at that depth
+        // "next" requires an id next to its $ref
         ValidationError error = single(validate("nodeRef", Map.of("id", "1", "next", Map.of())));
         assertEquals("Required property id is missing.", error.getMessage());
+        assertEquals("REQUEST/BODY#/nodeRef/next/id", error.getContext().getLocationForRequest());
+
+        error = single(validate("nodeRef", Map.of("id", "1", "next", Map.of("id", "2", "next", Map.of()))));
+        assertEquals("Required property id is missing.", error.getMessage());
+        assertEquals("REQUEST/BODY#/nodeRef/next/next/id", error.getContext().getLocationForRequest());
+    }
+
+    /**
+     * Not only the siblings: the referenced schema itself keeps applying below the first
+     * repetition, so Node's own `id: string` is validated at every level.
+     */
+    @Test
+    void refTargetIsAppliedOnEveryLevelOfRecursion() {
+        ValidationError error = single(validate("nodeRef", Map.of("id", "1", "next", Map.of("id", 42))));
+        assertEquals("42 is of type integer which does not match any of [string]", error.getMessage());
         assertEquals("REQUEST/BODY#/nodeRef/next/id", error.getContext().getLocationForRequest());
     }
 

--- a/core/src/test/java/com/predic8/membrane/core/openapi/validators/RefSiblingsOAS31Test.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/validators/RefSiblingsOAS31Test.java
@@ -1,0 +1,166 @@
+/*
+ *  Copyright 2026 predic8 GmbH, www.predic8.com
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.predic8.membrane.core.openapi.validators;
+
+import io.swagger.v3.oas.models.media.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.predic8.membrane.core.openapi.model.Request.post;
+import static com.predic8.membrane.core.openapi.util.JsonTestUtil.mapToJson;
+import static com.predic8.membrane.core.openapi.validators.ValidationContext.ValidatedEntityType.BODY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * OAS 3.1 follows JSON Schema 2020-12, where $ref is an ordinary applicator keyword: a sibling
+ * keyword is applied alongside the schema the $ref points at, and the two are AND-ed. See #3188.
+ */
+class RefSiblingsOAS31Test extends AbstractValidatorTest {
+
+    private static final Map<String, Object> ADDRESS = Map.of("street", "Koblenzer Str. 65", "city", "Bonn");
+
+    @Override
+    protected String getOpenAPIFileName() {
+        return "/openapi/specs/oas31/ref-siblings.yaml";
+    }
+
+    @Test
+    void refIsResolvedAndApplied() {
+        assertEquals(List.of(), messages(validate("nullableRef", ADDRESS)));
+
+        ValidationError error = single(validate("nullableRef", Map.of()));
+        assertEquals("Required properties city,street are missing in object /nullableRef.", error.getMessage());
+        assertEquals("REQUEST/BODY#/nullableRef", error.getContext().getLocationForRequest());
+        assertEquals("Address", error.getContext().getComplexType());
+        assertEquals(BODY, error.getContext().getValidatedEntityType());
+        assertEquals(400, error.getContext().getStatusCode());
+    }
+
+    /**
+     * The siblings survive parsing, so whatever is lost is lost inside Membrane, not upstream.
+     */
+    @Test
+    void parserKeepsSiblingsNextToRef() {
+        Map<String, Schema> properties = validator.getApi().getPaths().get("/siblings").getPost()
+                .getRequestBody().getContent().get("application/json").getSchema().getProperties();
+
+        Schema<?> nullableRef = properties.get("nullableRef");
+        assertEquals("#/components/schemas/Address", nullableRef.get$ref());
+        assertEquals(List.of("object", "null"), List.copyOf(nullableRef.getTypes()));
+
+        assertTrue(properties.get("readOnlyRef").getReadOnly());
+        assertEquals(List.of("zip"), properties.get("extraRequiredRef").getRequired());
+    }
+
+    /**
+     * $ref and its siblings are AND-ed, so the target keeps applying: Address is `type: object`
+     * and rejects null even though the sibling allows it. The spec-correct way to spell a
+     * nullable reference is `anyOf: [{$ref: Address}, {type: "null"}]`.
+     */
+    @Test
+    void siblingNullTypeDoesNotOverrideRefTarget() {
+        ValidationError error = single(validate("nullableRef", null));
+        assertEquals("null is of type null which does not match any of [object]", error.getMessage());
+        assertEquals("REQUEST/BODY#/nullableRef", error.getContext().getLocationForRequest());
+    }
+
+    @Test
+    void siblingTypeNarrowsUntypedRef() {
+        // AnyValue has no type, so the sibling `type: string` is the only constraint
+        assertEquals(List.of(), messages(validate("narrowedRef", "Bonn")));
+
+        ValidationError error = single(validate("narrowedRef", 42));
+        assertEquals("42 is of type integer which does not match any of [string]", error.getMessage());
+        assertEquals("REQUEST/BODY#/narrowedRef", error.getContext().getLocationForRequest());
+    }
+
+    /**
+     * Both the target and the sibling reject the value, and both errors are reported. That is what
+     * the union of two applied schemas amounts to.
+     */
+    @Test
+    void siblingAndTargetBothReportTypeMismatch() {
+        assertEquals(List.of("\"foo\" is of type string which does not match any of [object]",
+                        "\"foo\" is of type string which does not match any of [object, null]"),
+                messages(validate("nullableRef", "foo")));
+    }
+
+    @Test
+    void siblingRequiredIsApplied() {
+        // "zip" is required next to the $ref, the referenced Address has no such requirement
+        ValidationErrors errors = validate("extraRequiredRef", ADDRESS);
+
+        assertEquals(List.of("Required property zip is missing."), messages(errors));
+        assertEquals("REQUEST/BODY#/extraRequiredRef/zip", errors.getFirst().getContext().getLocationForRequest());
+    }
+
+    /**
+     * Both schemas require "city", so both report it missing. The user gets one error, not two.
+     */
+    @Test
+    void repeatedAssertionIsReportedOnce() {
+        assertEquals(List.of("Required property city is missing."),
+                messages(validate("duplicateRequiredRef", Map.of("street", "Koblenzer Str. 65"))));
+    }
+
+    /**
+     * Descending into Node stops where it repeats, but the keywords next to that $ref are not
+     * recursive and still have to be applied at the truncation boundary.
+     */
+    @Test
+    void siblingIsAppliedWhereRecursionIsTruncated() {
+        Map<String, Object> node = Map.of("id", "1", "next", Map.of("id", "2"));
+        assertEquals(List.of(), messages(validate("nodeRef", node)));
+
+        // "next" requires an id next to its $ref, and nothing else is validated at that depth
+        ValidationError error = single(validate("nodeRef", Map.of("id", "1", "next", Map.of())));
+        assertEquals("Required property id is missing.", error.getMessage());
+        assertEquals("REQUEST/BODY#/nodeRef/next/id", error.getContext().getLocationForRequest());
+    }
+
+    /**
+     * readOnly is read by the surrounding ObjectValidator, not by the SchemaValidator that resolves
+     * the $ref. The error has to stay a single one although two schemas are validated.
+     */
+    @Test
+    void siblingReadOnlyIsHonoured() {
+        ValidationError error = single(validate("readOnlyRef", ADDRESS));
+        assertTrue(error.getMessage().startsWith("The property readOnlyRef is read only."),
+                "Unexpected message: " + error.getMessage());
+        assertEquals("REQUEST/BODY#/readOnlyRef", error.getContext().getLocationForRequest());
+        assertEquals(BODY, error.getContext().getValidatedEntityType());
+    }
+
+    private ValidationErrors validate(String property, Object value) {
+        Map<String, Object> body = new HashMap<>();
+        body.put(property, value);
+        return validator.validate(post().path("/siblings").body(mapToJson(body)));
+    }
+
+    private static ValidationError single(ValidationErrors errors) {
+        assertEquals(1, errors.size(), () -> "Expected exactly one error but got " + messages(errors));
+        return errors.getFirst();
+    }
+
+    private static List<String> messages(ValidationErrors errors) {
+        return errors.getErrors().stream().map(ValidationError::getMessage).toList();
+    }
+}

--- a/core/src/test/java/com/predic8/membrane/core/openapi/validators/SchemaValidatorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/openapi/validators/SchemaValidatorTest.java
@@ -13,16 +13,28 @@
    limitations under the License. */
 package com.predic8.membrane.core.openapi.validators;
 
-import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.databind.node.*;
-import org.junit.jupiter.api.*;
-import org.junit.jupiter.params.*;
-import org.junit.jupiter.params.provider.*;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.SpecVersion;
+import io.swagger.v3.oas.models.media.Schema;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import java.io.*;
-import java.util.stream.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
 
-import static com.fasterxml.jackson.databind.node.BooleanNode.*;
+import static com.fasterxml.jackson.databind.node.BooleanNode.TRUE;
+import static com.predic8.membrane.core.openapi.util.OpenAPITestUtils.parseOpenAPI;
 import static com.predic8.membrane.core.openapi.validators.JsonSchemaValidator.*;
 import static java.io.InputStream.nullInputStream;
 import static org.junit.jupiter.api.Assertions.*;
@@ -30,6 +42,8 @@ import static org.junit.jupiter.api.Assertions.*;
 public class SchemaValidatorTest {
 
     private static final ObjectMapper mapper = new ObjectMapper();
+
+    private static final String ADDRESS_REF = "#/components/schemas/Address";
 
     static JsonSchemaValidator arrayValidator;
     static JsonSchemaValidator booleanValidator;
@@ -114,5 +128,63 @@ public class SchemaValidatorTest {
     @Test
     void canValidateWithInputStream() {
         assertNull(objectValidator.canValidate(nullInputStream()));
+    }
+
+    @Nested
+    class HasSiblings {
+
+        @Test
+        void refOnly() {
+            assertFalse(SchemaValidator.hasSiblings(new Schema<>().$ref(ADDRESS_REF)));
+        }
+
+        @Test
+        void emptySchema() {
+            assertFalse(SchemaValidator.hasSiblings(new Schema<>()));
+        }
+
+        @Test
+        void refAndType() {
+            assertTrue(SchemaValidator.hasSiblings(new Schema<>().$ref(ADDRESS_REF).types(Set.of("string"))));
+        }
+
+        @Test
+        void refAndRequired() {
+            assertTrue(SchemaValidator.hasSiblings(new Schema<>().$ref(ADDRESS_REF).required(List.of("zip"))));
+        }
+
+        @Test
+        void refAndReadOnly() {
+            assertTrue(SchemaValidator.hasSiblings(new Schema<>().$ref(ADDRESS_REF).readOnly(true)));
+        }
+
+        /**
+         * A different spec version alone is not a sibling keyword.
+         */
+        @Test
+        void refOnlyWithSpecVersion() {
+            Schema<?> schema = new Schema<>().$ref(ADDRESS_REF);
+            schema.setSpecVersion(SpecVersion.V31);
+            assertFalse(SchemaValidator.hasSiblings(schema));
+        }
+
+        @Test
+        void keywordWithoutRef() {
+            assertTrue(SchemaValidator.hasSiblings(new Schema<>().types(Set.of("string"))));
+        }
+
+        /**
+         * The hand built schemas above have to agree with what the parser produces. The parser uses
+         * Schema subclasses, so a plain $ref must not be mistaken for a schema with siblings.
+         */
+        @ParameterizedTest
+        @CsvSource({"nullableRef,true", "readOnlyRef,true", "extraRequiredRef,true",
+                    "narrowedRef,true", "plainRef,false"})
+        void parsedSchema(String property, boolean expected) {
+            OpenAPI api = parseOpenAPI(getClass().getResourceAsStream("/openapi/specs/oas31/ref-siblings.yaml"));
+            Schema<?> schema = (Schema<?>) api.getPaths().get("/siblings").getPost().getRequestBody()
+                    .getContent().get("application/json").getSchema().getProperties().get(property);
+            assertEquals(expected, SchemaValidator.hasSiblings(schema));
+        }
     }
 }

--- a/core/src/test/resources/openapi/specs/composition.yml
+++ b/core/src/test/resources/openapi/specs/composition.yml
@@ -122,6 +122,17 @@ paths:
             schema:
               $ref: "#/components/schemas/RefAllOfXmlType"
 
+  /composition-ref-recursive:
+    post:
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RefRecursiveNode"
+
 components:
   schemas:
     Address:
@@ -167,6 +178,14 @@ components:
     RefNotType:
       not:
         type: object
+    RefRecursiveNode:
+      type: object
+      required: [ id ]
+      properties:
+        id:
+          type: string
+        next:
+          $ref: "#/components/schemas/RefRecursiveNode"
     RefCycleA:
       type: object
       allOf:

--- a/core/src/test/resources/openapi/specs/oas31/ref-siblings.yaml
+++ b/core/src/test/resources/openapi/specs/oas31/ref-siblings.yaml
@@ -1,0 +1,62 @@
+openapi: '3.1.0'
+info:
+  title: Ref Siblings Test API
+  version: '1.0'
+paths:
+  /siblings:
+    post:
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                nullableRef:
+                  $ref: '#/components/schemas/Address'
+                  type:
+                    - object
+                    - "null"
+                readOnlyRef:
+                  $ref: '#/components/schemas/Address'
+                  readOnly: true
+                extraRequiredRef:
+                  $ref: '#/components/schemas/Address'
+                  required:
+                    - zip
+                duplicateRequiredRef:
+                  $ref: '#/components/schemas/Address'
+                  required:
+                    - city
+                nodeRef:
+                  $ref: '#/components/schemas/Node'
+                plainRef:
+                  $ref: '#/components/schemas/Address'
+                narrowedRef:
+                  $ref: '#/components/schemas/AnyValue'
+                  type: string
+components:
+  schemas:
+    AnyValue:
+      description: no type, so only a keyword next to the $ref constrains the value
+    Node:
+      type: object
+      properties:
+        id:
+          type: string
+        next:
+          $ref: '#/components/schemas/Node'
+          required:
+            - id
+    Address:
+      type: object
+      required:
+        - street
+        - city
+      properties:
+        street:
+          type: string
+        city:
+          type: string

--- a/core/src/test/resources/openapi/specs/ref-siblings.yaml
+++ b/core/src/test/resources/openapi/specs/ref-siblings.yaml
@@ -1,0 +1,43 @@
+openapi: '3.0.3'
+info:
+  title: Ref Siblings Test API
+  version: '1.0'
+paths:
+  /siblings:
+    post:
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                nullableRef:
+                  $ref: '#/components/schemas/Address'
+                  nullable: true
+                readOnlyRef:
+                  $ref: '#/components/schemas/Address'
+                  readOnly: true
+                extraRequiredRef:
+                  $ref: '#/components/schemas/Address'
+                  required:
+                    - zip
+                narrowedRef:
+                  $ref: '#/components/schemas/AnyValue'
+                  type: string
+components:
+  schemas:
+    AnyValue:
+      description: no type, so only a keyword next to the $ref constrains the value
+    Address:
+      type: object
+      required:
+        - street
+        - city
+      properties:
+        street:
+          type: string
+        city:
+          type: string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenAPI schema validation for `$ref` usage.
  * OpenAPI 3.1 now validates keywords alongside referenced schemas.
  * OpenAPI 3.0 continues ignoring sibling keywords next to `$ref`.
  * Prevented errors when required properties are absent alongside a reference.
  * Improved recursive reference handling and duplicate error prevention.

* **Tests**
  * Added coverage for `$ref` siblings, nullability, types, required properties, read-only fields, and recursive schemas across OpenAPI 3.0 and 3.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->