### PR TITLE
Publish the release tag to Maven Central, not whatever ref was dispatched

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           set -euo pipefail
           RELEASE_TAG="${INPUT_TAG:-$REF_NAME}"
-          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::'$RELEASE_TAG' is not a release tag. Dispatch this workflow on the tag, or pass the 'tag' input (e.g. v7.4.0)."
             exit 1
           fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,18 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-    
+    inputs:
+      tag:
+        description: "Release tag to build, e.g. v7.4.0. Required unless the workflow is run on the tag itself."
+        type: string
+        required: false
+        default: ''
+      latest:
+        description: "Also push the 'latest' Docker tag"
+        type: boolean
+        required: false
+        default: false
+
 env:
   REGISTRY: docker.io
   IMAGE_NAME: predic8/membrane
@@ -29,16 +40,30 @@ jobs:
     steps:
 #      - name: Dump context
 #        uses: crazy-max/ghaction-dump-context@v2
-      - uses: bhowell2/github-substring-action@1.0.2
+
+      # The release tag can come from the 'tag' input (when dispatched from a
+      # branch, e.g. by the Create Release workflow) or from the ref the
+      # workflow runs on (when triggered by a release, or dispatched on a tag).
+      - name: Resolve release tag
         id: release_version
-        with:
-          value: "${{ github.ref_name }}"
-          index_of_str: "v"
-          output_name: tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          RELEASE_TAG="${INPUT_TAG:-$REF_NAME}"
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+[.][0-9]+[.][0-9]+ ]]; then
+            echo "::error::'$RELEASE_TAG' is not a release tag. Dispatch this workflow on the tag, or pass the 'tag' input (e.g. v7.4.0)."
+            exit 1
+          fi
+          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          echo "tag=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
+          echo "Building Docker image for release $RELEASE_TAG"
+
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.ref }}
+          ref: refs/tags/${{ steps.release_version.outputs.release_tag }}
           persist-credentials: false
 
       # Install the cosign tool except on PR
@@ -69,21 +94,29 @@ jobs:
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
+      # 'latest' follows the release for a real release, and the 'latest' input
+      # for a manual run. Without the explicit event check a manual run would
+      # always push 'latest', because github.event.release is empty there.
+      # 'flavor: latest=false' is required as well: metadata-action defaults to
+      # 'latest=auto', which adds 'latest' for any semver version regardless of
+      # the enable= condition on the raw tag below.
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          flavor: |
+            latest=false
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest,enable=${{ ! github.event.release.prerelease }}
+            type=semver,pattern={{version}},value=${{ steps.release_version.outputs.release_tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.release_version.outputs.release_tag }}
+            type=semver,pattern={{major}},value=${{ steps.release_version.outputs.release_tag }}
+            type=raw,value=latest,enable=${{ (github.event_name == 'workflow_dispatch' && inputs.latest) || (github.event_name == 'release' && ! github.event.release.prerelease) }}
             type=sha,enable=false
 
       - uses: robinraju/release-downloader@v1.8
         with:
-          tag: "${{ github.ref_name }}"
+          tag: "${{ steps.release_version.outputs.release_tag }}"
           fileName: "membrane-api-gateway-${{ steps.release_version.outputs.tag }}.zip"
           out-file-path: "distribution/docker/release-bin"
           extract: false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           set -euo pipefail
           RELEASE_TAG="${INPUT_TAG:-$REF_NAME}"
-          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+[.][0-9]+[.][0-9]+ ]]; then
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             echo "::error::'$RELEASE_TAG' is not a release tag. Dispatch this workflow on the tag, or pass the 'tag' input (e.g. v7.4.0)."
             exit 1
           fi

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -3,13 +3,39 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish, e.g. v7.4.0. Required unless the workflow is run on the tag itself."
+        type: string
+        required: false
+        default: ''
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      # Without this the workflow deploys whatever ${{ github.ref }} points at,
+      # so dispatching it on a branch deploys that branch's SNAPSHOT to Maven
+      # Central instead of the release. Resolving an explicit tag also avoids
+      # the ambiguity of release-pr.yml creating a branch AND a tag named
+      # v<version>.
+      - name: Resolve release tag
+        id: release_version
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          RELEASE_TAG="${INPUT_TAG:-$REF_NAME}"
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::'$RELEASE_TAG' is not a release tag. Dispatch this workflow on the tag, or pass the 'tag' input (e.g. v7.4.0)."
+            exit 1
+          fi
+          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          echo "Publishing $RELEASE_TAG to Maven Central"
+
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.ref }}
+          ref: refs/tags/${{ steps.release_version.outputs.release_tag }}
           persist-credentials: false
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v3

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -13,6 +13,8 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # Needed to start the 'Build Docker Image' workflow via workflow_dispatch.
+  actions: write
 
 jobs:
   build-release:
@@ -100,6 +102,28 @@ jobs:
           bodyFile: "distribution/release-notes/${{ steps.get_version.outputs.VERSION }}.md"
           artifacts: "core/target/classes/com/predic8/membrane/core/config/json/membrane.schema.json,distribution/target/membrane-api-gateway-${{ steps.get_version.outputs.VERSION }}.zip,distribution/target/membrane-api-gateway-${{ steps.get_version.outputs.VERSION }}.zip.asc"
           token: ${{ github.token }}
