### PR TITLE
Trigger Docker image build explicitly after a release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           set -euo pipefail
           RELEASE_TAG="${INPUT_TAG:-$REF_NAME}"
-          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::'$RELEASE_TAG' is not a release tag. Dispatch this workflow on the tag, or pass the 'tag' input (e.g. v6.6.0)."
             exit 1
           fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -96,11 +96,16 @@ jobs:
       # 'latest' follows the release for a real release, and the 'latest' input
       # for a manual run. Without the explicit event check a manual run would
       # always push 'latest', because github.event.release is empty there.
+      # 'flavor: latest=false' is required as well: metadata-action defaults to
+      # 'latest=auto', which adds 'latest' for any semver version regardless of
+      # the enable= condition on the raw tag below.
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          flavor: |
+            latest=false
           tags: |
             type=semver,pattern={{version}},value=${{ steps.release_version.outputs.release_tag }}
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.release_version.outputs.release_tag }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,18 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-    
+    inputs:
+      tag:
+        description: "Release tag to build, e.g. v6.6.0. Required unless the workflow is run on the tag itself."
+        type: string
+        required: false
+        default: ''
+      latest:
+        description: "Also push the 'latest' Docker tag"
+        type: boolean
+        required: false
+        default: false
+
 env:
   REGISTRY: docker.io
   IMAGE_NAME: predic8/membrane
@@ -29,16 +40,30 @@ jobs:
     steps:
 #      - name: Dump context
 #        uses: crazy-max/ghaction-dump-context@v2
-      - uses: bhowell2/github-substring-action@1.0.2
+
+      # The release tag can come from the 'tag' input (when dispatched from a
+      # branch, e.g. by the Create Release workflow) or from the ref the
+      # workflow runs on (when triggered by a release, or dispatched on a tag).
+      - name: Resolve release tag
         id: release_version
-        with:
-          value: "${{ github.ref_name }}"
-          index_of_str: "v"
-          output_name: tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          RELEASE_TAG="${INPUT_TAG:-$REF_NAME}"
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "::error::'$RELEASE_TAG' is not a release tag. Dispatch this workflow on the tag, or pass the 'tag' input (e.g. v6.6.0)."
+            exit 1
+          fi
+          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          echo "tag=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
+          echo "Building Docker image for release $RELEASE_TAG"
+
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.ref }}
+          ref: refs/tags/${{ steps.release_version.outputs.release_tag }}
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
@@ -68,21 +93,24 @@ jobs:
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
+      # 'latest' follows the release for a real release, and the 'latest' input
+      # for a manual run. Without the explicit event check a manual run would
+      # always push 'latest', because github.event.release is empty there.
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest,enable=${{ ! github.event.release.prerelease }}
+            type=semver,pattern={{version}},value=${{ steps.release_version.outputs.release_tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.release_version.outputs.release_tag }}
+            type=semver,pattern={{major}},value=${{ steps.release_version.outputs.release_tag }}
+            type=raw,value=latest,enable=${{ (github.event_name == 'workflow_dispatch' && inputs.latest) || (github.event_name == 'release' && ! github.event.release.prerelease) }}
             type=sha,enable=false
 
       - uses: robinraju/release-downloader@v1.8
         with:
-          tag: "${{ github.ref_name }}"
+          tag: "${{ steps.release_version.outputs.release_tag }}"
           fileName: "membrane-api-gateway-${{ steps.release_version.outputs.tag }}.zip"
           out-file-path: "distribution/docker/release-bin"
           extract: false

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -13,6 +13,8 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # Needed to start the 'Build Docker Image' workflow via workflow_dispatch.
+  actions: write
 
 jobs:
   build-release:
@@ -109,6 +111,28 @@ jobs:
           bodyFile: "distribution/release-notes/${{ steps.get_version.outputs.VERSION }}.md"
           artifacts: "core/target/classes/com/predic8/membrane/core/config/json/membrane.schema.json,distribution/target/membrane-api-gateway-${{ steps.get_version.outputs.VERSION }}.zip,distribution/target/membrane-api-gateway-${{ steps.get_version.outputs.VERSION }}.zip.asc"
           token: ${{ github.token }}
+
+      # A release created with the default GITHUB_TOKEN does not fire the
+      # 'release: published' event: GitHub suppresses workflow triggering for
+      # events created by GITHUB_TOKEN, so the Docker build never started.
+      # workflow_dispatch is explicitly exempt from that restriction, so the
+      # build is kicked off here instead. It is dispatched on the base branch
+      # (the tag has no workflow file of its own for older releases) and gets
+      # the release tag passed as an input.
+      - name: Trigger Docker image build
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BASE_REF: ${{ github.base_ref }}
+          RELEASE_TAG: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          gh workflow run docker-publish.yml \
+            --repo "$REPO" \
+            --ref "$BASE_REF" \
+            --field tag="$RELEASE_TAG" \
+            --field latest=false
 
       - name: Trigger website pipeline on GitLab
         shell: bash

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -13,8 +13,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  # Needed to start the 'Build Docker Image' workflow via workflow_dispatch.
-  actions: write
 
 jobs:
   build-release:
