### PR TITLE
refactor: remove dead AbstractBody.writeNotRead()

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/http/AbstractBody.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/AbstractBody.java
@@ -165,8 +165,6 @@ public abstract class AbstractBody {
 
 	protected abstract void writeAlreadyRead(AbstractBodyTransferer out) throws IOException;
 
-	protected abstract void writeNotRead(AbstractBodyTransferer out) throws IOException;
-
 	/**
 	 * Is called when there are no observers that need to read the body. Streams the body without reading it
 	 */

--- a/core/src/main/java/com/predic8/membrane/core/http/Body.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/Body.java
@@ -134,28 +134,6 @@ public class Body extends AbstractBody {
 	}
 
 	@Override
-	protected void writeNotRead(AbstractBodyTransferer out) throws IOException {
-		byte[] buffer = new byte[BUFFER_SIZE];
-
-		long totalLength = 0;
-		int length;
-		chunks.clear();
-		while ((this.length > totalLength || this.length == -1) && (length = inputStream.read(buffer)) > 0) {
-			totalLength += length;
-			out.write(buffer, 0, length);
-			byte[] chunk = new byte[length];
-			System.arraycopy(buffer, 0, chunk, 0, length);
-			Chunk chunk1 = new Chunk(chunk);
-			chunks.add(chunk1);
-			for (MessageObserver observer : observers)
-				observer.bodyChunk(chunk1);
-		}
-
-		out.finish(null);
-		markAsRead();
-	}
-
-	@Override
 	protected void writeStreamed(AbstractBodyTransferer out) {
 		byte[] buffer = new byte[BUFFER_SIZE];
 

--- a/core/src/main/java/com/predic8/membrane/core/http/ChunkedBody.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/ChunkedBody.java
@@ -246,26 +246,6 @@ public class ChunkedBody extends AbstractBody {
     }
 
     @Override
-    protected void writeNotRead(AbstractBodyTransferer out) throws IOException {
-        log.debug("writeNotReadChunked");
-        int chunkSize;
-        while ((chunkSize = readChunkSize(inputStream)) > 0) {
-            Chunk chunk = new Chunk(readByteArray(inputStream, chunkSize));
-            out.write(chunk);
-            chunks.add(chunk);
-            for (MessageObserver observer : observers)
-                observer.bodyChunk(chunk);
-            //noinspection ResultOfMethodCallIgnored
-            inputStream.read(); // CR
-            //noinspection ResultOfMethodCallIgnored
-            inputStream.read(); // LF
-        }
-        trailer = readTrailer(inputStream);
-        out.finish(trailer);
-        markAsRead();
-    }
-
-    @Override
     protected void writeStreamed(AbstractBodyTransferer out) {
         log.debug("writeStreamed");
         int chunkSize;

--- a/core/src/main/java/com/predic8/membrane/core/http/EmptyBody.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/EmptyBody.java
@@ -39,11 +39,6 @@ public class EmptyBody extends AbstractBody {
 	}
 
 	@Override
-	protected void writeNotRead(AbstractBodyTransferer out) {
-		//ignore
-	}
-
-	@Override
 	protected void writeStreamed(AbstractBodyTransferer out) {
 		//ignore
 	}

--- a/core/src/main/java/com/predic8/membrane/core/http/XmlDomBody.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/XmlDomBody.java
@@ -274,11 +274,6 @@ public class XmlDomBody extends AbstractBody {
     }
 
     @Override
-    protected void writeNotRead(AbstractBodyTransferer out) throws IOException {
-        writeAlreadyRead(out);
-    }
-
-    @Override
     protected void writeStreamed(AbstractBodyTransferer out) {
         try {
             writeAlreadyRead(out);

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/sse/ServerSentEventsDemoStreamInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/sse/ServerSentEventsDemoStreamInterceptor.java
@@ -127,10 +127,6 @@ public class ServerSentEventsDemoStreamInterceptor extends AbstractInterceptor {
         }
 
         @Override
-        protected void writeNotRead(AbstractBodyTransferer out) {
-        }
-
-        @Override
         protected void writeStreamed(AbstractBodyTransferer out) {
 
         }

--- a/core/src/main/java/com/predic8/membrane/core/transport/http2/StreamInfo.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/http2/StreamInfo.java
@@ -205,26 +205,6 @@ public class StreamInfo {
         }
 
         @Override
-        protected void writeNotRead(AbstractBodyTransferer out) throws IOException {
-            chunks.clear();
-            while (true) {
-                DataFrame df = removeDataFrame();
-                if (df == null)
-                    continue;
-                int len = df.getDataLength();
-                if (len > 0)
-                    out.write(df.getContent(), df.getDataStartIndex(), len);
-                chunks.add(new Chunk(createByteArray(df)));
-
-                if (df.isEndStream())
-                    break;
-            }
-
-            out.finish(trailer);
-            markAsRead();
-        }
-
-        @Override
         protected void writeStreamed(AbstractBodyTransferer out) {
             chunks.clear();
             while (true) {

--- a/core/src/test/java/com/predic8/membrane/core/http/BodyTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/http/BodyTest.java
@@ -143,7 +143,6 @@ public class BodyTest {
 			@Override public long getLength() { return length; }
 			@Override protected void readLocal() {}
 			@Override protected void writeAlreadyRead(AbstractBodyTransferer out) {}
-			@Override protected void writeNotRead(AbstractBodyTransferer out) {}
 			@Override protected void writeStreamed(AbstractBodyTransferer out) {}
 			@Override protected byte[] getRawLocal() { return new byte[0]; }
 		};


### PR DESCRIPTION
## What

Removes `AbstractBody.writeNotRead()`, all six overrides and the test stub. Deletion only, 79 lines.

## Why

Nothing has called it since `721428ca2` (2020-10-13, *"introduction of MessageObserver.bodyChunk()"*).

Before that commit `AbstractBody.write()` chose between the two paths:

```java
if (hasRelevantObservers()) {
    writeNotRead(out);
} else {
    writeStreamed(out);
    wasStreamed = true;
}
```

That commit dropped the branch — `writeStreamed()` handles both cases now — and `write()` has
dispatched only to `writeStreamed()` or `writeAlreadyRead()` ever since. `writeNotRead()` stayed
behind as an abstract method that every `AbstractBody` subclass had to implement, in three cases
with a full body that could never run.

## Removed

| File | |
| --- | --- |
| `http/AbstractBody.java` | the abstract declaration |
| `http/Body.java` | override (22 lines) |
| `http/ChunkedBody.java` | override (20 lines) |
| `transport/http2/StreamInfo.java` | `Http2Body` override (20 lines) |
| `http/XmlDomBody.java` | override, delegated to `writeAlreadyRead()` |
| `http/EmptyBody.java` | empty override |
| `interceptor/sse/ServerSentEventsDemoStreamInterceptor.java` | `StreamingBody` empty override |
| `http/BodyTest.java` | stub in the anonymous `AbstractBody` |

No helper is orphaned: `StreamInfo`'s `createByteArray()` and `removeDataFrame()` are still called
from `readLocal()`, and `Body`'s `BUFFER_SIZE` / `ChunkedBody`'s `readChunkSize()`, `readByteArray()`
and `readTrailer()` are all still used by the live paths.

## Verification

- `mvn -o -DskipTests install` — BUILD SUCCESS across the whole reactor, so no caller existed in any
  module.
- `com.predic8.membrane.core.http` — 293/293 green.
- `com.predic8.membrane.core.transport` — 126/126 green (1 pre-existing skip).
- No remaining reference to the name anywhere in the repo, and no reflective lookup of it.

`ServerSentEventsDemoStreamInterceptor` has no unit test (it is covered by
`distribution/tutorials/misc/Server-Sent-Events.yaml`); its `StreamingBody` overrides `write()`
directly, so it never reached any of these methods, and only an empty body was deleted.

No behaviour change — the removed code was unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified body-writing behavior by removing the unused “not read” write path.
  * Body types now rely on their standard streaming or already-read handling when sending content.
  * Empty bodies use the default handling instead of silently ignoring this operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->