+
+      # A release created with the default GITHUB_TOKEN does not fire the
+      # 'release: published' event: GitHub suppresses workflow triggering for
+      # events created by GITHUB_TOKEN, so the Docker build never started.
+      # workflow_dispatch is explicitly exempt from that restriction, so the
+      # build is kicked off here instead. It is dispatched on the base branch
+      # (the tag has no workflow file of its own for older releases) and gets
+      # the release tag passed as an input.
+      - name: Trigger Docker image build
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BASE_REF: ${{ github.base_ref }}
+          RELEASE_TAG: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          gh workflow run docker-publish.yml \
+            --repo "$REPO" \
+            --ref "$BASE_REF" \
+            --field tag="$RELEASE_TAG" \
+            --field latest=false
 
   trigger-website:
     needs: build-release

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -13,8 +13,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  # Needed to start the 'Build Docker Image' workflow via workflow_dispatch.
-  actions: write
 
 jobs:
   build-release:
@@ -102,28 +100,6 @@ jobs:
           bodyFile: "distribution/release-notes/${{ steps.get_version.outputs.VERSION }}.md"
           artifacts: "core/target/classes/com/predic8/membrane/core/config/json/membrane.schema.json,distribution/target/membrane-api-gateway-${{ steps.get_version.outputs.VERSION }}.zip,distribution/target/membrane-api-gateway-${{ steps.get_version.outputs.VERSION }}.zip.asc"
           token: ${{ github.token }}
-
-      # A release created with the default GITHUB_TOKEN does not fire the
-      # 'release: published' event: GitHub suppresses workflow triggering for
-      # events created by GITHUB_TOKEN, so the Docker build never started.
-      # workflow_dispatch is explicitly exempt from that restriction, so the
-      # build is kicked off here instead. It is dispatched on the base branch
-      # (the tag has no workflow file of its own for older releases) and gets
-      # the release tag passed as an input.
-      - name: Trigger Docker image build
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          BASE_REF: ${{ github.base_ref }}
-          RELEASE_TAG: ${{ github.head_ref }}
-        run: |
-          set -euo pipefail
-          gh workflow run docker-publish.yml \
-            --repo "$REPO" \
-            --ref "$BASE_REF" \
-            --field tag="$RELEASE_TAG" \
-            --field latest=false
 
   trigger-website:
     needs: build-release


### PR DESCRIPTION
Follow-up to the `maven-publish.yml` finding in the review on #3214.

> Stacked on #3214 to avoid a conflict in `release-build.yml`. Merge that one first; this retargets to `master` automatically.

## The bug

`maven-publish.yml` checks out `${{ github.ref }}` and then runs `mvn deploy`. Every Maven Central release for months has gone out via manual `workflow_dispatch`, and **dispatching this workflow on a branch deploys that branch's SNAPSHOT to Central**, not the release. Two of the runs in the history are exactly that mistake being caught in time:

```
cancelled   master   workflow_dispatch   2026-07-13T21:04:13Z   22s
cancelled   master   workflow_dispatch   2026-06-30T09:47:32Z   53s
```

`master` is currently `7.5.1-SNAPSHOT`.

## The fix

A `tag` input resolved exactly as in #3214 — falling back to `github.ref_name`, validated against a complete SemVer version — and `ref: refs/tags/<tag>` on the checkout. An explicit tag ref also removes the latent ambiguity of `release-pr.yml` creating both a branch **and** a tag named `v<version>`.

## What this does *not* do, and why

It does not add a `gh workflow run maven-publish.yml` step to `release-build.yml` alongside the Docker one. That would be a two-line addition, and I left it out deliberately:

**1. The release-triggered runs were already failing, for an unrelated reason.** Every one of them:

| tag | date | result |
|---|---|---|
| v7.2.3 | 2026-06-10 | failure |
| v7.2.4 | 2026-06-25 | failure |
| v6.5.3 | 2026-06-26 | failure |
| v7.2.5 | 2026-06-26 | failure |

all ending in:

```
[ERROR] Unable to upload bundle for deployment: Deployment
[ERROR] Failed to execute goal org.sonatype.central:central-publishing-maven-plugin:0.8.0:publish
        (injected-central-publishing) on project service-proxy-war:
        ... Deployment failed while publishing
```

Every successful publish since has been a manual dispatch days later — a retry of that upload. So the suppressed trigger is not what made Central publishing manual; this upload failure is. Wiring in the dispatch converts a silent no-op into an automatic failure, which is an improvement in visibility but not a fix, and it should be a deliberate choice rather than something smuggled in here.

**2. Publishing to Central is irreversible.** A release cannot be unpublished. Moving `mvn deploy` from human-triggered to automatic widens the blast radius of any future bug in the release pipeline, so it deserves its own decision.

If you do want it automatic, it is this, next to the Docker dispatch in `release-build.yml`:

```yaml
      - name: Trigger Maven Central publish
        shell: bash
        env:
          GH_TOKEN: ${{ github.token }}
          REPO: ${{ github.repository }}
          BASE_REF: ${{ github.base_ref }}
          RELEASE_TAG: ${{ github.head_ref }}
        run: |
          set -euo pipefail
          gh workflow run maven-publish.yml \
            --repo "$REPO" \
            --ref "$BASE_REF" \
            --field tag="$RELEASE_TAG"
```

Say the word and I will add it — but the `central-publishing-maven-plugin` failure is worth understanding first, otherwise it just fails on a schedule.

## Missing from Central

For the record, `repo1.maven.org/maven2/org/membrane-soa/service-proxy-core` currently lists:

```
6.5.3  6.5.4  7.2.5  7.3.1  7.5.0
```

**7.4.0 and 6.6.0 were never published.** Once this is merged, the manual path is safe: `gh workflow run maven-publish.yml --ref master -f tag=v7.4.0`.

`6.X` needs the same change if 6.6.0 is to be published from there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Maven Central publishing now validates and uses the intended release tag, preventing branch SNAPSHOT builds from being deployed accidentally.
  * Docker image builds are now triggered reliably after a release is published.
  * Release automation now uses the selected release version consistently, reducing the risk of publishing or building artifacts from unintended source code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->