### PR TITLE
fix: fail on truncated bodies instead of NUL-padding them

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/util/ByteUtil.java
+++ b/core/src/main/java/com/predic8/membrane/core/util/ByteUtil.java
@@ -25,6 +25,14 @@ public class ByteUtil {
 
 	private static final Logger log = LoggerFactory.getLogger(ByteUtil.class.getName());
 
+	/**
+	 * Reads exactly <code>length</code> bytes, or fails.
+	 *
+	 * @param length how many bytes to read, or a negative value to read until the end of the stream
+	 * @throws EOFException if the stream ends before <code>length</code> bytes were read. The
+	 *         remainder of the buffer would otherwise still be zero and therefore indistinguishable
+	 *         from real content, letting a truncated message body pass as complete.
+	 */
 	public static byte[] readByteArray(InputStream in, int length) throws IOException {
 		if (length < 0)
 			return in.readAllBytes();
@@ -35,6 +43,8 @@ public class ByteUtil {
 		while (offset < length && (count = in.read(content, offset, length - offset)) >= 0) {
 			offset += count;
 		}
+		if (offset < length)
+			throw new EOFException("Stream ended after %d of %d expected bytes.".formatted(offset, length));
 		return content;
 	}
 

--- a/core/src/test/java/com/predic8/membrane/core/http/BodyTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/http/BodyTest.java
@@ -158,6 +158,32 @@ public class BodyTest {
 		assertTrue(unchunkedBody.hasRelevantObservers());
 	}
 
+	/**
+	 * A sender that announces Content-Length: 7 and then delivers 4 bytes must not produce a body
+	 * that claims to be complete. readByteArray() pads the shortfall with NULs, so the truncated
+	 * upload is reported as fully read and forwarded to the backend.
+	 * See <a href="https://github.com/membrane/api-gateway/issues/3193">#3193</a>.
+	 */
+	@Test
+	void truncatedContentLengthBodyFailsInsteadOfBeingZeroPadded() {
+		Body truncated = new Body(new ByteArrayInputStream("part".getBytes()), 7);
+
+		ReadingBodyException e = assertThrows(ReadingBodyException.class, truncated::read);
+
+		assertInstanceOf(EOFException.class, e.getCause());
+		assertFalse(truncated.isRead());
+	}
+
+	@Test
+	void completeContentLengthBodyIsStillRead() {
+		Body complete = new Body(new ByteArrayInputStream("payload".getBytes()), 7);
+
+		complete.read();
+
+		assertTrue(complete.isRead());
+		assertArrayEquals("payload".getBytes(), complete.getContent());
+	}
+
 	private static class NonRelevantObserver extends AbstractMessageObserver implements NonRelevantBodyObserver {}
 
 }

--- a/core/src/test/java/com/predic8/membrane/core/http/ChunkedBodyTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/http/ChunkedBodyTest.java
@@ -45,6 +45,8 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.ServerSocket;
@@ -53,6 +55,8 @@ import java.net.URL;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -468,6 +472,66 @@ public class ChunkedBodyTest {
         return new ByteArrayInputStream(chunks().add("""
                 { "foo": 42 }""").add("""
                 { "foo": 43 }""").build());
+    }
+
+    // -------------------------------------------------------------------------
+    // truncated bodies (https://github.com/membrane/api-gateway/issues/3193)
+    // -------------------------------------------------------------------------
+
+    /**
+     * A sender that announces a 7-byte chunk and then disappears. readByteArray() pads the
+     * shortfall with NULs, so the unfinished chunk is handed on as if it were complete and the
+     * failure surfaces only on the next chunk-size line, as "Empty chunk-size field".
+     */
+    @Nested
+    class TruncatedChunk {
+
+        private static final String TRUNCATED = "7" + CRLF + "part";
+
+        private static ChunkedBody truncatedBody() {
+            return new ChunkedBody(new ByteArrayInputStream(TRUNCATED.getBytes()));
+        }
+
+        @Test
+        void isNotDeliveredToTheConsumer() {
+            InputStream in = truncatedBody().getContentAsStream();
+
+            assertThrows(IOException.class, () -> in.readNBytes(7));
+        }
+
+        @Test
+        void isNotPublishedToObservers() {
+            ChunkedBody body = truncatedBody();
+            List<byte[]> published = new ArrayList<>();
+            body.addObserver(new AbstractMessageObserver() {
+                @Override
+                public void bodyChunk(Chunk chunk) {
+                    published.add(chunk.content());
+                }
+            });
+
+            InputStream in = body.getContentAsStream();
+            assertThrows(IOException.class, in::readAllBytes);
+
+            assertEquals(0, published.size(), "a chunk the sender never finished must not reach an observer");
+        }
+
+        @Test
+        void failsWithEndOfStreamNotAnEmptyChunkSize() {
+            ReadingBodyException e = assertThrows(ReadingBodyException.class, truncatedBody()::read);
+
+            assertInstanceOf(EOFException.class, e.getCause());
+        }
+
+        @Test
+        void isNotForwardedDownstream() {
+            ChunkedBody body = truncatedBody();
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+            assertThrows(ReadingBodyException.class, () -> body.write(new ChunkedBodyTransferer(out), false));
+
+            assertEquals(0, out.size(), "no part of an unfinished chunk may reach the peer");
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/core/src/test/java/com/predic8/membrane/core/util/ByteUtilTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/util/ByteUtilTest.java
@@ -52,4 +52,33 @@ public class ByteUtilTest {
 	public void testReadByteArray2() throws IOException {
 		assertArrayEquals(readByteArray(in2, message2.length()), message2.getBytes());
 	}
+
+	/**
+	 * A stream that ends before the requested number of bytes has been delivered must be reported.
+	 * Returning the pre-allocated buffer makes its NUL padding indistinguishable from real content,
+	 * so a truncated message body is accepted as complete.
+	 * See <a href="https://github.com/membrane/api-gateway/issues/3193">#3193</a>.
+	 */
+	@Test
+	void readByteArrayThrowsWhenTheStreamEndsEarly() {
+		assertThrows(EOFException.class, () -> readByteArray(new ByteArrayInputStream("part".getBytes()), 7));
+	}
+
+	/**
+	 * The full-length read must keep working when it takes several read() calls to get there -
+	 * a short read is not the same as the end of the stream.
+	 */
+	@Test
+	void readByteArrayAccumulatesAcrossShortReads() throws IOException {
+		assertArrayEquals(message1.getBytes(), readByteArray(oneByteAtATime(message1), message1.length()));
+	}
+
+	private static InputStream oneByteAtATime(String content) {
+		return new FilterInputStream(new ByteArrayInputStream(content.getBytes())) {
+			@Override
+			public int read(byte[] b, int off, int len) throws IOException {
+				return super.read(b, off, 1); // force the caller to loop
+			}
+		};
+	}
 }


### PR DESCRIPTION
ByteUtil.readByteArray() returned its pre-allocated buffer when the stream ended before the requested number of bytes had been read, so the zero padding was indistinguishable from real content.

On the Content-Length path (Body.readLocal) this produced no error at all: the body reported isRead() == true with its content padded to the announced length, and the truncated message was forwarded. The chunked reader handed the padded chunk to the observers and to the consumer, then failed one chunk later with the misleading "Empty chunk-size field"; ChunkedBody.writeStreamed() had already written it to the peer. Frame.read() padded HTTP/2 frame payloads the same way, although Frame.readByte() already threw EOFException for the frame header.

readByteArray() now throws EOFException on a short read. As it extends IOException, every caller's existing handling turns it into a ReadingBodyException without a signature change. Reading until the end of the stream (length < 0) is unaffected.

Note this changes a path that previously appeared to work: a truncated Content-Length body is now a hard body-read failure rather than silently padded.

Closes #3193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Incomplete fixed-length HTTP request and response bodies are now rejected instead of being treated as complete.
  - Truncated chunked transfers now fail safely without delivering partial data to consumers.
  - Complete bodies continue to be processed successfully, including data received across multiple short reads.
- **Tests**
  - Added coverage for truncated, complete, and fragmented body-reading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->