### PR TITLE
Trigger Docker image build explicitly after a release (port of #3213)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           set -euo pipefail
           RELEASE_TAG="${INPUT_TAG:-$REF_NAME}"
-          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::'$RELEASE_TAG' is not a release tag. Dispatch this workflow on the tag, or pass the 'tag' input (e.g. v7.4.0)."
             exit 1
           fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,18 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-    
+    inputs:
+      tag:
+        description: "Release tag to build, e.g. v7.4.0. Required unless the workflow is run on the tag itself."
+        type: string
+        required: false
+        default: ''
+      latest:
+        description: "Also push the 'latest' Docker tag"
+        type: boolean
+        required: false
+        default: false
+
 env:
   REGISTRY: docker.io
   IMAGE_NAME: predic8/membrane
@@ -29,16 +40,30 @@ jobs:
     steps:
 #      - name: Dump context
 #        uses: crazy-max/ghaction-dump-context@v2
-      - uses: bhowell2/github-substring-action@1.0.2
+
+      # The release tag can come from the 'tag' input (when dispatched from a
+      # branch, e.g. by the Create Release workflow) or from the ref the
+      # workflow runs on (when triggered by a release, or dispatched on a tag).
+      - name: Resolve release tag
         id: release_version
-        with:
-          value: "${{ github.ref_name }}"
-          index_of_str: "v"
-          output_name: tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          RELEASE_TAG="${INPUT_TAG:-$REF_NAME}"
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+[.][0-9]+[.][0-9]+ ]]; then
+            echo "::error::'$RELEASE_TAG' is not a release tag. Dispatch this workflow on the tag, or pass the 'tag' input (e.g. v7.4.0)."
+            exit 1
+          fi
+          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          echo "tag=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
+          echo "Building Docker image for release $RELEASE_TAG"
+
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.ref }}
+          ref: refs/tags/${{ steps.release_version.outputs.release_tag }}
           persist-credentials: false
 
       # Install the cosign tool except on PR
@@ -69,21 +94,29 @@ jobs:
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
+      # 'latest' follows the release for a real release, and the 'latest' input
+      # for a manual run. Without the explicit event check a manual run would
+      # always push 'latest', because github.event.release is empty there.
+      # 'flavor: latest=false' is required as well: metadata-action defaults to
+      # 'latest=auto', which adds 'latest' for any semver version regardless of
+      # the enable= condition on the raw tag below.
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          flavor: |
+            latest=false
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest,enable=${{ ! github.event.release.prerelease }}
+            type=semver,pattern={{version}},value=${{ steps.release_version.outputs.release_tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.release_version.outputs.release_tag }}
+            type=semver,pattern={{major}},value=${{ steps.release_version.outputs.release_tag }}
+            type=raw,value=latest,enable=${{ (github.event_name == 'workflow_dispatch' && inputs.latest) || (github.event_name == 'release' && ! github.event.release.prerelease) }}
             type=sha,enable=false
 
       - uses: robinraju/release-downloader@v1.8
         with:
-          tag: "${{ github.ref_name }}"
+          tag: "${{ steps.release_version.outputs.release_tag }}"
           fileName: "membrane-api-gateway-${{ steps.release_version.outputs.tag }}.zip"
           out-file-path: "distribution/docker/release-bin"
           extract: false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           set -euo pipefail
           RELEASE_TAG="${INPUT_TAG:-$REF_NAME}"
-          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+[.][0-9]+[.][0-9]+ ]]; then
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             echo "::error::'$RELEASE_TAG' is not a release tag. Dispatch this workflow on the tag, or pass the 'tag' input (e.g. v7.4.0)."
             exit 1
           fi

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -13,8 +13,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  # Needed to start the 'Build Docker Image' workflow via workflow_dispatch.
-  actions: write
 
 jobs:
   build-release:
@@ -103,13 +101,34 @@ jobs:
           artifacts: "core/target/classes/com/predic8/membrane/core/config/json/membrane.schema.json,distribution/target/membrane-api-gateway-${{ steps.get_version.outputs.VERSION }}.zip,distribution/target/membrane-api-gateway-${{ steps.get_version.outputs.VERSION }}.zip.asc"
           token: ${{ github.token }}
 
-      # A release created with the default GITHUB_TOKEN does not fire the
-      # 'release: published' event: GitHub suppresses workflow triggering for
-      # events created by GITHUB_TOKEN, so the Docker build never started.
-      # workflow_dispatch is explicitly exempt from that restriction, so the
-      # build is kicked off here instead. It is dispatched on the base branch
-      # (the tag has no workflow file of its own for older releases) and gets
-      # the release tag passed as an input.
+  trigger-website:
+    needs: build-release
+    uses: ./.github/workflows/trigger-website-pipeline.yml
+    with:
+      version: ${{ needs.build-release.outputs.version }}
+    secrets: inherit
+
+  # A release created with the default GITHUB_TOKEN does not fire the
+  # 'release: published' event: GitHub suppresses workflow triggering for
+  # events created by GITHUB_TOKEN, so the Docker build never started.
+  # workflow_dispatch is explicitly exempt from that restriction, so the build
+  # is kicked off here instead.
+  #
+  # Dispatched on the base branch rather than on the tag, because release-pr.yml
+  # creates a branch AND a tag named v<version>, so '--ref v<version>' would be
+  # ambiguous; the tag is passed as an input instead.
+  #
+  # Its own job on purpose: a dispatch that fails -- against a branch whose
+  # docker-publish.yml predates the 'tag' input the API rejects it with 422 --
+  # must not fail the release itself or block the jobs beside it. It also keeps
+  # 'actions: write' off the Maven steps in build-release.
+  trigger-docker:
+    needs: build-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
       - name: Trigger Docker image build
         shell: bash
         env:
