### PR TITLE
fix(tutorials): preserve container exit status in run-docker.cmd launchers

### DIFF
--- a/distribution/tutorials/advanced/run-docker.cmd
+++ b/distribution/tutorials/advanced/run-docker.cmd
@@ -1,5 +1,5 @@
 @echo off
-setlocal enabledelayedexpansion
+setlocal EnableExtensions DisableDelayedExpansion
 
 set "DIR=%~dp0"
 set "IMAGE=predic8/membrane:7.5.0"
@@ -10,6 +10,7 @@ set "CLEANUP_CMD=docker rm -f %CID% >nul 2>nul"
 
 docker cp "%DIR%." "%CID%:/opt/membrane/" >nul
 docker start -a "%CID%"
+set "STATUS=%ERRORLEVEL%"
 
 %CLEANUP_CMD%
-endlocal
+endlocal & exit /b %STATUS%

--- a/distribution/tutorials/ai/mcp/run-docker.cmd
+++ b/distribution/tutorials/ai/mcp/run-docker.cmd
@@ -1,5 +1,5 @@
 @echo off
-setlocal enabledelayedexpansion
+setlocal EnableExtensions DisableDelayedExpansion
 
 set "DIR=%~dp0"
 set "IMAGE=predic8/membrane:7.5.0"
@@ -10,6 +10,7 @@ set "CLEANUP_CMD=docker rm -f %CID% >nul 2>nul"
 
 docker cp "%DIR%." "%CID%:/opt/membrane/" >nul
 docker start -a "%CID%"
+set "STATUS=%ERRORLEVEL%"
 
 %CLEANUP_CMD%
-endlocal
+endlocal & exit /b %STATUS%

--- a/distribution/tutorials/getting-started/run-docker.cmd
+++ b/distribution/tutorials/getting-started/run-docker.cmd
@@ -1,5 +1,5 @@
 @echo off
-setlocal enabledelayedexpansion
+setlocal EnableExtensions DisableDelayedExpansion
 
 set "DIR=%~dp0"
 set "IMAGE=predic8/membrane:7.5.0"
@@ -10,6 +10,7 @@ set "CLEANUP_CMD=docker rm -f %CID% >nul 2>nul"
 
 docker cp "%DIR%." "%CID%:/opt/membrane/" >nul
 docker start -a "%CID%"
+set "STATUS=%ERRORLEVEL%"
 
 %CLEANUP_CMD%
-endlocal
+endlocal & exit /b %STATUS%

--- a/distribution/tutorials/json/run-docker.cmd
+++ b/distribution/tutorials/json/run-docker.cmd
@@ -1,5 +1,5 @@
 @echo off
-setlocal enabledelayedexpansion
+setlocal EnableExtensions DisableDelayedExpansion
 
 set "DIR=%~dp0"
 set "IMAGE=predic8/membrane:7.5.0"
@@ -10,6 +10,7 @@ set "CLEANUP_CMD=docker rm -f %CID% >nul 2>nul"
 
 docker cp "%DIR%." "%CID%:/opt/membrane/" >nul
 docker start -a "%CID%"
+set "STATUS=%ERRORLEVEL%"
 
 %CLEANUP_CMD%
-endlocal
+endlocal & exit /b %STATUS%

--- a/distribution/tutorials/operation/run-docker.cmd
+++ b/distribution/tutorials/operation/run-docker.cmd
@@ -1,5 +1,5 @@
 @echo off
-setlocal enabledelayedexpansion
+setlocal EnableExtensions DisableDelayedExpansion
 
 set "DIR=%~dp0"
 set "IMAGE=predic8/membrane:7.5.0"
@@ -10,6 +10,7 @@ set "CLEANUP_CMD=docker rm -f %CID% >nul 2>nul"
 
 docker cp "%DIR%." "%CID%:/opt/membrane/" >nul
 docker start -a "%CID%"
+set "STATUS=%ERRORLEVEL%"
 
 %CLEANUP_CMD%
