### PR TITLE
Check response flow in dynamic registration

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/authorizationservice/DynamicRegistration.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/authorizationservice/DynamicRegistration.java
@@ -78,9 +78,11 @@ public class DynamicRegistration {
             throw new RuntimeException("Registration interceptorchain (request) had a problem");
 
         client.call(exc);
-        Response response = exc.getResponse();
 
-        router.getFlowController().invokeResponseHandlers(exc, interceptors);
+        if (router.getFlowController().invokeResponseHandlers(exc, interceptors) != CONTINUE)
+            throw new RuntimeException("Registration interceptorchain (response) had a problem");
+
+        Response response = exc.getResponse();
 
         if (response.getStatusCode() < 200 || response.getStatusCode() > 201)
             throw new RuntimeException("Registration endpoint didn't return successful: " + response.getStatusMessage());

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/authorizationservice/DynamicRegistrationTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/authorizationservice/DynamicRegistrationTest.java
@@ -1,0 +1,94 @@
+/* Copyright 2025 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.core.interceptor.oauth2.authorizationservice;
+
+import com.predic8.membrane.core.exchange.*;
+import com.predic8.membrane.core.http.*;
+import com.predic8.membrane.core.interceptor.*;
+import com.predic8.membrane.core.router.*;
+import com.predic8.membrane.core.transport.http.*;
+import com.predic8.membrane.core.transport.http.client.*;
+import org.junit.jupiter.api.*;
+
+import java.io.*;
+
+import static com.predic8.membrane.core.interceptor.Outcome.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class DynamicRegistrationTest {
+
+    private DynamicRegistration reg;
+    private FlowController flowController;
+    private HttpClient httpClient;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        flowController = mock(FlowController.class);
+        httpClient = mock(HttpClient.class);
+
+        HttpClientFactory factory = mock(HttpClientFactory.class);
+        when(factory.createClient(any())).thenReturn(httpClient);
+
+        Router router = mock(Router.class);
+        when(router.getFlowController()).thenReturn(flowController);
+        when(router.getHttpClientFactory()).thenReturn(factory);
+
+        reg = new DynamicRegistration();
+        reg.init(router);
+    }
+
+    private void stubCall(Response response) throws Exception {
+        doAnswer(inv -> {
+            ((Exchange) inv.getArgument(0)).setResponse(response);
+            return null;
+        }).when(httpClient).call(any());
+    }
+
+    @Test
+    void happyPath() throws Exception {
+        when(flowController.invokeRequestHandlers(any(), anyList())).thenReturn(CONTINUE);
+        stubCall(Response.ok().body("{}").build());
+        when(flowController.invokeResponseHandlers(any(), anyList())).thenReturn(CONTINUE);
+
+        InputStream body = reg.retrieveOpenIDConfiguration("http://example.com/.well-known");
+        assertNotNull(body);
+    }
+
+    @Test
+    void responseFlowAbortThrows() throws Exception {
+        when(flowController.invokeRequestHandlers(any(), anyList())).thenReturn(CONTINUE);
+        stubCall(Response.ok().build());
+        when(flowController.invokeResponseHandlers(any(), anyList())).thenReturn(ABORT);
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> reg.retrieveOpenIDConfiguration("http://example.com/.well-known"));
+        assertTrue(ex.getMessage().contains("response"));
+    }
+
+    @Test
+    void responseReplacedByInterceptorIsReturned() throws Exception {
+        when(flowController.invokeRequestHandlers(any(), anyList())).thenReturn(CONTINUE);
+        stubCall(Response.ok().body("stale").build());
+        doAnswer(inv -> {
+            ((Exchange) inv.getArgument(0)).setResponse(Response.ok().body("replaced").build());
+            return CONTINUE;
+        }).when(flowController).invokeResponseHandlers(any(), anyList());
+
+        String body = new String(reg.retrieveOpenIDConfiguration("http://example.com/.well-known").readAllBytes());
+        assertEquals("replaced", body);
+    }
+}


### PR DESCRIPTION
Hit an issue where response handlers in dynamic registration weren't being checked, so we'd grab stale responses. Moved the read to after the handlers run and added a check for the flow outcome. Included tests. Fixes #3200.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OAuth2 dynamic registration response handling.
  - Responses interrupted by processing rules now fail correctly instead of being silently ignored.
  - Responses replaced during processing are now returned as expected.

- **Tests**
  - Added coverage for successful configuration retrieval, interrupted responses, and responses replaced during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->