### PR TITLE
Port/sticky body read failure / Logging of Client Disconnects

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/exchange/Exchange.java
+++ b/core/src/main/java/com/predic8/membrane/core/exchange/Exchange.java
@@ -15,13 +15,17 @@
 package com.predic8.membrane.core.exchange;
 
 import com.predic8.membrane.core.http.BodyCollectingMessageObserver;
+import com.predic8.membrane.core.http.Message;
 import com.predic8.membrane.core.http.Request;
 import com.predic8.membrane.core.proxies.Proxy;
 import com.predic8.membrane.core.proxies.SSLableProxy;
 import com.predic8.membrane.core.transport.http.AbstractHttpHandler;
 import com.predic8.membrane.core.transport.http.Connection;
 import com.predic8.membrane.core.util.HttpUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
@@ -48,6 +52,8 @@ public class Exchange extends AbstractExchange {
     private AbstractHttpHandler handler;
 
     private String originalHostHeader = "";
+
+    private static final Logger log = LoggerFactory.getLogger(Exchange.class);
 
     private Connection targetConnection;
 
@@ -148,8 +154,37 @@ public class Exchange extends AbstractExchange {
         handler = null;
     }
 
+    /**
+     * Detaches the target connection and closes it. Used to reclaim a connection that would otherwise
+     * be orphaned when an exception skipped the normal hand-over. It must not go back to the pool
+     * either: the request body may have been written to it only partially.
+     *
+     * @return whether a connection was still attached
+     */
+    public boolean closeTargetConnection() {
+        Connection con = targetConnection;
+        if (con == null)
+            return false;
+        targetConnection = null;
+        try {
+            con.close();
+        } catch (IOException e) {
+            log.debug("Closing target connection.", e);
+        }
+        return true;
+    }
+
     public boolean canKeepConnectionAlive() {
-        return getRequest().isKeepAlive() && getResponse().isKeepAlive();
+        return canKeepAlive(getRequest()) && canKeepAlive(getResponse());
+    }
+
+    /**
+     * A message whose body read failed leaves the connection desynchronized: the rest of the body is
+     * still in the stream and would be parsed as the beginning of the next message. Keep-alive headers
+     * alone are therefore not enough to decide that a connection may be reused.
+     */
+    private static boolean canKeepAlive(Message m) {
+        return m.isKeepAlive() && !m.getBody().hasFailed();
     }
 
     @Override

--- a/core/src/main/java/com/predic8/membrane/core/http/AbstractBody.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/AbstractBody.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.predic8.membrane.core.http.BodyState.*;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -46,6 +47,12 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * threads is illegal. Using a Body Stream after the Body as been accessed by
  * someone else (using streams or not) is illegal.
  * <p>
+ * Failing to read a body is terminal: the {@link ReadingBodyException} is recorded (see
+ * {@link #fail(IOException)}), the observers are notified via
+ * {@link MessageObserver#bodyFailed(ReadingBodyException)} and every later access re-throws that same
+ * exception instead of touching the (dead) stream again. This keeps the original cause visible rather
+ * than replacing it with a follow-up error like "stream is closed".
+ * <p>
  * Public instance methods must not throw {@link IOException}s. Throw an
  * unchecked {@link ReadingBodyException} or {@link WritingBodyException} instead.
  * (This is enforced by the BodyDoesntThrowIOExceptionTest .)
@@ -60,19 +67,26 @@ public abstract class AbstractBody {
 	 */
 	static final int MAX_ARRAY_LENGTH = Integer.MAX_VALUE - 8;
 
-	// whether the body has been read completely from the wire
-	boolean read;
+	/**
+	 * How far consuming this body has got. Never assign directly: go through {@link #markAsRead()} or
+	 * {@link #fail(IOException)}, which enforce the transitions.
+	 */
+	private BodyState state = UNREAD;
 
 	protected final List<Chunk> chunks = new ArrayList<>();
 	protected final List<MessageObserver> observers = new ArrayList<>(1);
+
+	/**
+	 * Whether the body was passed through without being retained. Orthogonal to {@link #state}: a
+	 * streamed body still becomes {@link BodyState.Read} once it has been consumed completely.
+	 */
 	private boolean wasStreamed = false;
 
 	public void read() {
-		if (read)
+		if (isRead())
 			return;
 
-		if (wasStreamed)
-			throw new IllegalStateException("Cannot read body after it was streamed.");
+		requireReadable();
 
 		for (MessageObserver observer : observers)
 			observer.bodyRequested(this);
@@ -81,25 +95,126 @@ public abstract class AbstractBody {
 		try {
 			readLocal();
 		} catch (IOException e) {
-			throw new ReadingBodyException(e);
+			throw fail(e);
 		}
 		markAsRead();
 	}
 
 	public void discard() {
+		if (state instanceof Failed(var cause)) {
+			// Nothing left to drain and no reason to bother the caller: discard() is a best-effort
+			// operation (see Message.discardBody()).
+			log.debug("Not discarding body: reading it already failed ({}).", cause.getMessage());
+			return;
+		}
 		read();
 	}
 
-	protected void markAsRead() {
-		if (read)
-			return;
+	/**
+	 * Guards every access to the body's content. Exhaustive over {@link BodyState}, so a new state
+	 * cannot be added without deciding what each access point does with it.
+	 *
+	 * @throws ReadingBodyException if reading the body failed earlier. The stream is dead; retrying it
+	 *         would only produce a follow-up error hiding the original cause.
+	 */
+	private void requireReadable() {
+		switch (state) {
+			case Failed(var cause) -> throw cause;
+			case Unread ignored -> requireNotStreamed();
+			case Read ignored -> requireNotStreamed();
+		}
+	}
 
-		read = true;
+	private void requireNotStreamed() {
+		if (wasStreamed)
+			throw new IllegalStateException("Cannot read body after it was streamed.");
+	}
+
+	/**
+	 * The failure half of {@link #requireReadable()}, for subclasses that must not touch a dead stream
+	 * but are reached on paths where streaming is legal.
+	 *
+	 * @throws ReadingBodyException if reading the body failed earlier.
+	 */
+	protected void throwIfFailed() {
+		if (state instanceof Failed(var cause))
+			throw cause;
+	}
+
+	/**
+	 * Records that reading this body failed and notifies the observers.
+	 * <p>
+	 * The first failure wins: the recorded exception is never replaced and the observers are notified
+	 * only once. Returns the exception so callers can write {@code throw fail(e);}.
+	 */
+	protected ReadingBodyException fail(IOException e) {
+		if (state instanceof Failed(var cause))
+			return cause;
+		ReadingBodyException failure = new ReadingBodyException(e);
+		state = new Failed(failure); // arm the latch before notifying, so a re-entering observer sees the failed state
+		notifyBodyFailed(failure);
+		return failure;
+	}
+
+	private void notifyBodyFailed(ReadingBodyException e) {
+		// Copy and clear first: observers may access the list (e.g. ShadowingInterceptor) and this is the
+		// last event fired on them, just as in markAsRead().
+		List<MessageObserver> os = new ArrayList<>(observers);
+		observers.clear();
+		for (MessageObserver observer : os) {
+			try {
+				observer.bodyFailed(e);
+			} catch (Exception ex) {
+				// must not mask the original exception: Connection.bodyFailed() may throw
+				e.addSuppressed(ex);
+				log.warn("Observer {} failed while handling a body read error.", observer, ex);
+			}
+		}
+	}
+
+	protected void markAsRead() {
+		switch (state) {
+			case Read ignored -> {
+				return;
+			}
+			// A failed body never becomes read: bodyComplete must not follow bodyFailed.
+			case Failed ignored -> {
+				return;
+			}
+			case Unread ignored -> state = READ;
+		}
+
+		onMarkedAsRead();
 
 		for (MessageObserver observer : observers)
 			observer.bodyComplete(this);
 
 		observers.clear();
+	}
+
+	/**
+	 * Hook for subclasses that keep their own completion state. Runs only when the body actually
+	 * transitioned to read, so such state can never contradict {@link #isRead()} - in particular it
+	 * stays unset for a body whose read failed.
+	 */
+	protected void onMarkedAsRead() {
+		// no additional state to update
+	}
+
+	/**
+	 * @return whether reading the body failed. In that case {@link #isRead()} stays <code>false</code>
+	 *         and accessing the content throws the recorded {@link ReadingBodyException}.
+	 */
+	public boolean hasFailed() {
+		return state instanceof Failed;
+	}
+
+	/**
+	 * @return the exception recorded when reading this body failed, or <code>null</code>. Useful to tell
+	 *         which of an exchange's bodies a {@link ReadingBodyException} belongs to.
+	 */
+	public ReadingBodyException getObservedException() {
+		return state instanceof Failed(var cause) ? cause : null;
 	}
 
 	protected abstract void readLocal() throws IOException;
@@ -124,8 +239,7 @@ public abstract class AbstractBody {
 	 * you should therefore use {@link #getContentAsStream()} instead.
 	 */
 	public byte[] getContent() {
-		if (wasStreamed)
-			throw new IllegalStateException("Cannot read body after it was streamed.");
+		requireReadable();
 		read();
 		long length = getLength();
 		if (length > MAX_ARRAY_LENGTH)
@@ -139,15 +253,17 @@ public abstract class AbstractBody {
 	}
 
 	public InputStream getContentAsStream() {
-		if (wasStreamed)
-			throw new IllegalStateException("Cannot read body after it was streamed.");
+		requireReadable();
 		read();
 		return new BodyInputStream(chunks);
 	}
 
 	public void write(AbstractBodyTransferer out, boolean retainCopy) {
+		// never (re-)transmit a body whose read failed: that would send a truncated body
+		if (state instanceof Failed(var cause))
+			throw cause;
 		try {
-			if (!read && !retainCopy) {
+			if (!isRead() && !retainCopy) {
 				if (wasStreamed)
 					log.warn("Streaming the body twice will not work.");
 				for (MessageObserver observer : observers)
@@ -214,7 +330,7 @@ public abstract class AbstractBody {
         try {
             return getRawLocal();
         } catch (IOException e) {
-            throw new ReadingBodyException(e);
+            throw fail(e);
         }
     }
 
@@ -242,7 +358,7 @@ public abstract class AbstractBody {
 	}
 
 	public boolean isRead() {
-		return read;
+		return state instanceof Read;
 	}
 
 	/**
@@ -251,8 +367,14 @@ public abstract class AbstractBody {
 	 * @param observer MessageObserver to add
 	 */
 	public void addObserver(MessageObserver observer) {
-		if (read) {
+		if (isRead()) {
 			observer.bodyComplete(this);
+			return;
+		}
+		if (state instanceof Failed(var cause)) {
+			// the terminal event already happened: fire it immediately instead of registering an observer
+			// that would never be called
+			observer.bodyFailed(cause);
 			return;
 		}
 		if (wasStreamed)

--- a/core/src/main/java/com/predic8/membrane/core/http/Body.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/Body.java
@@ -84,8 +84,10 @@ public class Body extends AbstractBody {
 	}
 
 	public void discard() {
-		if (read)
+		if (isRead())
 			return;
+		if (hasFailed())
+			return; // see AbstractBody.discard(): best-effort, and the stream is already dead
 		if (wasStreamed())
 			return;
 
@@ -95,7 +97,7 @@ public class Body extends AbstractBody {
         try {
             skipBodyContent();
         } catch (IOException e) {
-            throw new ReadingBodyException(e);
+            throw fail(e);
         }
     }
 
@@ -167,7 +169,7 @@ public class Body extends AbstractBody {
                 if (!((this.length > totalLength || this.length == -1) && (length = inputStream.read(buffer)) > 0))
                     break;
             } catch (IOException e) {
-                throw new ReadingBodyException(e);
+                throw fail(e);
             }
             totalLength += length;
 			streamedLength += length;

--- a/core/src/main/java/com/predic8/membrane/core/http/BodyState.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/BodyState.java
@@ -1,0 +1,41 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.core.http;
+
+/**
+ * How far consuming an {@link AbstractBody} has got. A body starts {@link #UNREAD} and moves at most
+ * once into one of the two terminal states, so "read" and "failed" can never both hold.
+ * <p>
+ * This is deliberately not the whole story of a body: whether it was <i>streamed</i> (passed through
+ * without being retained) is an orthogonal property, see {@link AbstractBody#wasStreamed()}. A
+ * streamed body is still {@link Read} once it has been consumed completely.
+ */
+sealed interface BodyState {
+
+	/** Nothing consumed yet: the only state a body may be read, streamed or failed from. */
+	record Unread() implements BodyState {}
+
+	/** Consumed completely. For a buffered body the content is in the chunks; for a streamed one it is gone. */
+	record Read() implements BodyState {}
+
+	/**
+	 * Reading failed. {@code cause} is re-thrown on every later access so the original failure stays
+	 * visible instead of being replaced by a follow-up error such as "stream is closed".
+	 */
+	record Failed(ReadingBodyException cause) implements BodyState {}
+
+	BodyState UNREAD = new Unread();
+	BodyState READ = new Read();
+}

--- a/core/src/main/java/com/predic8/membrane/core/http/ChunkedBody.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/ChunkedBody.java
@@ -152,30 +152,31 @@ public class ChunkedBody extends AbstractBody {
 
     @Override
     public void read() {
+        throwIfFailed(); // before the drain below: it would re-read the dead stream
         try {
             if (bodyObserved && !bodyComplete)
                 ByteUtil.readStream(getContentAsStream());
             bodyObserved = true;
             super.read();
         } catch (IOException e) {
-            throw new ReadingBodyException(e);
+            throw fail(e);
         }
     }
 
     @Override
     public void write(AbstractBodyTransferer out, boolean retainCopy) {
+        throwIfFailed(); // before the drain below: it would re-read the dead stream
         try {
             if (bodyObserved && !bodyComplete)
                 ByteUtil.readStream(getContentAsStream());
         } catch (IOException e) {
-            throw new ReadingBodyException(e);
+            throw fail(e);
         }
         super.write(out, retainCopy);
     }
 
     @Override
-    protected void markAsRead() {
-        super.markAsRead();
+    protected void onMarkedAsRead() {
         bodyComplete = true;
     }
 
@@ -191,8 +192,10 @@ public class ChunkedBody extends AbstractBody {
 
     @Override
     public void discard() {
-        if (read)
+        if (isRead())
             return;
+        if (hasFailed())
+            return; // see AbstractBody.discard(): best-effort, and the stream is already dead
         if (wasStreamed())
             return;
 
@@ -203,7 +206,7 @@ public class ChunkedBody extends AbstractBody {
             readChunksAndDrop(inputStream);
             trailer = readTrailer(inputStream);
         } catch (IOException e) {
-            throw new ReadingBodyException(e);
+            throw fail(e);
         }
         markAsRead();
     }
@@ -212,6 +215,7 @@ public class ChunkedBody extends AbstractBody {
     boolean bodyComplete = false;
 
     public InputStream getContentAsStream() {
+        throwIfFailed(); // before chunks.clear() below, which would drop the partially read body
         if (wasStreamed())
             throw new IllegalStateException("Cannot read body after it was streamed.");
         if (!bodyObserved) {
@@ -226,21 +230,29 @@ public class ChunkedBody extends AbstractBody {
             protected Chunk readNextChunk() throws IOException {
                 if (bodyComplete)
                     return null;
-                int chunkSize = readChunkSize(inputStream);
-                if (chunkSize > 0) {
-                    Chunk c = new Chunk(readByteArray(inputStream, chunkSize));
-                    inputStream.read(); // CR
-                    inputStream.read(); // LF
-                    for (MessageObserver observer : observers)
-                        observer.bodyChunk(c);
-                    return c;
+                throwIfFailed();
+                try {
+                    int chunkSize = readChunkSize(inputStream);
+                    if (chunkSize > 0) {
+                        Chunk c = new Chunk(readByteArray(inputStream, chunkSize));
+                        inputStream.read(); // CR
+                        inputStream.read(); // LF
+                        for (MessageObserver observer : observers)
+                            observer.bodyChunk(c);
+                        return c;
+                    }
+                    trailer = readTrailer(inputStream);
+
+                    // After the trailer(0 + CRLF + CRLF) is read we mark the body read
+                    markAsRead();
+
+                    return null;
+                } catch (IOException e) {
+                    // Record the failure (and notify the observers), but keep the InputStream contract:
+                    // callers of read() expect an IOException, not a ReadingBodyException.
+                    fail(e);
+                    throw e;
                 }
-                trailer = readTrailer(inputStream);
-
-                // After the trailer(0 + CRLF + CRLF) is read we mark the body read
-                markAsRead();
-
-                return null;
             }
         };
     }
@@ -287,7 +299,7 @@ public class ChunkedBody extends AbstractBody {
             }
             trailer = readTrailer(inputStream);
         } catch (IOException e) { // note that we only want to catch the IOExceptions associated to *reading* the body
-            throw new ReadingBodyException(e);
+            throw fail(e);
         }
         try {
             out.finish(trailer);
@@ -353,11 +365,6 @@ public class ChunkedBody extends AbstractBody {
         if (wasStreamed())
             return lengthStreamed;
         return super.getLength();
-    }
-
-    @Override
-    public boolean isRead() {
-        return super.isRead() && bodyComplete;
     }
 
     @Override

--- a/core/src/main/java/com/predic8/membrane/core/http/Message.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/Message.java
@@ -335,7 +335,7 @@ public abstract class Message {
 		if (header.hasContentLength())
 			return header.getContentLength() == 0;
 
-		if (getBody().read) {
+		if (getBody().isRead()) {
 			return getBody().getLength() == 0;
         }
 

--- a/core/src/main/java/com/predic8/membrane/core/http/MessageObserver.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/MessageObserver.java
@@ -50,8 +50,25 @@ public interface MessageObserver {
 	 * {@link Message#addObserver(MessageObserver)}), as the body may have
 	 * already been fully received when registering the observer.
 	 * <p>
-	 * This is the last event that will be fired on any MessageObserver.
+	 * This is the last event that will be fired on any MessageObserver, unless reading the body fails,
+	 * in which case {@link #bodyFailed(ReadingBodyException)} is fired instead. The two are mutually
+	 * exclusive.
 	 */
     void bodyComplete(AbstractBody body);
+
+	/**
+	 * Notification that reading the body failed and no {@link #bodyComplete(AbstractBody)} will follow.
+	 * <p>
+	 * Like {@link #bodyComplete(AbstractBody)} this may run instantaneously during
+	 * {@link AbstractBody#addObserver(MessageObserver)}, when the body has already failed.
+	 * <p>
+	 * Defaults to doing nothing: only observers that hold a resource for the duration of the body (an
+	 * open stream, a pooled connection, a buffer) need to act on it.
+	 *
+	 * @param e the recorded failure
+	 */
+	default void bodyFailed(ReadingBodyException e) {
+		// most observers have nothing to release
+	}
 
 }

--- a/core/src/main/java/com/predic8/membrane/core/http/ReadingBodyException.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/ReadingBodyException.java
@@ -14,6 +14,8 @@
 
 package com.predic8.membrane.core.http;
 
+import static com.predic8.membrane.core.util.ExceptionUtil.getRootCause;
+
 /**
  * Indicates that an error occurred while reading the body of a message.
  * The 'message' should already be enough to indicate the error.
@@ -29,11 +31,21 @@ public class ReadingBodyException extends RuntimeException {
     }
 
     /**
-     * @return whether this exception is the failure recorded on the given message's body. Useful to
-     * tell which end of the exchange the failure belongs to: the client (request body) or the target
+     * @return whether this exception reports the failure recorded on the given message's body. Useful
+     * to tell which end of the exchange the failure belongs to: the client (request body) or the target
      * server (response body).
+     * <p>
+     * Matches either the recorded exception itself or one wrapping the same root cause. The latter is
+     * needed because {@link ChunkedBody#getContentAsStream()} has to honour the {@link java.io.InputStream}
+     * contract: it records the failure but throws the raw {@link java.io.IOException}, which a caller
+     * may then wrap in a second {@link ReadingBodyException}. That wrapper is not the recorded instance,
+     * yet it carries the very same cause object and reports the very same failure.
      */
     public boolean belongsTo(Message message) {
-        return message != null && message.getBody().getObservedException() == this;
+        if (message == null)
+            return false;
+        ReadingBodyException recorded = message.getBody().getObservedException();
+        return recorded == this
+                || (recorded != null && getRootCause(recorded) == getRootCause(this));
     }
 }

--- a/core/src/main/java/com/predic8/membrane/core/http/ReadingBodyException.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/ReadingBodyException.java
@@ -27,4 +27,13 @@ public class ReadingBodyException extends RuntimeException {
     public ReadingBodyException(String message) {
         super(message);
     }
+
+    /**
+     * @return whether this exception is the failure recorded on the given message's body. Useful to
+     * tell which end of the exchange the failure belongs to: the client (request body) or the target
+     * server (response body).
+     */
+    public boolean belongsTo(Message message) {
+        return message != null && message.getBody().getObservedException() == this;
+    }
 }

--- a/core/src/main/java/com/predic8/membrane/core/http/Response.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/Response.java
@@ -14,26 +14,33 @@
 
 package com.predic8.membrane.core.http;
 
-import com.fasterxml.jackson.core.*;
-import com.fasterxml.jackson.databind.*;
-import com.predic8.membrane.core.exchange.*;
-import com.predic8.membrane.core.transport.http.*;
-import com.predic8.membrane.core.util.*;
-import org.apache.commons.text.*;
-import org.slf4j.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.transport.http.EOFWhileReadingFirstLineException;
+import com.predic8.membrane.core.transport.http.EOFWhileReadingLineException;
+import com.predic8.membrane.core.transport.http.NoResponseException;
+import com.predic8.membrane.core.util.EndOfStreamException;
+import com.predic8.membrane.core.util.HttpUtil;
+import org.apache.commons.text.StringEscapeUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.*;
-import java.util.*;
-import java.util.regex.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import static com.predic8.membrane.annot.Constants.*;
+import static com.predic8.membrane.annot.Constants.CRLF;
+import static com.predic8.membrane.annot.Constants.PRODUCT_NAME;
 import static com.predic8.membrane.core.http.Header.*;
 import static com.predic8.membrane.core.http.MimeType.*;
-import static com.predic8.membrane.core.http.Response.ResponseBuilder.*;
+import static com.predic8.membrane.core.http.Response.ResponseBuilder.newInstance;
 import static com.predic8.membrane.core.util.HttpUtil.*;
 import static java.lang.Integer.parseInt;
-import static java.nio.charset.StandardCharsets.*;
-import static org.apache.commons.text.StringEscapeUtils.*;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.text.StringEscapeUtils.escapeXml11;
 
 public class Response extends Message {
 
@@ -111,6 +118,15 @@ public class Response extends Message {
 
 			@Override
 			public void bodyComplete(AbstractBody body) {
+				closeStream();
+			}
+
+			@Override
+			public void bodyFailed(ReadingBodyException e) {
+				closeStream(); // the stream is ours to close whether the body made it or not
+			}
+
+			private void closeStream() {
 				try {
 					stream.close();
 				} catch (IOException e) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/shadowing/ShadowingInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/shadowing/ShadowingInterceptor.java
@@ -13,23 +13,26 @@
    limitations under the License. */
 package com.predic8.membrane.core.interceptor.shadowing;
 
-import com.predic8.membrane.annot.*;
-import com.predic8.membrane.core.exchange.*;
+import com.predic8.membrane.annot.MCChildElement;
+import com.predic8.membrane.annot.MCElement;
+import com.predic8.membrane.core.exchange.Exchange;
 import com.predic8.membrane.core.http.*;
-import com.predic8.membrane.core.interceptor.*;
-import com.predic8.membrane.core.proxies.*;
-import com.predic8.membrane.core.proxies.AbstractServiceProxy.*;
-import com.predic8.membrane.core.transport.http.*;
-import com.predic8.membrane.core.util.*;
-import org.slf4j.*;
+import com.predic8.membrane.core.interceptor.AbstractInterceptor;
+import com.predic8.membrane.core.interceptor.Outcome;
+import com.predic8.membrane.core.proxies.Target;
+import com.predic8.membrane.core.transport.http.HttpClient;
+import com.predic8.membrane.core.util.URIFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.*;
-import java.net.*;
-import java.util.*;
-import java.util.concurrent.*;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
 
-import static com.predic8.membrane.core.interceptor.Outcome.*;
-import static java.util.concurrent.Executors.*;
+import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
+import static java.util.concurrent.Executors.newCachedThreadPool;
 
 /**
  * @description Clones incoming requests and sends them asynchronously to one or more shadow targets (main exchange continues unchanged).
@@ -66,6 +69,12 @@ public class ShadowingInterceptor extends AbstractInterceptor {
             @Override
             public void bodyComplete(AbstractBody completeBody) {
                 cloneRequestAndSend(completeBody, exc, copiedHeader);
+            }
+
+            @Override
+            public void bodyFailed(ReadingBodyException e) {
+                // the body is incomplete: shadowing it would send a truncated request to the targets
+                log.debug("Not shadowing the request: reading its body failed.", e);
             }
         });
         return CONTINUE;

--- a/core/src/main/java/com/predic8/membrane/core/transport/http/AbstractHttpHandler.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/http/AbstractHttpHandler.java
@@ -15,8 +15,10 @@
 package com.predic8.membrane.core.transport.http;
 
 import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.http.ReadingBodyException;
 import com.predic8.membrane.core.http.Request;
 import com.predic8.membrane.core.http.Response;
+import com.predic8.membrane.core.http.WritingBodyException;
 import com.predic8.membrane.core.transport.Transport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,6 +27,8 @@ import java.io.IOException;
 import java.net.InetAddress;
 
 import static com.predic8.membrane.core.exceptions.ProblemDetails.internal;
+import static com.predic8.membrane.core.util.ExceptionUtil.concatMessageAndCauseMessages;
+import static com.predic8.membrane.core.util.ExceptionUtil.isPeerDisconnect;
 
 public abstract class AbstractHttpHandler  {
 
@@ -76,6 +80,41 @@ public abstract class AbstractHttpHandler  {
             }
             log.warn("An exception occurred while handling a request: ", e);
 		}
+	}
+
+	/**
+	 * Reading a body can fail on either end: the client while its request body is being read, or the
+	 * target server while its response body is being streamed to the client. Attribute the failure to
+	 * the body that actually recorded it, and log a peer going away as normal operation rather than as
+	 * an error.
+	 */
+	protected void logReadingBodyException(ReadingBodyException e) {
+		if (!isPeerDisconnect(e)) {
+			log.error("", e);
+			return;
+		}
+		if (e.belongsTo(exchange.getResponse()))
+			log.warn("Server connection to {} closed while the response body was being read: {}",
+					exchange.getDestinations(), concatMessageAndCauseMessages(e));
+		else if (e.belongsTo(exchange.getRequest()))
+			log.info("Client closed the connection while its request body was being read: {}",
+					concatMessageAndCauseMessages(e));
+		else
+			log.info("Connection closed while a message body was being read: {}",
+					concatMessageAndCauseMessages(e));
+	}
+
+	/**
+	 * Only writing the response to the client can reach the handlers: a failure writing the request body
+	 * to the target is swallowed by {@link #invokeHandlers()} and turned into a 500. So this is always
+	 * the client's end.
+	 */
+	protected void logWritingBodyException(WritingBodyException e) {
+		if (isPeerDisconnect(e))
+			log.info("Client closed the connection while the response body was being written: {}",
+					concatMessageAndCauseMessages(e));
+		else
+			log.error("", e);
 	}
 
 	private Response generateErrorResponse(Exception e) {

--- a/core/src/main/java/com/predic8/membrane/core/transport/http/Connection.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/http/Connection.java
@@ -285,12 +285,13 @@ public class Connection implements Closeable, MessageObserver, NonRelevantBodyOb
 	 */
 	@Override
 	public void bodyFailed(ReadingBodyException e) {
+		if (exchange == null)
+			return;
+		// detach before closing: a failing close() must not leave this connection attached to the exchange
+		exchange.setTargetConnection(null);
+		exchange = null;
 		try {
-			if (exchange != null) {
-				close();
-				exchange.setTargetConnection(null);
-				exchange = null;
-			}
+			close();
 		} catch (IOException e2) {
 			throw new RuntimeException(e2);
 		}

--- a/core/src/main/java/com/predic8/membrane/core/transport/http/Connection.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/http/Connection.java
@@ -13,23 +13,27 @@
    limitations under the License. */
 package com.predic8.membrane.core.transport.http;
 
-import com.predic8.membrane.core.exchange.*;
+import com.predic8.membrane.core.exchange.Exchange;
 import com.predic8.membrane.core.http.*;
-import com.predic8.membrane.core.transport.http.client.*;
-import com.predic8.membrane.core.transport.ssl.*;
-import org.jetbrains.annotations.*;
-import org.slf4j.*;
+import com.predic8.membrane.core.transport.http.client.ProxyConfiguration;
+import com.predic8.membrane.core.transport.ssl.SSLProvider;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import javax.net.ssl.*;
+import javax.net.ssl.SSLSocket;
 import java.io.*;
-import java.net.*;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.util.Random;
 
-import static com.predic8.membrane.annot.Constants.*;
+import static com.predic8.membrane.annot.Constants.USERAGENT;
 import static com.predic8.membrane.core.transport.http.ByteStreamLogging.wrapConnectionInputStream;
 import static com.predic8.membrane.core.transport.http.ByteStreamLogging.wrapConnectionOutputStream;
-import static com.predic8.membrane.core.util.text.TextUtil.*;
+import static com.predic8.membrane.core.util.text.TextUtil.isNullOrEmpty;
 
 /**
  * A {@link Connection} is an outbound TCP/IP (with or without TLS) connection, possibly managed
@@ -268,6 +272,28 @@ public class Connection implements Closeable, MessageObserver, NonRelevantBodyOb
 	@Override
 	public void bodyRequested(AbstractBody body) {
 		// do nothing
+	}
+
+	/**
+	 * A failed body read leaves this connection desynchronized: the rest of the body is still in the
+	 * stream and would be parsed as the beginning of the next message. Close it rather than letting it
+	 * go back into the pool.
+	 * <p>
+	 * {@link HttpServerHandler} closes an orphaned target connection as well, but only for exchanges
+	 * that reach its {@code finally}; connections obtained directly via {@link ConnectionFactory} have
+	 * no such backstop.
+	 */
+	@Override
+	public void bodyFailed(ReadingBodyException e) {
+		try {
+			if (exchange != null) {
+				close();
+				exchange.setTargetConnection(null);
+				exchange = null;
+			}
+		} catch (IOException e2) {
+			throw new RuntimeException(e2);
+		}
 	}
 
 	@Override

--- a/core/src/main/java/com/predic8/membrane/core/transport/http/HttpServerHandler.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/http/HttpServerHandler.java
@@ -152,6 +152,16 @@ public class HttpServerHandler extends AbstractHttpHandler implements Runnable, 
             // respond 400 and close the connection to avoid request smuggling.
             log.debug("Rejecting request with invalid framing: {}", e.getMessage());
             respondWithBadRequestAndClose(e.getMessage());
+        } catch (ReadingBodyException e) {
+            logReadingBodyException(e);
+        } catch (WritingBodyException e) {
+            // Only writing the response to the client can reach this: a failure writing the request body to
+            // the target is swallowed by process() and turned into a 500. So this is always the client's end.
+            if (isPeerDisconnect(e))
+                log.info("Client closed the connection while the response body was being written: {}",
+                        concatMessageAndCauseMessages(e));
+            else
+                log.error("", e);
         } catch (Exception e) {
             log.error("", e);
         } finally {
@@ -165,6 +175,9 @@ public class HttpServerHandler extends AbstractHttpHandler implements Runnable, 
                 }
 
             closeConnections();
+
+            // the target connection is orphaned when an exception skipped determineConnectionContinuation()
+            exchange.closeTargetConnection();
 
             exchange.detach();
 

--- a/core/src/main/java/com/predic8/membrane/core/transport/http/HttpServerHandler.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/http/HttpServerHandler.java
@@ -155,13 +155,7 @@ public class HttpServerHandler extends AbstractHttpHandler implements Runnable, 
         } catch (ReadingBodyException e) {
             logReadingBodyException(e);
         } catch (WritingBodyException e) {
-            // Only writing the response to the client can reach this: a failure writing the request body to
-            // the target is swallowed by process() and turned into a 500. So this is always the client's end.
-            if (isPeerDisconnect(e))
-                log.info("Client closed the connection while the response body was being written: {}",
-                        concatMessageAndCauseMessages(e));
-            else
-                log.error("", e);
+            logWritingBodyException(e);
         } catch (Exception e) {
             log.error("", e);
         } finally {

--- a/core/src/main/java/com/predic8/membrane/core/transport/http2/StreamInfo.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/http2/StreamInfo.java
@@ -232,7 +232,7 @@ public class StreamInfo {
                 try {
                     df = removeDataFrame();
                 } catch (IOException e) {
-                    throw new ReadingBodyException(e);
+                    throw fail(e);
                 }
                 if (df == null)
                     continue;

--- a/core/src/main/java/com/predic8/membrane/core/util/ExceptionUtil.java
+++ b/core/src/main/java/com/predic8/membrane/core/util/ExceptionUtil.java
@@ -15,6 +15,10 @@ package com.predic8.membrane.core.util;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.io.EOFException;
+import java.net.*;
+import java.nio.channels.ClosedChannelException;
+
 public class ExceptionUtil {
 
     /**
@@ -43,6 +47,30 @@ public class ExceptionUtil {
             }
         } while (throwable != null);
         return sb.toString();
+    }
+
+    /**
+     * Whether the throwable was (ultimately) caused by the peer going away, e.g. a client aborting an
+     * upload. Such events are normal operation and should not be logged as errors.
+     * <p>
+     * Deliberately type-based: a plain {@link java.io.IOException} is not treated as a disconnect,
+     * because it can just as well indicate a genuine fault.
+     * <p>
+     * {@link ConnectException}, {@link NoRouteToHostException}, {@link BindException} and
+     * {@link PortUnreachableException} are excluded although they extend {@link SocketException}: they
+     * indicate that a connection could not be established in the first place (e.g. an unreachable
+     * backend), which is a genuine fault and not a peer going away.
+     */
+    public static boolean isPeerDisconnect(Throwable t) {
+        Throwable root = getRootCause(t);
+        if (root instanceof ConnectException          // connection refused / backend unreachable
+                || root instanceof NoRouteToHostException
+                || root instanceof PortUnreachableException
+                || root instanceof BindException)     // local setup failure
+            return false;
+        return root instanceof ClosedChannelException
+                || root instanceof SocketException
+                || root instanceof EOFException;
     }
 
     public static Throwable getRootCause(Throwable t) {

--- a/core/src/test/java/com/predic8/membrane/core/exchange/ExchangeKeepAliveTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/exchange/ExchangeKeepAliveTest.java
@@ -1,0 +1,93 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.core.exchange;
+
+import com.predic8.membrane.core.http.*;
+import com.predic8.membrane.core.transport.http.Connection;
+import org.junit.jupiter.api.Test;
+
+import java.net.ServerSocket;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * A message whose body read failed leaves the connection desynchronized: the rest of the body is still
+ * in the stream. Such a connection must neither be kept alive nor go back into the pool, no matter what
+ * the keep-alive headers say.
+ */
+class ExchangeKeepAliveTest {
+
+    @Test
+    void fullyReadBodiesKeepTheConnectionAlive() {
+        assertTrue(exchange(new Request(), new Response()).canKeepConnectionAlive());
+    }
+
+    @Test
+    void failedRequestBodyPreventsKeepAlive() {
+        Request request = new Request();
+        failBody(request);
+
+        assertFalse(exchange(request, new Response()).canKeepConnectionAlive());
+    }
+
+    @Test
+    void failedResponseBodyPreventsKeepAlive() {
+        Response response = new Response();
+        failBody(response);
+
+        assertFalse(exchange(new Request(), response).canKeepConnectionAlive());
+    }
+
+    @Test
+    void closeTargetConnectionDetachesAndCloses() throws Exception {
+        try (ServerSocket server = new ServerSocket(0)) {
+            Exchange exc = new Exchange(null);
+            Connection con = Connection.open("localhost", server.getLocalPort(), null, null, 30000);
+            exc.setTargetConnection(con);
+
+            assertTrue(exc.closeTargetConnection());
+
+            assertNull(exc.getTargetConnection(), "must be detached, so nothing hands it back to the pool");
+            assertTrue(con.isClosed());
+        }
+    }
+
+    @Test
+    void closeTargetConnectionIsANoOpWithoutAConnection() {
+        Exchange exc = new Exchange(null);
+
+        assertFalse(exc.closeTargetConnection());
+        assertNull(exc.getTargetConnection());
+    }
+
+    private static Exchange exchange(Request request, Response response) {
+        Exchange exc = new Exchange(null);
+        exc.setRequest(request);
+        exc.setResponse(response);
+        return exc;
+    }
+
+    /**
+     * Puts the message's body into the failed state the way it happens in production: by reading from a
+     * stream that dies mid-body.
+     */
+    private static void failBody(Message message) {
+        Body body = new Body(ThrowingInputStream.closedChannel("partial"), 1000);
+        message.setBody(body);
+
+        assertThrows(ReadingBodyException.class, body::read);
+        assertTrue(body.hasFailed());
+    }
+}

--- a/core/src/test/java/com/predic8/membrane/core/http/BodyStickyErrorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/http/BodyStickyErrorTest.java
@@ -205,7 +205,26 @@ class BodyStickyErrorTest {
         assertFalse(e.belongsTo(healthy));
         assertFalse(e.belongsTo(null));
         assertFalse(new ReadingBodyException(new ClosedChannelException()).belongsTo(request),
-                "a re-wrapped exception is not the recorded one");
+                "an unrelated failure, despite being of the same type");
+    }
+
+    /**
+     * ChunkedBody's lazy stream records the failure but throws the raw IOException, which a caller may
+     * wrap again. That wrapper is a different object than the recorded exception, yet it reports the
+     * same failure - otherwise the handlers would log "a message body" instead of naming the end that
+     * actually died.
+     */
+    @Test
+    void belongsToMatchesAWrapperAroundTheSameCause() {
+        Request request = new Request();
+        request.setBody(body);
+
+        ReadingBodyException recorded = assertThrows(ReadingBodyException.class, body::read);
+        // as MessageUtil / removeBodyFromBuffer do: wrap the IOException the stream threw
+        ReadingBodyException rewrapped = new ReadingBodyException((Exception) recorded.getCause());
+
+        assertNotSame(recorded, rewrapped);
+        assertTrue(rewrapped.belongsTo(request));
     }
 
     private static class RecordingObserver extends AbstractMessageObserver {

--- a/core/src/test/java/com/predic8/membrane/core/http/BodyStickyErrorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/http/BodyStickyErrorTest.java
@@ -1,0 +1,206 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.core.http;
+
+import com.predic8.membrane.core.util.ExceptionUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.channels.ClosedChannelException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * A client that aborts while sending its body must produce exactly one exception, not a cascade of
+ * follow-up errors from every component that touches the body afterwards.
+ */
+class BodyStickyErrorTest {
+
+    private ThrowingInputStream stream;
+    private Body body;
+
+    @BeforeEach
+    void setUp() {
+        stream = ThrowingInputStream.closedChannel("partial");
+        body = new Body(stream, 15_000_000); // a large upload, as in the reported case
+    }
+
+    @Test
+    void firstReadThrowsWithOriginalCause() {
+        ReadingBodyException e = assertThrows(ReadingBodyException.class, body::read);
+
+        assertInstanceOf(ClosedChannelException.class, ExceptionUtil.getRootCause(e));
+        assertTrue(ExceptionUtil.isPeerDisconnect(e));
+        assertTrue(body.hasFailed());
+        assertFalse(body.isRead());
+    }
+
+    @Test
+    void secondReadThrowsSameExceptionWithoutTouchingTheStream() {
+        ReadingBodyException first = assertThrows(ReadingBodyException.class, body::read);
+
+        ReadingBodyException second = assertThrows(ReadingBodyException.class, body::read);
+        ReadingBodyException third = assertThrows(ReadingBodyException.class, body::read);
+
+        assertSame(first, second);
+        assertSame(first, third);
+        assertEquals(0, stream.getReadCallsAfterFailure());
+    }
+
+    @Test
+    void allAccessorsRethrowTheRecordedException() {
+        ReadingBodyException first = assertThrows(ReadingBodyException.class, body::read);
+
+        assertSame(first, body.getObservedException()); // identifies which body a failure belongs to
+        assertSame(first, assertThrows(ReadingBodyException.class, body::getContent));
+        assertSame(first, assertThrows(ReadingBodyException.class, body::getContentAsStream));
+        assertSame(first, assertThrows(ReadingBodyException.class, body::getLength));
+        assertSame(first, assertThrows(ReadingBodyException.class, body::getRaw));
+        assertSame(first, assertThrows(ReadingBodyException.class,
+                () -> body.write(new PlainBodyTransferer(new ByteArrayOutputStream()), false)));
+
+        assertEquals(0, stream.getReadCallsAfterFailure());
+    }
+
+    @Test
+    void discardAfterFailureIsSilent() {
+        assertThrows(ReadingBodyException.class, body::read);
+
+        assertDoesNotThrow(body::discard);
+        assertEquals(0, stream.getReadCallsAfterFailure());
+    }
+
+    @Test
+    void toStringAfterFailureDoesNotRead() {
+        assertThrows(ReadingBodyException.class, body::read);
+
+        assertDoesNotThrow(body::toString);
+        assertEquals(0, stream.getReadCallsAfterFailure());
+    }
+
+    @Test
+    void messageDiscardBodySwallowsTheRecordedException() {
+        Request request = new Request();
+        request.setBody(body);
+        assertThrows(ReadingBodyException.class, body::read);
+
+        assertDoesNotThrow(request::discardBody);
+        assertEquals(0, stream.getReadCallsAfterFailure());
+    }
+
+    @Test
+    void bodyFailedFiresOnceAndClearsObservers() {
+        RecordingObserver observer = new RecordingObserver();
+        body.addObserver(observer);
+
+        assertThrows(ReadingBodyException.class, body::read);
+        assertThrows(ReadingBodyException.class, body::read);
+
+        assertEquals(1, observer.errors.size());
+        assertEquals(0, observer.completions);
+        assertTrue(body.getObservers().isEmpty());
+    }
+
+    @Test
+    void observerSeesTheFailedStateWhileBeingNotified() {
+        List<Boolean> latchWasArmed = new ArrayList<>();
+        body.addObserver(new AbstractMessageObserver() {
+            @Override
+            public void bodyFailed(ReadingBodyException e) {
+                latchWasArmed.add(body.hasFailed());
+            }
+        });
+
+        assertThrows(ReadingBodyException.class, body::read);
+
+        assertEquals(List.of(true), latchWasArmed);
+    }
+
+    @Test
+    void throwingObserverDoesNotMaskTheOriginalException() {
+        RuntimeException fromObserver = new RuntimeException("observer is broken");
+        body.addObserver(new AbstractMessageObserver() {
+            @Override
+            public void bodyFailed(ReadingBodyException e) {
+                throw fromObserver;
+            }
+        });
+
+        ReadingBodyException e = assertThrows(ReadingBodyException.class, body::read);
+
+        assertInstanceOf(ClosedChannelException.class, ExceptionUtil.getRootCause(e));
+        assertArrayEquals(new Throwable[]{fromObserver}, e.getSuppressed());
+    }
+
+    @Test
+    void lateObserverIsNotifiedImmediately() {
+        assertThrows(ReadingBodyException.class, body::read);
+
+        RecordingObserver observer = new RecordingObserver();
+        body.addObserver(observer);
+
+        assertEquals(1, observer.errors.size());
+        assertTrue(body.getObservers().isEmpty());
+    }
+
+    @Test
+    void failedBodyNeverBecomesRead() {
+        RecordingObserver observer = new RecordingObserver();
+        body.addObserver(observer);
+
+        assertThrows(ReadingBodyException.class, body::read);
+
+        // markAsRead() has no Failed -> Read transition, so bodyComplete can never follow bodyFailed
+        assertFalse(body.isRead());
+        assertTrue(body.hasFailed());
+        assertEquals(0, observer.completions);
+
+        assertThrows(ReadingBodyException.class, body::read);
+        assertFalse(body.isRead());
+        assertEquals(0, observer.completions);
+    }
+
+    @Test
+    void streamedIsIndependentOfRead() {
+        Body ok = new Body(new ByteArrayInputStream("hello".getBytes()), 5);
+
+        ok.read();
+
+        // "read" and "streamed" are orthogonal: consuming a body buffered does not mark it streamed
+        assertTrue(ok.isRead());
+        assertFalse(ok.wasStreamed());
+        assertFalse(ok.hasFailed());
+        assertNull(ok.getObservedException());
+    }
+
+    private static class RecordingObserver extends AbstractMessageObserver {
+        final List<ReadingBodyException> errors = new ArrayList<>();
+        int completions;
+
+        @Override
+        public void bodyFailed(ReadingBodyException e) {
+            errors.add(e);
+        }
+
+        @Override
+        public void bodyComplete(AbstractBody body) {
+            completions++;
+        }
+    }
+}

--- a/core/src/test/java/com/predic8/membrane/core/http/BodyStickyErrorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/http/BodyStickyErrorTest.java
@@ -189,6 +189,25 @@ class BodyStickyErrorTest {
         assertNull(ok.getObservedException());
     }
 
+    /**
+     * The handlers use belongsTo() to attribute a failure to the client (request body) or the target
+     * server (response body), which decides the log level.
+     */
+    @Test
+    void belongsToIdentifiesTheFailingMessage() {
+        Request request = new Request();
+        request.setBody(body);
+        Response healthy = Response.ok("fine").build();
+
+        ReadingBodyException e = assertThrows(ReadingBodyException.class, body::read);
+
+        assertTrue(e.belongsTo(request));
+        assertFalse(e.belongsTo(healthy));
+        assertFalse(e.belongsTo(null));
+        assertFalse(new ReadingBodyException(new ClosedChannelException()).belongsTo(request),
+                "a re-wrapped exception is not the recorded one");
+    }
+
     private static class RecordingObserver extends AbstractMessageObserver {
         final List<ReadingBodyException> errors = new ArrayList<>();
         int completions;

--- a/core/src/test/java/com/predic8/membrane/core/http/ChunkedBodyStickyErrorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/http/ChunkedBodyStickyErrorTest.java
@@ -155,4 +155,25 @@ class ChunkedBodyStickyErrorTest {
 
         assertEquals(List.of("isRead=true bodyComplete=true", "partial"), observed);
     }
+
+    /**
+     * The end-to-end shape of the attribution problem: the lazy stream throws the raw IOException (to
+     * honour the InputStream contract), a caller wraps it again, and the handlers must still be able to
+     * tell which end of the exchange died.
+     */
+    @Test
+    void aWrappedFailureFromTheLazyStreamIsStillAttributable() throws IOException {
+        Request request = new Request();
+        request.setBody(body);
+
+        var in = body.getContentAsStream();
+        in.readNBytes(7);
+        IOException fromStream = assertThrows(IOException.class, in::read);
+
+        // as MessageUtil / HttpServerHandler.removeBodyFromBuffer() do
+        ReadingBodyException rewrapped = new ReadingBodyException(fromStream);
+
+        assertNotSame(body.getObservedException(), rewrapped);
+        assertTrue(rewrapped.belongsTo(request));
+    }
 }

--- a/core/src/test/java/com/predic8/membrane/core/http/ChunkedBodyStickyErrorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/http/ChunkedBodyStickyErrorTest.java
@@ -1,0 +1,128 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.core.http;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * A truncated "Transfer-Encoding: chunked" body fails inside the lazily reading stream returned by
+ * {@link ChunkedBody#getContentAsStream()}. That failure must be recorded, so that the drain in
+ * {@link ChunkedBody#read()} / {@link ChunkedBody#write} does not re-read the dead stream.
+ */
+class ChunkedBodyStickyErrorTest {
+
+    private ThrowingInputStream stream;
+    private ChunkedBody body;
+
+    @BeforeEach
+    void setUp() {
+        // a well-formed first chunk, then the client vanishes
+        stream = new ThrowingInputStream("7\r\npartial\r\n".getBytes(), new ClosedChannelException());
+        body = new ChunkedBody(stream);
+    }
+
+    @Test
+    void markAsReadLeavesAFailedBodyIncomplete() throws IOException {
+        var in = body.getContentAsStream();
+        in.readNBytes(7);
+        assertThrows(IOException.class, in::read);
+
+        // markAsRead() must not be able to complete a failed body: AbstractBody refuses the
+        // transition and therefore never runs onMarkedAsRead(), so bodyComplete stays false.
+        // Were it set, readNextChunk()'s leading bodyComplete check would swallow the failure.
+        body.markAsRead();
+
+        assertFalse(body.bodyComplete);
+        assertFalse(body.isRead());
+        assertTrue(body.hasFailed());
+    }
+
+    @Test
+    void markAsReadCompletesAHealthyBody() {
+        ChunkedBody healthy = new ChunkedBody(new ByteArrayInputStream("0\r\n\r\n".getBytes()));
+
+        healthy.read();
+
+        // the hook ran, so the subclass flag and the base state agree
+        assertTrue(healthy.bodyComplete);
+        assertTrue(healthy.isRead());
+        assertFalse(healthy.hasFailed());
+    }
+
+    @Test
+    void failureInTheLazyStreamIsRecorded() throws IOException {
+        var in = body.getContentAsStream();
+
+        assertArrayEquals("partial".getBytes(), in.readNBytes(7));
+        assertThrows(IOException.class, in::read); // InputStream contract is preserved
+        assertTrue(body.hasFailed());
+        assertFalse(body.isRead());
+    }
+
+    @Test
+    void readAfterFailureDoesNotDrainTheDeadStream() throws IOException {
+        var in = body.getContentAsStream();
+        in.readNBytes(7);
+        assertThrows(IOException.class, in::read);
+        int readsSoFar = stream.getReadCallsAfterFailure();
+
+        ReadingBodyException e = assertThrows(ReadingBodyException.class, body::read);
+
+        assertInstanceOf(ClosedChannelException.class, e.getCause());
+        assertEquals(readsSoFar, stream.getReadCallsAfterFailure());
+        assertSame(e, assertThrows(ReadingBodyException.class, body::read));
+    }
+
+    @Test
+    void writeAfterFailureDoesNotEmitATruncatedBody() throws IOException {
+        var in = body.getContentAsStream();
+        in.readNBytes(7);
+        assertThrows(IOException.class, in::read);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        assertThrows(ReadingBodyException.class, () -> body.write(new PlainBodyTransferer(out), false));
+
+        assertEquals(0, out.size());
+    }
+
+    @Test
+    void discardAfterFailureIsSilent() throws IOException {
+        var in = body.getContentAsStream();
+        in.readNBytes(7);
+        assertThrows(IOException.class, in::read);
+
+        assertDoesNotThrow(body::discard);
+    }
+
+    @Test
+    void getContentAsStreamAfterFailureDoesNotDropTheChunksRead() throws IOException {
+        var in = body.getContentAsStream();
+        in.readNBytes(7);
+        assertThrows(IOException.class, in::read);
+        int chunksRead = body.chunks.size();
+
+        assertThrows(ReadingBodyException.class, body::getContentAsStream);
+
+        assertEquals(chunksRead, body.chunks.size());
+    }
+}

--- a/core/src/test/java/com/predic8/membrane/core/http/ChunkedBodyStickyErrorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/http/ChunkedBodyStickyErrorTest.java
@@ -21,6 +21,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -124,5 +126,33 @@ class ChunkedBodyStickyErrorTest {
         assertThrows(ReadingBodyException.class, body::getContentAsStream);
 
         assertEquals(chunksRead, body.chunks.size());
+    }
+
+    /**
+     * The onMarkedAsRead() hook runs before the observers are notified, so a re-entering observer sees a
+     * consistent body: isRead() and bodyComplete already agree. Notably MessageSnapshot's observer reads
+     * the body again from inside bodyComplete(); the leading bodyComplete check in readNextChunk() then
+     * gives it a clean EOF instead of re-reading the exhausted wire stream.
+     */
+    @Test
+    void observerSeesACompletedBodyWhileBeingNotified() throws IOException {
+        ChunkedBody healthy = new ChunkedBody(new ByteArrayInputStream("7\r\npartial\r\n0\r\n\r\n".getBytes()));
+        List<String> observed = new ArrayList<>();
+        healthy.addObserver(new AbstractMessageObserver() {
+            @Override
+            public void bodyComplete(AbstractBody body) {
+                observed.add("isRead=" + body.isRead() + " bodyComplete=" + healthy.bodyComplete);
+                try {
+                    // re-entrant read, as MessageSnapshot does: must terminate rather than touch the wire
+                    observed.add(new String(healthy.getContentAsStream().readAllBytes()));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+
+        healthy.read();
+
+        assertEquals(List.of("isRead=true bodyComplete=true", "partial"), observed);
     }
 }

--- a/core/src/test/java/com/predic8/membrane/core/http/ChunkedBodyTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/http/ChunkedBodyTest.java
@@ -333,7 +333,7 @@ public class ChunkedBodyTest {
         assertEquals(0, is.available());
 
         //  0 + CRLF + CRLF is not read yet
-        assertFalse(cb.read);
+        assertFalse(cb.isRead());
 
         if (!(is instanceof BodyInputStream bodyIs)) {
             fail();
@@ -344,7 +344,7 @@ public class ChunkedBodyTest {
         assertNull(bodyIs.readNextChunk());
 
         // Message is now completely read
-        assertTrue(cb.read);
+        assertTrue(cb.isRead());
     }
 
     @Test
@@ -367,7 +367,7 @@ public class ChunkedBodyTest {
         assertNull(bodyIs.readNextChunk());
 
         // Message is now completely read
-        assertTrue(cb.read);
+        assertTrue(cb.isRead());
     }
 
     private static @NotNull ByteArrayInputStream getJSONBodyWithSingleChunk() {
@@ -412,7 +412,7 @@ public class ChunkedBodyTest {
         assertNull(bodyIs.readNextChunk());
 
         // Message is now completely read
-        assertTrue(cb.read);
+        assertTrue(cb.isRead());
     }
 
     @Test

--- a/core/src/test/java/com/predic8/membrane/core/http/ResponseBuilderTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/http/ResponseBuilderTest.java
@@ -14,7 +14,12 @@
 
 package com.predic8.membrane.core.http;
 
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -46,5 +51,43 @@ public class ResponseBuilderTest {
         assertInstanceOf( EmptyBody.class,res.getBody());
         assertEquals(0, res.getBody().getLength());
         assertEquals("", res.getBodyAsStringDecoded());
+    }
+
+    /**
+     * The stream handed to body(stream, true) is ours to close once the body is done with it - whether
+     * it was read completely or the read failed.
+     */
+    @Test
+    void streamIsClosedWhenTheBodyIsComplete() throws Exception {
+        CloseRecordingInputStream stream = new CloseRecordingInputStream(new ByteArrayInputStream("hi".getBytes()));
+
+        Response res = Response.ok().body(stream, true).build();
+        res.getBody().read();
+
+        assertTrue(stream.closed);
+    }
+
+    @Test
+    void streamIsClosedWhenReadingTheBodyFails() {
+        CloseRecordingInputStream stream = new CloseRecordingInputStream(ThrowingInputStream.closedChannel("partial"));
+
+        Response res = Response.ok().body(stream, true).build();
+
+        assertThrows(ReadingBodyException.class, () -> res.getBody().read());
+        assertTrue(stream.closed, "otherwise a failed response body leaks the stream");
+    }
+
+    private static class CloseRecordingInputStream extends FilterInputStream {
+        boolean closed;
+
+        CloseRecordingInputStream(InputStream in) {
+            super(in);
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            super.close();
+        }
     }
 }

--- a/core/src/test/java/com/predic8/membrane/core/http/ThrowingInputStream.java
+++ b/core/src/test/java/com/predic8/membrane/core/http/ThrowingInputStream.java
@@ -1,0 +1,91 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.core.http;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.ClosedChannelException;
+
+/**
+ * Serves a prefix of bytes and then fails, simulating a client that aborts while sending its body.
+ * Counts the read attempts made after the first failure, so tests can assert that a dead stream is not
+ * touched again.
+ */
+public class ThrowingInputStream extends InputStream {
+
+    private final InputStream prefix;
+    private final IOException toThrow;
+    private boolean failed;
+    private int readCallsAfterFailure;
+
+    public ThrowingInputStream(byte[] prefix, IOException toThrow) {
+        this.prefix = new ByteArrayInputStream(prefix);
+        this.toThrow = toThrow;
+    }
+
+    /**
+     * Reproduces the AJP/Undertow case: the channel to the client is gone.
+     */
+    public static ThrowingInputStream closedChannel(String prefix) {
+        return new ThrowingInputStream(prefix.getBytes(), new ClosedChannelException());
+    }
+
+    @Override
+    public int read() throws IOException {
+        countAndFail();
+        int b = prefix.read();
+        if (b == -1)
+            fail();
+        return b;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        countAndFail();
+        int read = prefix.read(b, off, len);
+        if (read == -1)
+            fail();
+        return read;
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        countAndFail();
+        long skipped = prefix.skip(n);
+        if (skipped == 0)
+            fail();
+        return skipped;
+    }
+
+    private void countAndFail() throws IOException {
+        if (failed) {
+            readCallsAfterFailure++;
+            fail();
+        }
+    }
+
+    private void fail() throws IOException {
+        failed = true;
+        throw toThrow;
+    }
+
+    /**
+     * @return how often this stream was read after it had already failed. Expected to stay 0.
+     */
+    public int getReadCallsAfterFailure() {
+        return readCallsAfterFailure;
+    }
+}

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/shadowing/ShadowingInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/shadowing/ShadowingInterceptorTest.java
@@ -13,22 +13,29 @@
    limitations under the License. */
 package com.predic8.membrane.core.interceptor.shadowing;
 
-import com.predic8.membrane.core.exchange.*;
-import com.predic8.membrane.core.exchangestore.*;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.exchangestore.ForgetfulExchangeStore;
 import com.predic8.membrane.core.http.*;
-import com.predic8.membrane.core.interceptor.flow.*;
-import com.predic8.membrane.core.interceptor.lang.*;
-import com.predic8.membrane.core.proxies.AbstractServiceProxy.*;
-import com.predic8.membrane.core.proxies.*;
-import com.predic8.membrane.core.router.*;
-import com.predic8.membrane.core.transport.http.*;
-import org.junit.jupiter.api.*;
-import org.mockito.*;
+import com.predic8.membrane.core.interceptor.flow.ReturnInterceptor;
+import com.predic8.membrane.core.interceptor.lang.SetHeaderInterceptor;
+import com.predic8.membrane.core.proxies.ServiceProxy;
+import com.predic8.membrane.core.proxies.ServiceProxyKey;
+import com.predic8.membrane.core.proxies.Target;
+import com.predic8.membrane.core.router.DefaultRouter;
+import com.predic8.membrane.core.transport.http.HttpTransport;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
-import java.util.*;
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.List;
 
-import static com.predic8.membrane.core.http.MimeType.*;
-import static io.restassured.RestAssured.*;
+import static com.predic8.membrane.core.http.MimeType.APPLICATION_JSON;
+import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -142,5 +149,47 @@ class ShadowingInterceptorTest {
         assertEquals("/foo", exc.getRequest().getUri());
         assertEquals("https://www.predic8.com:9000/foo", exc.getDestinations().getFirst());
         assertEquals(APPLICATION_JSON, exc.getRequest().getHeader().getContentType());
+    }
+
+    /**
+     * A request body that failed to read is incomplete: shadowing it would send a truncated request to
+     * the targets, so the clone must be suppressed.
+     */
+    @Test
+    void failedRequestBodyIsNotShadowed() throws Exception {
+        List<AbstractBody> shadowed = new ArrayList<>();
+        ShadowingInterceptor interceptor = new ShadowingInterceptor() {
+            @Override
+            public void cloneRequestAndSend(AbstractBody completeBody, Exchange mainExchange, Header copiedHeader) {
+                shadowed.add(completeBody);
+            }
+        };
+        Exchange exchange = new Request.Builder().post("http://localhost:2000").buildExchange();
+        Body body = new Body(ThrowingInputStream.closedChannel("partial"), 1000);
+        exchange.getRequest().setBody(body);
+
+        interceptor.handleRequest(exchange);
+        assertThrows(ReadingBodyException.class, body::read);
+
+        assertTrue(shadowed.isEmpty());
+    }
+
+    @Test
+    void completeRequestBodyIsShadowed() throws Exception {
+        List<AbstractBody> shadowed = new ArrayList<>();
+        ShadowingInterceptor interceptor = new ShadowingInterceptor() {
+            @Override
+            public void cloneRequestAndSend(AbstractBody completeBody, Exchange mainExchange, Header copiedHeader) {
+                shadowed.add(completeBody);
+            }
+        };
+        Exchange exchange = new Request.Builder().post("http://localhost:2000").buildExchange();
+        Body body = new Body(new ByteArrayInputStream("foo".getBytes()), 3);
+        exchange.getRequest().setBody(body);
+
+        interceptor.handleRequest(exchange);
+        body.read();
+
+        assertEquals(List.of(body), shadowed);
     }
 }

--- a/core/src/test/java/com/predic8/membrane/core/transport/http/ConnectionTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/transport/http/ConnectionTest.java
@@ -15,13 +15,26 @@
 package com.predic8.membrane.core.transport.http;
 
 
-import com.predic8.membrane.core.proxies.*;
-import com.predic8.membrane.core.router.*;
-import org.junit.jupiter.api.*;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.http.Body;
+import com.predic8.membrane.core.http.ReadingBodyException;
+import com.predic8.membrane.core.http.ThrowingInputStream;
+import com.predic8.membrane.core.proxies.ServiceProxy;
+import com.predic8.membrane.core.proxies.ServiceProxyKey;
+import com.predic8.membrane.core.router.Router;
+import com.predic8.membrane.core.router.TestRouter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import java.io.*;
-import java.net.*;
-import java.util.*;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.nio.channels.ClosedChannelException;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -97,5 +110,47 @@ public class ConnectionTest {
 				return;
 			}
 		}
+	}
+
+	/**
+	 * A failed body read leaves the connection desynchronized: the rest of the body is still in the
+	 * stream. Such a connection must be closed and detached rather than go back into the pool.
+	 */
+	@Test
+	void bodyFailedClosesAndDetachesTheConnection() {
+		Exchange exc = new Exchange(null);
+		exc.setTargetConnection(conLocalhost);
+		conLocalhost.setExchange(exc);
+
+		conLocalhost.bodyFailed(new ReadingBodyException(new ClosedChannelException()));
+
+		assertTrue(conLocalhost.isClosed());
+		assertNull(exc.getTargetConnection(), "must be detached, so nothing hands it back to the pool");
+	}
+
+	@Test
+	void bodyFailedIsANoOpWithoutAnExchange() {
+		assertDoesNotThrow(() -> conLocalhost.bodyFailed(new ReadingBodyException(new ClosedChannelException())));
+
+		assertFalse(conLocalhost.isClosed(), "no exchange owns this connection, so it stays usable");
+	}
+
+	/**
+	 * The failure notification arrives through the observer chain: registering the connection on a body
+	 * that then fails must close it, which is how the real response path reaches bodyFailed().
+	 */
+	@Test
+	void failingBodyNotifiesTheConnectionAsObserver() {
+		Exchange exc = new Exchange(null);
+		exc.setTargetConnection(conLocalhost);
+		conLocalhost.setExchange(exc);
+
+		Body body = new Body(ThrowingInputStream.closedChannel("partial"), 1000);
+		body.addObserver(conLocalhost);
+
+		assertThrows(ReadingBodyException.class, body::read);
+
+		assertTrue(conLocalhost.isClosed());
+		assertNull(exc.getTargetConnection());
 	}
 }

--- a/core/src/test/java/com/predic8/membrane/core/transport/http2/Http2BodyStickyErrorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/transport/http2/Http2BodyStickyErrorTest.java
@@ -1,0 +1,121 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.core.transport.http2;
+
+import com.predic8.membrane.core.http.AbstractBody;
+import com.predic8.membrane.core.http.PlainBodyTransferer;
+import com.predic8.membrane.core.http.ReadingBodyException;
+import com.predic8.membrane.core.transport.http2.frame.DataFrame;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The body behind an HTTP/2 stream must record a failed read exactly like {@code Body} and
+ * {@code ChunkedBody} do: first failure wins, and every later access re-throws that same exception
+ * instead of pulling on the stream again.
+ * <p>
+ * <b>This is a contract test, not a regression test for a reachable defect.</b> The
+ * {@link IOException} handled by {@code Http2Body} cannot currently be thrown in production: the
+ * {@code throws IOException} chain behind {@link StreamInfo#removeDataFrame()} is vestigial -
+ * {@code FlowControl.processed()} only calls {@code increaseWindow()} (pure arithmetic) and
+ * {@code FrameSender.send(Frame)}, which queues rather than doing I/O. The compiler nevertheless
+ * forces the catch to exist, so it is wired through the same failure latch as every other body, and
+ * this test pins that wiring in case the path ever goes live.
+ */
+class Http2BodyStickyErrorTest {
+
+    private static final IOException PEER_GONE = new IOException("connection reset");
+
+    private CountingStreamInfo streamInfo;
+    private AbstractBody body;
+
+    @BeforeEach
+    void setUp() {
+        // null sender is safe: FlowControl only stores it, PeerFlowControl does not even do that
+        streamInfo = new CountingStreamInfo();
+        body = streamInfo.createBody();
+    }
+
+    @Test
+    void readRecordsTheFailure() {
+        ReadingBodyException e = assertThrows(ReadingBodyException.class, body::read);
+
+        assertSame(PEER_GONE, e.getCause());
+        assertTrue(body.hasFailed());
+        assertFalse(body.isRead(), "a failed body never becomes read");
+        assertSame(e, body.getObservedException());
+    }
+
+    @Test
+    void secondReadRethrowsWithoutTouchingTheStream() {
+        ReadingBodyException first = assertThrows(ReadingBodyException.class, body::read);
+        assertEquals(1, streamInfo.removeCalls);
+
+        ReadingBodyException second = assertThrows(ReadingBodyException.class, body::read);
+
+        assertSame(first, second);
+        assertEquals(1, streamInfo.removeCalls, "the dead stream must not be polled again");
+    }
+
+    @Test
+    void streamingRecordsTheFailureAndEmitsNothing() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        // retainCopy=false on an unread body routes to Http2Body.writeStreamed()
+        ReadingBodyException e = assertThrows(ReadingBodyException.class,
+                () -> body.write(new PlainBodyTransferer(out), false));
+
+        assertSame(PEER_GONE, e.getCause());
+        assertTrue(body.hasFailed());
+        assertEquals(0, out.size(), "a body whose read failed must not be partially transmitted");
+    }
+
+    @Test
+    void streamingAfterAFailedReadRethrowsTheOriginal() {
+        ReadingBodyException first = assertThrows(ReadingBodyException.class, body::read);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        ReadingBodyException second = assertThrows(ReadingBodyException.class,
+                () -> body.write(new PlainBodyTransferer(out), false));
+
+        assertSame(first, second, "the original cause must survive, not be replaced by a follow-up");
+        assertEquals(1, streamInfo.removeCalls);
+        assertEquals(0, out.size());
+    }
+
+    /**
+     * Fails on the first data frame and counts how often it was asked, so the tests can assert that
+     * a dead stream is not polled again.
+     */
+    private static class CountingStreamInfo extends StreamInfo {
+
+        int removeCalls;
+
+        CountingStreamInfo() {
+            super(1, null, new Settings(), new Settings());
+        }
+
+        @Override
+        public DataFrame removeDataFrame() throws IOException {
+            removeCalls++;
+            throw PEER_GONE;
+        }
+    }
+}

--- a/core/src/test/java/com/predic8/membrane/core/util/ExceptionUtilTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/util/ExceptionUtilTest.java
@@ -13,10 +13,17 @@
    limitations under the License. */
 package com.predic8.membrane.core.util;
 
+import com.predic8.membrane.core.http.ReadingBodyException;
 import org.junit.jupiter.api.Test;
 
+import java.io.EOFException;
+import java.io.IOException;
+import java.net.*;
+import java.nio.channels.ClosedChannelException;
+
 import static com.predic8.membrane.core.util.ExceptionUtil.concatMessageAndCauseMessages;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static com.predic8.membrane.core.util.ExceptionUtil.isPeerDisconnect;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ExceptionUtilTest {
 
@@ -36,5 +43,69 @@ public class ExceptionUtilTest {
     public void testLevel3() {
         assertEquals("foo caused by: bar caused by: baz",
                 concatMessageAndCauseMessages(new RuntimeException("foo", new RuntimeException("bar", new RuntimeException("baz")))));
+    }
+
+    @Test
+    void clientDisconnectClosedChannel() {
+        assertTrue(isPeerDisconnect(new ReadingBodyException(new ClosedChannelException())));
+    }
+
+    @Test
+    void clientDisconnectNestedSeveralLevelsDeep() {
+        assertTrue(isPeerDisconnect(new ReadingBodyException(
+                new ReadingBodyException(new IOException(new SocketException("Connection reset"))))));
+    }
+
+    @Test
+    void serverSideDisconnectMatchesTheSameWay() {
+        // the predicate is deliberately side-agnostic: a backend closing mid-response looks the same
+        assertTrue(isPeerDisconnect(new ReadingBodyException(new SocketException("Connection reset"))));
+    }
+
+    @Test
+    void clientDisconnectEndOfStream() {
+        assertTrue(isPeerDisconnect(new ReadingBodyException(new EOFException())));
+    }
+
+    @Test
+    void plainIOExceptionIsNoClientDisconnect() {
+        // e.g. Undertow's "UT010029: Stream is closed": deliberately not matched by message. It is no
+        // longer reached anyway, now that a failed body read is sticky.
+        assertFalse(isPeerDisconnect(new ReadingBodyException(new IOException("UT010029: Stream is closed"))));
+    }
+
+    @Test
+    void genuineFaultIsNoClientDisconnect() {
+        assertFalse(isPeerDisconnect(new ReadingBodyException(new IllegalStateException("broken"))));
+    }
+
+    @Test
+    void nullIsNoClientDisconnect() {
+        assertFalse(isPeerDisconnect(null));
+    }
+
+    @Test
+    void connectExceptionIsNoPeerDisconnect() {
+        // ConnectException extends SocketException, but an unreachable backend is a genuine fault
+        assertFalse(isPeerDisconnect(new ConnectException("Connection refused")));
+        assertFalse(isPeerDisconnect(new ReadingBodyException(
+                new IOException(new ConnectException("Connection refused")))));
+    }
+
+    @Test
+    void noRouteToHostIsNoPeerDisconnect() {
+        assertFalse(isPeerDisconnect(new NoRouteToHostException("No route to host")));
+        assertFalse(isPeerDisconnect(new ReadingBodyException(new NoRouteToHostException("No route to host"))));
+    }
+
+    @Test
+    void portUnreachableIsNoPeerDisconnect() {
+        assertFalse(isPeerDisconnect(new PortUnreachableException("ICMP port unreachable")));
+    }
+
+    @Test
+    void bindExceptionIsNoPeerDisconnect() {
+        assertFalse(isPeerDisconnect(new BindException("Address already in use")));
+        assertFalse(isPeerDisconnect(new ReadingBodyException(new BindException("Address already in use"))));
     }
 }

--- a/war/src/main/java/com/predic8/membrane/servlet/embedded/HttpServletHandler.java
+++ b/war/src/main/java/com/predic8/membrane/servlet/embedded/HttpServletHandler.java
@@ -35,6 +35,8 @@ import java.util.Enumeration;
 
 import static com.predic8.membrane.core.exchange.Exchange.HTTP_SERVLET_REQUEST;
 import static com.predic8.membrane.core.http.Header.TRANSFER_ENCODING;
+import static com.predic8.membrane.core.util.ExceptionUtil.concatMessageAndCauseMessages;
+import static com.predic8.membrane.core.util.ExceptionUtil.isPeerDisconnect;
 
 class HttpServletHandler extends AbstractHttpHandler {
 	private static final Logger log = LoggerFactory.getLogger(HttpServletHandler.class);
@@ -85,12 +87,43 @@ class HttpServletHandler extends AbstractHttpHandler {
 		} catch (EOFWhileReadingFirstLineException e) {
 			log.debug("Client connection terminated before line was read. Line so far: ("
 					+ e.getLineSoFar() + ")");
+		} catch (ReadingBodyException e) {
+			logReadingBodyException(e);
+		} catch (WritingBodyException e) {
+			// Only writeResponse() can throw this here: a failure writing the request body to the target is
+			// swallowed by invokeHandlers() and turned into a 500. So this is always the client's end.
+			if (isPeerDisconnect(e))
+				log.info("Client closed the connection while the response body was being written: {}",
+						concatMessageAndCauseMessages(e));
+			else
+				log.error(e.getMessage(), e);
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 		} finally {
 			exchange.detach();
 		}
 
+	}
+
+	/**
+	 * Reading a body can fail on either end: the client while its request body is being read, or the
+	 * target server while its response body is being streamed to the client. Attribute the failure to
+	 * the body that actually recorded it.
+	 */
+	private void logReadingBodyException(ReadingBodyException e) {
+		if (!isPeerDisconnect(e)) {
+			log.error(e.getMessage(), e);
+			return;
+		}
+		if (e.belongsTo(exchange.getResponse()))
+			log.warn("Server connection to {} closed while the response body was being read: {}",
+					exchange.getDestinations(), concatMessageAndCauseMessages(e));
+		else if (e.belongsTo(exchange.getRequest()))
+			log.info("Client closed the connection while its request body was being read: {}",
+					concatMessageAndCauseMessages(e));
+		else
+			log.info("Connection closed while a message body was being read: {}",
+					concatMessageAndCauseMessages(e));
 	}
 
 	protected void writeResponse(Response res) throws Exception {

--- a/war/src/main/java/com/predic8/membrane/servlet/embedded/HttpServletHandler.java
+++ b/war/src/main/java/com/predic8/membrane/servlet/embedded/HttpServletHandler.java
@@ -35,8 +35,6 @@ import java.util.Enumeration;
 
 import static com.predic8.membrane.core.exchange.Exchange.HTTP_SERVLET_REQUEST;
 import static com.predic8.membrane.core.http.Header.TRANSFER_ENCODING;
-import static com.predic8.membrane.core.util.ExceptionUtil.concatMessageAndCauseMessages;
-import static com.predic8.membrane.core.util.ExceptionUtil.isPeerDisconnect;
 
 class HttpServletHandler extends AbstractHttpHandler {
 	private static final Logger log = LoggerFactory.getLogger(HttpServletHandler.class);
@@ -90,40 +88,13 @@ class HttpServletHandler extends AbstractHttpHandler {
 		} catch (ReadingBodyException e) {
 			logReadingBodyException(e);
 		} catch (WritingBodyException e) {
-			// Only writeResponse() can throw this here: a failure writing the request body to the target is
-			// swallowed by invokeHandlers() and turned into a 500. So this is always the client's end.
-			if (isPeerDisconnect(e))
-				log.info("Client closed the connection while the response body was being written: {}",
-						concatMessageAndCauseMessages(e));
-			else
-				log.error(e.getMessage(), e);
+			logWritingBodyException(e);
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 		} finally {
 			exchange.detach();
 		}
 
-	}
-
-	/**
-	 * Reading a body can fail on either end: the client while its request body is being read, or the
-	 * target server while its response body is being streamed to the client. Attribute the failure to
-	 * the body that actually recorded it.
-	 */
-	private void logReadingBodyException(ReadingBodyException e) {
-		if (!isPeerDisconnect(e)) {
-			log.error(e.getMessage(), e);
-			return;
-		}
-		if (e.belongsTo(exchange.getResponse()))
-			log.warn("Server connection to {} closed while the response body was being read: {}",
-					exchange.getDestinations(), concatMessageAndCauseMessages(e));
-		else if (e.belongsTo(exchange.getRequest()))
-			log.info("Client closed the connection while its request body was being read: {}",
-					concatMessageAndCauseMessages(e));
-		else
-			log.info("Connection closed while a message body was being read: {}",
-					concatMessageAndCauseMessages(e));
 	}
 
 	protected void writeResponse(Response res) throws Exception {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Body-reading failures are now recorded and consistently reported on subsequent access attempts.
  * Connections with incomplete or failed bodies are safely closed instead of being reused.
  * Keep-alive decisions now reject exchanges with failed request or response bodies.
  * Incomplete request bodies are no longer sent to shadow targets.
  * Network disconnects and body read/write failures receive more accurate handling and logging.
* **Tests**
  * Added coverage for failed body reads, connection cleanup, keep-alive behavior, shadowing, and disconnect detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->