-endlocal
+endlocal & exit /b %STATUS%

--- a/distribution/tutorials/orchestration/run-docker.cmd
+++ b/distribution/tutorials/orchestration/run-docker.cmd
@@ -1,5 +1,5 @@
 @echo off
-setlocal enabledelayedexpansion
+setlocal EnableExtensions DisableDelayedExpansion
 
 set "DIR=%~dp0"
 set "IMAGE=predic8/membrane:7.5.0"
@@ -10,6 +10,7 @@ set "CLEANUP_CMD=docker rm -f %CID% >nul 2>nul"
 
 docker cp "%DIR%." "%CID%:/opt/membrane/" >nul
 docker start -a "%CID%"
+set "STATUS=%ERRORLEVEL%"
 
 %CLEANUP_CMD%
-endlocal
+endlocal & exit /b %STATUS%

--- a/distribution/tutorials/security/json-rpc/run-docker.cmd
+++ b/distribution/tutorials/security/json-rpc/run-docker.cmd
@@ -1,5 +1,5 @@
 @echo off
-setlocal enabledelayedexpansion
+setlocal EnableExtensions DisableDelayedExpansion
 
 set "DIR=%~dp0"
 set "IMAGE=predic8/membrane:7.5.0"
@@ -10,6 +10,7 @@ set "CLEANUP_CMD=docker rm -f %CID% >nul 2>nul"
 
 docker cp "%DIR%." "%CID%:/opt/membrane/" >nul
 docker start -a "%CID%"
+set "STATUS=%ERRORLEVEL%"
 
 %CLEANUP_CMD%
-endlocal
+endlocal & exit /b %STATUS%

--- a/distribution/tutorials/security/run-docker.cmd
+++ b/distribution/tutorials/security/run-docker.cmd
@@ -1,5 +1,5 @@
 @echo off
-setlocal enabledelayedexpansion
+setlocal EnableExtensions DisableDelayedExpansion
 
 set "DIR=%~dp0"
 set "IMAGE=predic8/membrane:7.5.0"
@@ -10,6 +10,7 @@ set "CLEANUP_CMD=docker rm -f %CID% >nul 2>nul"
 
 docker cp "%DIR%." "%CID%:/opt/membrane/" >nul
 docker start -a "%CID%"
+set "STATUS=%ERRORLEVEL%"
 
 %CLEANUP_CMD%
-endlocal
+endlocal & exit /b %STATUS%

--- a/distribution/tutorials/soap/run-docker.cmd
+++ b/distribution/tutorials/soap/run-docker.cmd
@@ -1,5 +1,5 @@
 @echo off
-setlocal enabledelayedexpansion
+setlocal EnableExtensions DisableDelayedExpansion
 
 set "DIR=%~dp0"
 set "IMAGE=predic8/membrane:7.5.0"
@@ -10,6 +10,7 @@ set "CLEANUP_CMD=docker rm -f %CID% >nul 2>nul"
 
 docker cp "%DIR%." "%CID%:/opt/membrane/" >nul
 docker start -a "%CID%"
+set "STATUS=%ERRORLEVEL%"
 
 %CLEANUP_CMD%
-endlocal
+endlocal & exit /b %STATUS%

--- a/distribution/tutorials/ssl-tls/run-docker.cmd
+++ b/distribution/tutorials/ssl-tls/run-docker.cmd
@@ -1,5 +1,5 @@
 @echo off
-setlocal enabledelayedexpansion
+setlocal EnableExtensions DisableDelayedExpansion
 
 set "DIR=%~dp0"
 set "IMAGE=predic8/membrane:7.5.0"
@@ -10,6 +10,7 @@ set "CLEANUP_CMD=docker rm -f %CID% >nul 2>nul"
 
 docker cp "%DIR%." "%CID%:/opt/membrane/" >nul
 docker start -a "%CID%"
+set "STATUS=%ERRORLEVEL%"
 
 %CLEANUP_CMD%
