### PR TITLE
Move every workflow action off the Node 16 runtime

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v6
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -28,7 +28,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v6
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Setup Java JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v6
       with:
         distribution: 'temurin'
         java-version: 21
@@ -46,7 +46,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
 #    - name: Autobuild
-#      uses: github/codeql-action/autobuild@v2
+#      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           set -euo pipefail
           RELEASE_TAG="${INPUT_TAG:-$REF_NAME}"
-          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::'$RELEASE_TAG' is not a release tag. Dispatch this workflow on the tag, or pass the 'tag' input (e.g. v7.4.0)."
             exit 1
           fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,18 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-    
+    inputs:
+      tag:
+        description: "Release tag to build, e.g. v7.4.0. Required unless the workflow is run on the tag itself."
+        type: string
+        required: false
+        default: ''
+      latest:
+        description: "Also push the 'latest' Docker tag"
+        type: boolean
+        required: false
+        default: false
+
 env:
   REGISTRY: docker.io
   IMAGE_NAME: predic8/membrane
@@ -29,16 +40,30 @@ jobs:
     steps:
 #      - name: Dump context
 #        uses: crazy-max/ghaction-dump-context@v2
-      - uses: bhowell2/github-substring-action@1.0.2
+
+      # The release tag can come from the 'tag' input (when dispatched from a
+      # branch, e.g. by the Create Release workflow) or from the ref the
+      # workflow runs on (when triggered by a release, or dispatched on a tag).
+      - name: Resolve release tag
         id: release_version
-        with:
-          value: "${{ github.ref_name }}"
-          index_of_str: "v"
-          output_name: tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          RELEASE_TAG="${INPUT_TAG:-$REF_NAME}"
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+[.][0-9]+[.][0-9]+ ]]; then
+            echo "::error::'$RELEASE_TAG' is not a release tag. Dispatch this workflow on the tag, or pass the 'tag' input (e.g. v7.4.0)."
+            exit 1
+          fi
+          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          echo "tag=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
+          echo "Building Docker image for release $RELEASE_TAG"
+
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.ref }}
+          ref: refs/tags/${{ steps.release_version.outputs.release_tag }}
           persist-credentials: false
 
       # Install the cosign tool except on PR
@@ -69,21 +94,29 @@ jobs:
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
+      # 'latest' follows the release for a real release, and the 'latest' input
+      # for a manual run. Without the explicit event check a manual run would
+      # always push 'latest', because github.event.release is empty there.
+      # 'flavor: latest=false' is required as well: metadata-action defaults to
+      # 'latest=auto', which adds 'latest' for any semver version regardless of
+      # the enable= condition on the raw tag below.
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          flavor: |
+            latest=false
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest,enable=${{ ! github.event.release.prerelease }}
+            type=semver,pattern={{version}},value=${{ steps.release_version.outputs.release_tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.release_version.outputs.release_tag }}
+            type=semver,pattern={{major}},value=${{ steps.release_version.outputs.release_tag }}
+            type=raw,value=latest,enable=${{ (github.event_name == 'workflow_dispatch' && inputs.latest) || (github.event_name == 'release' && ! github.event.release.prerelease) }}
             type=sha,enable=false
 
       - uses: robinraju/release-downloader@v1.8
         with:
-          tag: "${{ github.ref_name }}"
+          tag: "${{ steps.release_version.outputs.release_tag }}"
           fileName: "membrane-api-gateway-${{ steps.release_version.outputs.tag }}.zip"
           out-file-path: "distribution/docker/release-bin"
           extract: false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           set -euo pipefail
           RELEASE_TAG="${INPUT_TAG:-$REF_NAME}"
-          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+[.][0-9]+[.][0-9]+ ]]; then
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             echo "::error::'$RELEASE_TAG' is not a release tag. Dispatch this workflow on the tag, or pass the 'tag' input (e.g. v7.4.0)."
             exit 1
           fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -73,20 +73,19 @@ jobs:
         uses: sigstore/cosign-installer@v3.4.0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
         # possible optimization
 #        with:
 #          platforms: ${{ matrix.platform }}
 
-      # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+        uses: docker/setup-buildx-action@v4
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKER_HUB_USER }}
@@ -102,7 +101,7 @@ jobs:
       # the enable= condition on the raw tag below.
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6
         with:
           images: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
           flavor: |
@@ -114,7 +113,7 @@ jobs:
             type=raw,value=latest,enable=${{ (github.event_name == 'workflow_dispatch' && inputs.latest) || (github.event_name == 'release' && ! github.event.release.prerelease) }}
             type=sha,enable=false
 
-      - uses: robinraju/release-downloader@v1.8
+      - uses: robinraju/release-downloader@v1.13
         with:
           tag: "${{ steps.release_version.outputs.release_tag }}"
           fileName: "membrane-api-gateway-${{ steps.release_version.outputs.tag }}.zip"
@@ -126,7 +125,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: distribution/docker
           platforms: linux/amd64,linux/arm64
@@ -151,7 +150,7 @@ jobs:
         run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign -y {}@${{ steps.build-and-push.outputs.digest }}
 
       - name: Docker Hub Description
-        uses: peter-evans/dockerhub-description@v3
+        uses: peter-evans/dockerhub-description@v5
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_PASS }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -12,7 +12,7 @@ jobs:
           ref: ${{ github.ref }}
           persist-credentials: false
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v6
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -27,11 +27,11 @@ jobs:
         id: get_version
         run: echo '${{ github.head_ref }}' | sed 's/v/::set-output name=VERSION::/'
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v6
         with:
           java-version: '21'
           distribution: 'temurin'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
       - id: compile-membrane