@@ -112,28 +110,6 @@ jobs:
           artifacts: "core/target/classes/com/predic8/membrane/core/config/json/membrane.schema.json,distribution/target/membrane-api-gateway-${{ steps.get_version.outputs.VERSION }}.zip,distribution/target/membrane-api-gateway-${{ steps.get_version.outputs.VERSION }}.zip.asc"
           token: ${{ github.token }}
 
-      # A release created with the default GITHUB_TOKEN does not fire the
-      # 'release: published' event: GitHub suppresses workflow triggering for
-      # events created by GITHUB_TOKEN, so the Docker build never started.
-      # workflow_dispatch is explicitly exempt from that restriction, so the
-      # build is kicked off here instead. It is dispatched on the base branch
-      # (the tag has no workflow file of its own for older releases) and gets
-      # the release tag passed as an input.
-      - name: Trigger Docker image build
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          BASE_REF: ${{ github.base_ref }}
-          RELEASE_TAG: ${{ github.head_ref }}
-        run: |
-          set -euo pipefail
-          gh workflow run docker-publish.yml \
-            --repo "$REPO" \
-            --ref "$BASE_REF" \
-            --field tag="$RELEASE_TAG" \
-            --field latest=false
-
       - name: Trigger website pipeline on GitLab
         shell: bash
         env:
@@ -150,3 +126,39 @@ jobs:
             --form-string "variables[PIPELINE]=release" \
             --form-string "variables[MEMBRANE_VERSION]=${VERSION}" \
             "https://gitlab.predic8.de/api/v4/projects/94/trigger/pipeline"
+
+  # A release created with the default GITHUB_TOKEN does not fire the
+  # 'release: published' event: GitHub suppresses workflow triggering for
+  # events created by GITHUB_TOKEN, so the Docker build never started.
+  # workflow_dispatch is explicitly exempt from that restriction, so the build
+  # is kicked off here instead.
+  #
+  # Dispatched on the base branch rather than on the tag, because release-pr.yml
+  # creates a branch AND a tag named v<version>, so '--ref v<version>' would be
+  # ambiguous; the tag is passed as an input instead.
+  #
+  # Its own job on purpose: a dispatch that fails -- against a branch whose
+  # docker-publish.yml predates the 'tag' input the API rejects it with 422 --
+  # must not fail the release itself or block the jobs beside it. It also keeps
+  # 'actions: write' off the Maven steps in build-release.
+  trigger-docker:
+    needs: build-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Trigger Docker image build
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BASE_REF: ${{ github.base_ref }}
+          RELEASE_TAG: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          gh workflow run docker-publish.yml \
+            --repo "$REPO" \
+            --ref "$BASE_REF" \
+            --field tag="$RELEASE_TAG" \
+            --field latest=false


### PR DESCRIPTION
## Problem

`Build Docker Image` only triggers on `release: [published]`. Since #3085 switched the release creation in `release-build.yml` from `secrets.PAT` to `${{ github.token }}`, that event no longer starts a workflow: GitHub [suppresses workflow triggering for events created with `GITHUB_TOKEN`](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).

Run history confirms it — the last `release`-triggered Docker build was **v7.2.5 (2026-06-26)**; everything since was manual. **v6.6.0 and v7.4.0 have no image on Docker Hub.**

## Changes

**`release-build.yml`**
- Adds an explicit `gh workflow run docker-publish.yml` step after the release is created. `workflow_dispatch` and `repository_dispatch` are the documented exceptions to the `GITHUB_TOKEN` restriction, so this works with the default token — it just needs `actions: write`.
- Dispatched on `github.base_ref` (the release branch) with the tag passed as an input, to avoid the branch/tag name ambiguity of `v<version>`.

**`docker-publish.yml`**
- New `tag` input: the release tag to build. Falls back to `github.ref_name` when the workflow is run on the tag itself, so dispatching on a tag keeps working. Validated, with a clear error if it is not a release tag.
- New `latest` input (default `false`) and a corrected `latest` condition. Previously `enable=${{ ! github.event.release.prerelease }}` evaluated to **true** on any manual run, because `github.event.release` is empty there — that is how the manual v7.5.0 run came to repoint `predic8/membrane:latest`. Now `latest` follows the release for a `release` event and the input for a manual run.
- Checkout and the release download both use the resolved tag (`refs/tags/...`), so a build dispatched from a branch still builds the right release.
- Drops the `bhowell2/github-substring-action` dependency; the version is derived in the resolve step.

## Notes

- `release-build.yml` hardcodes `prerelease: true`, so a release-triggered run still never pushes `latest` — unchanged behaviour. Pushing `latest` stays a deliberate manual dispatch with `latest=true`.
- **master needs the same change** — it has the identical `github.token` + `release` trigger combination.