@@ -124,10 +143,3 @@ jobs:
             --ref "$BASE_REF" \
             --field tag="$RELEASE_TAG" \
             --field latest=false
-
-  trigger-website:
-    needs: build-release
-    uses: ./.github/workflows/trigger-website-pipeline.yml
-    with:
-      version: ${{ needs.build-release.outputs.version }}
-    secrets: inherit

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -13,6 +13,8 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # Needed to start the 'Build Docker Image' workflow via workflow_dispatch.
+  actions: write
 
 jobs:
   build-release:
@@ -100,6 +102,28 @@ jobs:
           bodyFile: "distribution/release-notes/${{ steps.get_version.outputs.VERSION }}.md"
           artifacts: "core/target/classes/com/predic8/membrane/core/config/json/membrane.schema.json,distribution/target/membrane-api-gateway-${{ steps.get_version.outputs.VERSION }}.zip,distribution/target/membrane-api-gateway-${{ steps.get_version.outputs.VERSION }}.zip.asc"
           token: ${{ github.token }}
+
+      # A release created with the default GITHUB_TOKEN does not fire the
+      # 'release: published' event: GitHub suppresses workflow triggering for
+      # events created by GITHUB_TOKEN, so the Docker build never started.
+      # workflow_dispatch is explicitly exempt from that restriction, so the
+      # build is kicked off here instead. It is dispatched on the base branch
+      # (the tag has no workflow file of its own for older releases) and gets
+      # the release tag passed as an input.
+      - name: Trigger Docker image build
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BASE_REF: ${{ github.base_ref }}
+          RELEASE_TAG: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          gh workflow run docker-publish.yml \
+            --repo "$REPO" \
+            --ref "$BASE_REF" \
+            --field tag="$RELEASE_TAG" \
+            --field latest=false
 
   trigger-website:
     needs: build-release


### PR DESCRIPTION
Port of #3213 to `master`. Same root cause, same fix — `master` carries the identical `github.token` + `release`-trigger combination, which is why **v7.4.0 has no image on Docker Hub** either.

## Problem

`Build Docker Image` only triggers on `release: [published]`. Since #3085 switched the release creation in `release-build.yml` from `secrets.PAT` to `${{ github.token }}`, that event no longer starts a workflow: GitHub [suppresses workflow triggering for events created with `GITHUB_TOKEN`](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).

The last `release`-triggered Docker build was **v7.2.5 (2026-06-26)**; v7.3.1 and v7.5.0 were built by manual dispatch, and v7.4.0 was never built at all.

## Changes

**`release-build.yml`**
- Adds an explicit `gh workflow run docker-publish.yml` step after the release is created. `workflow_dispatch` and `repository_dispatch` are the documented exceptions to the `GITHUB_TOKEN` restriction, so this works with the default token — it just needs `actions: write`.
- Dispatched on `github.base_ref` with the tag passed as an input, to avoid the branch/tag name ambiguity of `v<version>` (`release-pr.yml` creates both).

**`docker-publish.yml`**
- New `tag` input, falling back to `github.ref_name` so dispatching on a tag keeps working; validated, with a clear error otherwise. Checkout and the release download both use the resolved `refs/tags/<tag>`, so a build dispatched from a branch still builds the right release.
- New `latest` input (default `false`) plus two fixes to the `latest` tag:
  - `flavor: latest=false`. `docker/metadata-action` defaults to `latest=auto`, which appends `latest` for **any** semver version independently of the `enable=` condition on the raw entry — so that condition was dead code, and every release build pushed `latest`, including maintenance releases from older branches.
  - `enable=${{ ! github.event.release.prerelease }}` evaluates to **true** on a manual run, because `github.event.release` is empty there. Now `latest` follows the release for a `release` event and the input for a manual run.
- Drops the `bhowell2/github-substring-action` dependency; the version is derived in the resolve step.

## Notes

- `release-build.yml` hardcodes `prerelease: true`, so a release-triggered build never publishes `latest`. Pushing `latest` is a deliberate dispatch with `latest=true` — which is what already happened for v7.5.0.
- Merge #3213 first, or at least don't merge this alone and then cut a release from `6.X`: the dispatch step needs `docker-publish.yml` with the `tag` input present on the branch it dispatches to.
- v6.6.0 has meanwhile been built and pushed manually ([run 34100932880](https://github.com/membrane/api-gateway/actions/runs/34100932880)). **v7.4.0 has not** — decide whether it is still worth publishing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Manual Docker publishing supports specifying a release tag.
  - Manual publishing can optionally apply the `latest` image tag.
  - Release builds automatically trigger the corresponding Docker image build.

- **Bug Fixes**
  - Docker image builds and publishing now follow the release workflow reliably.
  - Image tags and release downloads consistently use the selected release version.
  - Prerelease versions no longer receive the `latest` tag automatically.
  - Release tags are validated before Docker publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->