### PR TITLE
Refactor: rename `sslInterceptors` to `interceptors` across codebase

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/proxies/SSLProxy.java
+++ b/core/src/main/java/com/predic8/membrane/core/proxies/SSLProxy.java
@@ -74,7 +74,7 @@ public class SSLProxy implements Proxy {
     private ConnectionConfiguration connectionConfiguration = new ConnectionConfiguration();
     private final RuleStatisticCollector ruleStatisticCollector = new RuleStatisticCollector();
     private boolean useAsDefault = true;
-    private List<SSLInterceptor> sslInterceptors = new ArrayList<>();
+    private List<SSLInterceptor> interceptors = new ArrayList<>();
 
     public ConnectionConfiguration getConnectionConfiguration() {
         return connectionConfiguration;
@@ -147,8 +147,8 @@ public class SSLProxy implements Proxy {
 
     }
 
-    public List<SSLInterceptor> getSslInterceptors() {
-        return sslInterceptors;
+    public List<SSLInterceptor> getInterceptors() {
+        return interceptors;
     }
 
     /**
@@ -156,8 +156,8 @@ public class SSLProxy implements Proxy {
      *              They only see the data of the TLS handshake, never the encrypted payload.
      */
     @MCChildElement(allowForeign = true, order = 50)
-    public void setSslInterceptors(List<SSLInterceptor> sslInterceptors) {
-        this.sslInterceptors = sslInterceptors;
+    public void setInterceptors(List<SSLInterceptor> interceptors) {
+        this.interceptors = interceptors;
     }
 
     int port;
@@ -250,7 +250,7 @@ public class SSLProxy implements Proxy {
     public void init(Router router) {
         this.router = router;
         cm = new ConnectionManager(connectionConfiguration.getKeepAliveTimeout(), router.getTimerManager());
-        for (SSLInterceptor i : sslInterceptors)
+        for (SSLInterceptor i : interceptors)
             i.init(router);
     }
 
@@ -417,7 +417,7 @@ public class SSLProxy implements Proxy {
 
             boolean cont = true;
             try {
-                for (SSLInterceptor interceptor : sslInterceptors) {
+                for (SSLInterceptor interceptor : interceptors) {
                     Outcome o = interceptor.handleRequest(exc);
                     if (o != Outcome.CONTINUE) {
                         cont = false;

--- a/core/src/main/java/com/predic8/membrane/core/sslinterceptor/SSLLogInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/sslinterceptor/SSLLogInterceptor.java
@@ -37,7 +37,7 @@ import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
  * sslProxy:
  *   host: api.example.com
  *   port: 8443
- *   sslInterceptors:
+ *   interceptors:
  *     - sslLog: {}
  *   target:
  *     host: api.example.com

--- a/core/src/test/java/com/predic8/membrane/core/proxies/SSLProxyTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/proxies/SSLProxyTest.java
@@ -169,20 +169,20 @@ class SSLProxyTest {
         };
     }
 
-    private int startRouterWithSSLProxy(SSLInterceptor... sslInterceptors) throws IOException {
+    private int startRouterWithSSLProxy(SSLInterceptor... interceptors) throws IOException {
         int port = freePort();
         router = new TestRouter();
-        router.add(createSSLProxy(port, sslInterceptors));
+        router.add(createSSLProxy(port, interceptors));
         router.start();
         return port;
     }
 
-    private SSLProxy createSSLProxy(int port, SSLInterceptor... sslInterceptors) {
+    private SSLProxy createSSLProxy(int port, SSLInterceptor... interceptors) {
         SSLProxy sslProxy = new SSLProxy();
         sslProxy.setHost(SNI_HOST);
         sslProxy.setPort(port);
         sslProxy.setUseAsDefault(false);
-        sslProxy.setSslInterceptors(List.of(sslInterceptors));
+        sslProxy.setInterceptors(List.of(interceptors));
         SSLProxy.Target target = new SSLProxy.Target();
         target.setHost(backend.getInetAddress().getHostAddress());
         target.setPort(backend.getLocalPort());

--- a/distribution/tutorials/ssl-tls/30-TLS-Passthrough.yaml
+++ b/distribution/tutorials/ssl-tls/30-TLS-Passthrough.yaml
@@ -60,7 +60,7 @@
 sslProxy:
   host: api.predic8.de
   port: 8443
-  sslInterceptors:
+  interceptors:
     # Logs each forwarded connection; without it a passthrough leaves no trace
     - sslLog: {}
   target:
@@ -71,7 +71,7 @@ sslProxy:
 sslProxy:
   host: www.membrane-api.io
   port: 8443
-  sslInterceptors:
+  interceptors:
     - sslLog: {}
   target:
     host: www.membrane-api.io


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed the SSL proxy interceptor configuration property from `sslInterceptors` to `interceptors`.
  * Renamed the corresponding SSL proxy accessor methods.
* **Documentation**
  * Updated SSL logging examples and TLS passthrough tutorials to use the new `interceptors` configuration property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->