-endlocal
+endlocal & exit /b %STATUS%

--- a/distribution/tutorials/transformation/run-docker.cmd
+++ b/distribution/tutorials/transformation/run-docker.cmd
@@ -1,5 +1,5 @@
 @echo off
-setlocal enabledelayedexpansion
+setlocal EnableExtensions DisableDelayedExpansion
 
 set "DIR=%~dp0"
 set "IMAGE=predic8/membrane:7.5.0"
@@ -10,6 +10,7 @@ set "CLEANUP_CMD=docker rm -f %CID% >nul 2>nul"
 
 docker cp "%DIR%." "%CID%:/opt/membrane/" >nul
 docker start -a "%CID%"
+set "STATUS=%ERRORLEVEL%"
 
 %CLEANUP_CMD%
-endlocal
+endlocal & exit /b %STATUS%

--- a/distribution/tutorials/xml/run-docker.cmd
+++ b/distribution/tutorials/xml/run-docker.cmd
@@ -1,5 +1,5 @@
 @echo off
-setlocal enabledelayedexpansion
+setlocal EnableExtensions DisableDelayedExpansion
 
 set "DIR=%~dp0"
 set "IMAGE=predic8/membrane:7.5.0"
@@ -10,6 +10,7 @@ set "CLEANUP_CMD=docker rm -f %CID% >nul 2>nul"
 
 docker cp "%DIR%." "%CID%:/opt/membrane/" >nul
 docker start -a "%CID%"
+set "STATUS=%ERRORLEVEL%"
 
 %CLEANUP_CMD%
-endlocal
+endlocal & exit /b %STATUS%


### PR DESCRIPTION
## Summary

All `distribution/tutorials/**/run-docker.cmd` launchers now preserve the exit status from `docker start -a`, and no longer mangle `!` characters forwarded in `%*`.

## Problem

After `docker start -a` completed, the trailing `docker rm` cleanup command overwrote `ERRORLEVEL`, so the launcher always reported success even when the containerized command failed. Separately, `setlocal enabledelayedexpansion` caused `!` characters in forwarded Docker arguments (`%*`) to be interpreted/removed before Docker ever saw them.

## Changes

Applied identically to all 12 `run-docker.cmd` launchers:

- `setlocal enabledelayedexpansion` → `setlocal EnableExtensions DisableDelayedExpansion`
- Capture `ERRORLEVEL` immediately after `docker start -a`, run the existing cleanup command, then return the captured status after `endlocal`:
  ```bat
  docker start -a "%CID%"
  set "STATUS=%ERRORLEVEL%"

  %CLEANUP_CMD%
  endlocal & exit /b %STATUS%
  ```

Affected files:
- `distribution/tutorials/advanced/run-docker.cmd`
- `distribution/tutorials/ai/mcp/run-docker.cmd`
- `distribution/tutorials/getting-started/run-docker.cmd`
- `distribution/tutorials/json/run-docker.cmd`
- `distribution/tutorials/operation/run-docker.cmd`
- `distribution/tutorials/orchestration/run-docker.cmd`
- `distribution/tutorials/security/json-rpc/run-docker.cmd`
- `distribution/tutorials/security/run-docker.cmd`
- `distribution/tutorials/soap/run-docker.cmd`
- `distribution/tutorials/ssl-tls/run-docker.cmd`
- `distribution/tutorials/transformation/run-docker.cmd`
- `distribution/tutorials/xml/run-docker.cmd`

None of the launchers used delayed-expansion (`!var!`) syntax elsewhere, so disabling it is safe. The Unix `run-docker.sh` equivalents already propagate exit status correctly via `set -e` + `trap`, so this brings the Windows launchers to parity.

Closes #3206

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Windows Docker tutorial scripts now correctly return the container’s exit status after cleanup, making failures visible to calling tools and users.
  * Command handling was adjusted to prevent delayed variable expansion issues during script execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->