@@ -61,13 +61,13 @@ jobs:
           cd ..
       - name: Create Pull Request for next Snapshot
         id: cpr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "Snapshot version"
           title: "Snapshot version"
           author: "github-actions <github-actions@github.com>"
           body: "Update all project `pom.xml` and related files to post-${{ steps.get_version.outputs.VERSION }} snapshot version"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
       - id: install-secret-key

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -13,6 +13,8 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # Needed to start the 'Build Docker Image' workflow via workflow_dispatch.
+  actions: write
 
 jobs:
   build-release:
@@ -100,6 +102,28 @@ jobs:
           bodyFile: "distribution/release-notes/${{ steps.get_version.outputs.VERSION }}.md"
           artifacts: "core/target/classes/com/predic8/membrane/core/config/json/membrane.schema.json,distribution/target/membrane-api-gateway-${{ steps.get_version.outputs.VERSION }}.zip,distribution/target/membrane-api-gateway-${{ steps.get_version.outputs.VERSION }}.zip.asc"
           token: ${{ github.token }}
+
+      # A release created with the default GITHUB_TOKEN does not fire the
+      # 'release: published' event: GitHub suppresses workflow triggering for
+      # events created by GITHUB_TOKEN, so the Docker build never started.
+      # workflow_dispatch is explicitly exempt from that restriction, so the
+      # build is kicked off here instead. It is dispatched on the base branch
+      # (the tag has no workflow file of its own for older releases) and gets
+      # the release tag passed as an input.
+      - name: Trigger Docker image build
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BASE_REF: ${{ github.base_ref }}
+          RELEASE_TAG: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          gh workflow run docker-publish.yml \
+            --repo "$REPO" \
+            --ref "$BASE_REF" \
+            --field tag="$RELEASE_TAG" \
+            --field latest=false
 
   trigger-website:
     needs: build-release

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v6
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/update-docker-latest.yml
+++ b/.github/workflows/update-docker-latest.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKER_HUB_USER }}


### PR DESCRIPTION
Follow-up to the review on #3214, where CodeRabbit flagged `docker/metadata-action@v4` for requesting the removed Node 16 runtime. The finding is correct, but that action is not a special case — **every action in these workflows except `actions/checkout` was on node16**, so bumping one of them buys nothing.

> Stacked on #3214 to avoid conflicts in `docker-publish.yml`. Merge that one first; this retargets to `master` automatically.

## Changes

| action | before | after | runtime before → after |
|---|---|---|---|
| `actions/setup-java` | `v3` ×6 | `v6` | node16 → node24 |
| `actions/checkout` | `v3` ×2 | `v7` | node16 → node24 |
| `docker/setup-qemu-action` | `v2` | `v4` | node16 → node24 |
| `docker/setup-buildx-action` | `79abd3f` (2022 SHA) | `v4` | node16 → node24 |
| `docker/login-action` | `28218f9` (2022 SHA) | `v4` | node16 → node24 |
| `docker/metadata-action` | `v4` | `v6` | node16 → node24 |
| `robinraju/release-downloader` | `v1.8` | `v1.13` | node16 → node24 |
| `docker/build-push-action` | `v4` | `v7` | node16 → node24 |
| `peter-evans/dockerhub-description` | `v3` | `v5` | node16 → node24 |

Plus three version alignments, where the same action was pinned to two different majors across the repo:

| action | before | after | where |
|---|---|---|---|
| `peter-evans/create-pull-request` | `v7` | `v8` | `release-build.yml` (`release-pr.yml` was already `v8`) |
| `github/codeql-action/autobuild` | `v2` | `v3` | `codeql.yml`, commented out, next to `init@v3` / `analyze@v3` |
| `docker/setup-buildx-action`, `docker/login-action` | `v3` | `v4` | `update-docker-latest.yml` |

After this, every action resolves to node24 or is a composite action, except `github/codeql-action/*` which is node20 at its current major — nothing to bump there.

## Compatibility checks

Rather than bumping on version numbers alone, I checked each target major's `action.yml` against what these workflows actually pass:

- `docker/metadata-action@v6` — keeps `images`, `flavor`, `tags`; `value=` on `type=semver` is still documented and supported, which #3214 relies on.
- `docker/build-push-action@v7` — keeps `context`, `platforms`, `push`, `tags`, `labels`, `cache-from`, `cache-to`, and still exposes the `digest` output that the cosign signing step consumes.
- `peter-evans/dockerhub-description@v5` — keeps `username`, `password`, `repository`, `readme-filepath`.
- `robinraju/release-downloader@v1.13` — keeps `tag`, `fileName`, `out-file-path`, `extract`.
- `actions/setup-java@v6` — keeps `java-version`, `distribution`, `server-id`, `server-username`, `server-password`.

## Worth a maintainer's eye

- **The SHA pins are gone.** `setup-buildx-action` and `login-action` were pinned to 2022 commits and are now on version tags, like every other action here. That is a deliberate move from a stronger to a weaker supply-chain guarantee — say the word and I will re-pin all of them to SHAs instead. The buildx pin carried a `# Workaround: docker/build-push-action#461` comment; that issue is long closed, so the comment went with it.
- **`dockerhub-description@v5`** documents `password` as a Docker Hub password *or* a PAT with `read/write/delete` scope. `DOCKER_HUB_PASS` already has push rights, so this should be fine, but it is the one credential-shaped change in here.
- `build-and-test.yml` and `codeql.yml` are exercised by this PR's own checks. The release workflows are not — they only run on a release, so those bumps are verified by inspection, not execution.
- **`6.X` needs the same sweep** if releases continue from it, and 6.6.0 shipped from there ten days ago.
