### PR TITLE
fix(cli): harden option parsing, validation and help across all subcommands

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/cli/CliCommand.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/CliCommand.java
@@ -19,9 +19,16 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 
+import static org.apache.commons.cli.Option.builder;
 import static org.apache.commons.lang3.StringUtils.trim;
 
 public class CliCommand {
+
+    /**
+     * Registered on every command, so that no command can forget to support {@code -h}.
+     */
+    private static final Option HELP = builder("h").longOpt("help").desc("Display this text").build();
+
     private final String name;
     private final String description;
     private final List<Pair<String, String>> examples;
@@ -34,7 +41,7 @@ public class CliCommand {
         this.name = name;
         this.description = description;
         this.subcommands = new LinkedHashMap<>();
-        this.options = new Options();
+        this.options = new Options().addOption(HELP);
         this.examples = new ArrayList<>();
     }
 
@@ -66,10 +73,24 @@ public class CliCommand {
         try {
             commandLine = new DefaultParser().parse(options, args, true);
         } catch (MissingOptionException e) {
-            throw new MissingRequiredOptionException(e.getMessage(), this);
+            // Asking for help must work even when required options are missing.
+            commandLine = new DefaultParser().parse(optionsWithoutRequired(), args, true);
+            if (!isOptionSet(HELP.getOpt())) {
+                throw new MissingRequiredOptionException(e.getMessage(), this);
+            }
         }
 
         return this;
+    }
+
+    private Options optionsWithoutRequired() {
+        Options relaxed = new Options();
+        for (Option option : options.getOptions()) {
+            Option copy = (Option) option.clone();
+            copy.setRequired(false);
+            relaxed.addOption(copy);
+        }
+        return relaxed;
     }
 
     private static boolean isCommand(String[] args) {
@@ -141,6 +162,7 @@ public class CliCommand {
 
     public void setOptions(Options options) {
         this.options = options;
+        this.options.addOption(HELP);
     }
 
     public boolean isOptionSet(String opt) {

--- a/core/src/main/java/com/predic8/membrane/core/cli/CliCommand.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/CliCommand.java
@@ -17,17 +17,16 @@ import com.predic8.membrane.core.util.Pair;
 import org.apache.commons.cli.*;
 import org.jetbrains.annotations.NotNull;
 
+import java.math.BigInteger;
 import java.util.*;
 
+import static java.math.BigInteger.valueOf;
 import static org.apache.commons.cli.Option.builder;
 import static org.apache.commons.lang3.StringUtils.trim;
 
 public class CliCommand {
 
-    /**
-     * Registered on every command, so that no command can forget to support {@code -h}.
-     */
-    private static final Option HELP = builder("h").longOpt("help").desc("Display this text").build();
+    private static final String HELP_OPTION = "h";
 
     private final String name;
     private final String description;
@@ -41,7 +40,7 @@ public class CliCommand {
         this.name = name;
         this.description = description;
         this.subcommands = new LinkedHashMap<>();
-        this.options = new Options().addOption(HELP);
+        this.options = withHelp(new Options());
         this.examples = new ArrayList<>();
     }
 
@@ -67,7 +66,7 @@ public class CliCommand {
             if (hasSubcommand(cmd)) {
                 return subcommands.get(cmd).parse(Arrays.copyOfRange(args, 1, args.length));
             }
-            throw new ParseException("Unknown command: " + cmd);
+            throw new CommandParseException("Unknown command: " + cmd, this);
         }
 
         try {
@@ -77,7 +76,7 @@ public class CliCommand {
         } catch (MissingOptionException e) {
             // Asking for help must work even when required options are missing.
             commandLine = new DefaultParser().parse(optionsWithoutRequired(), args);
-            if (!isOptionSet(HELP.getOpt())) {
+            if (!isOptionSet(HELP_OPTION)) {
                 throw new MissingRequiredOptionException(e.getMessage(), this);
             }
         }
@@ -95,6 +94,16 @@ public class CliCommand {
         if (!leftovers.isEmpty()) {
             throw new CommandParseException("Unexpected argument: " + String.join(" ", leftovers), this);
         }
+    }
+
+    /**
+     * Returns a copy of {@code source} that also carries {@code -h}, so that no command can forget
+     * to support it. A copy, because {@code source} may be owned - and shared - by the caller.
+     */
+    private static Options withHelp(Options source) {
+        Options copy = new Options().addOption(builder(HELP_OPTION).longOpt("help").desc("Display this text").build());
+        source.getOptions().forEach(copy::addOption);
+        return copy;
     }
 
     private Options optionsWithoutRequired() {
@@ -175,8 +184,7 @@ public class CliCommand {
     }
 
     public void setOptions(Options options) {
-        this.options = options;
-        this.options.addOption(HELP);
+        this.options = withHelp(options);
     }
 
     public boolean isOptionSet(String opt) {
@@ -202,20 +210,27 @@ public class CliCommand {
      * @throws InvalidOptionValueException if the value is not a number or outside minimum..maximum
      */
     public int getIntOptionValue(String option, int defaultValue, int minimum, int maximum) {
-        String value = getTrimmedOptionValue(option);
+        final String value = getTrimmedOptionValue(option);
         if (value == null) {
             return defaultValue;
         }
-        long parsed;
+        final BigInteger parsed = parseNumber(option, value);
+        if (parsed.compareTo(valueOf(minimum)) < 0 || parsed.compareTo(valueOf(maximum)) > 0) {
+            throw new InvalidOptionValueException("Invalid value for -%s: %d must be between %d and %d.".formatted(option, parsed, minimum, maximum));
+        }
+        return parsed.intValueExact();
+    }
+
+    /**
+     * Parses without a width limit, so that a value too large for an {@code int} is reported as out
+     * of range rather than as not being a number.
+     */
+    private static BigInteger parseNumber(String option, String value) {
         try {
-            parsed = Long.parseLong(value);
+            return new BigInteger(value);
         } catch (NumberFormatException e) {
             throw new InvalidOptionValueException("Invalid value for -%s: '%s' is not a number.".formatted(option, value));
         }
-        if (parsed < minimum || parsed > maximum) {
-            throw new InvalidOptionValueException("Invalid value for -%s: %d must be between %d and %d.".formatted(option, parsed, minimum, maximum));
-        }
-        return (int) parsed;
     }
 
     public String getName() {

--- a/core/src/main/java/com/predic8/membrane/core/cli/CliCommand.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/CliCommand.java
@@ -15,7 +15,7 @@ package com.predic8.membrane.core.cli;
 
 import com.predic8.membrane.core.util.Pair;
 import org.apache.commons.cli.*;
-import org.jetbrains.annotations.*;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 
@@ -149,6 +149,28 @@ public class CliCommand {
 
     public String getOptionValue(String opt) {
         return commandLine != null ? trim(commandLine.getOptionValue(opt)) : null;
+    }
+
+    /**
+     * Returns the value of a numeric option, or {@code defaultValue} if the option is not set.
+     *
+     * @throws InvalidOptionValueException if the value is not a number or outside minimum..maximum
+     */
+    public int getIntOptionValue(String option, int defaultValue, int minimum, int maximum) {
+        String value = getOptionValue(option);
+        if (value == null) {
+            return defaultValue;
+        }
+        long parsed;
+        try {
+            parsed = Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            throw new InvalidOptionValueException("Invalid value for -%s: '%s' is not a number.".formatted(option, value));
+        }
+        if (parsed < minimum || parsed > maximum) {
+            throw new InvalidOptionValueException("Invalid value for -%s: %d must be between %d and %d.".formatted(option, parsed, minimum, maximum));
+        }
+        return (int) parsed;
     }
 
     public String getName() {

--- a/core/src/main/java/com/predic8/membrane/core/cli/CliCommand.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/CliCommand.java
@@ -71,16 +71,30 @@ public class CliCommand {
         }
 
         try {
-            commandLine = new DefaultParser().parse(options, args, true);
+            commandLine = new DefaultParser().parse(options, args);
+        } catch (UnrecognizedOptionException e) {
+            throw new CommandParseException("Unknown option: " + e.getOption(), this);
         } catch (MissingOptionException e) {
             // Asking for help must work even when required options are missing.
-            commandLine = new DefaultParser().parse(optionsWithoutRequired(), args, true);
+            commandLine = new DefaultParser().parse(optionsWithoutRequired(), args);
             if (!isOptionSet(HELP.getOpt())) {
                 throw new MissingRequiredOptionException(e.getMessage(), this);
             }
         }
+        rejectUnexpectedArguments();
 
         return this;
+    }
+
+    /**
+     * Everything the parser could not assign to an option is an error: nothing reads
+     * {@link CommandLine#getArgList()}, so leftovers would be dropped without a word, see issue #3218.
+     */
+    private void rejectUnexpectedArguments() throws CommandParseException {
+        List<String> leftovers = commandLine.getArgList();
+        if (!leftovers.isEmpty()) {
+            throw new CommandParseException("Unexpected argument: " + String.join(" ", leftovers), this);
+        }
     }
 
     private Options optionsWithoutRequired() {

--- a/core/src/main/java/com/predic8/membrane/core/cli/CliCommand.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/CliCommand.java
@@ -170,7 +170,16 @@ public class CliCommand {
     }
 
     public String getOptionValue(String opt) {
-        return commandLine != null ? trim(commandLine.getOptionValue(opt)) : null;
+        return commandLine != null ? commandLine.getOptionValue(opt) : null;
+    }
+
+    /**
+     * Returns the value of an option with surrounding whitespace removed. Only for file locations
+     * and the like; values carrying a secret must be read with {@link #getOptionValue(String)},
+     * byte-for-byte.
+     */
+    public String getTrimmedOptionValue(String opt) {
+        return trim(getOptionValue(opt));
     }
 
     /**
@@ -179,7 +188,7 @@ public class CliCommand {
      * @throws InvalidOptionValueException if the value is not a number or outside minimum..maximum
      */
     public int getIntOptionValue(String option, int defaultValue, int minimum, int maximum) {
-        String value = getOptionValue(option);
+        String value = getTrimmedOptionValue(option);
         if (value == null) {
             return defaultValue;
         }

--- a/core/src/main/java/com/predic8/membrane/core/cli/CommandParseException.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/CommandParseException.java
@@ -1,0 +1,33 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+package com.predic8.membrane.core.cli;
+
+import org.apache.commons.cli.ParseException;
+
+/**
+ * A command line error that knows the command it occurred in, so that the help of that command can
+ * be printed instead of the help of the root command.
+ */
+public class CommandParseException extends ParseException {
+    private final CliCommand command;
+
+    public CommandParseException(String message, CliCommand command) {
+        super(message);
+        this.command = command;
+    }
+
+    public CliCommand getCommand() {
+        return command;
+    }
+}

--- a/core/src/main/java/com/predic8/membrane/core/cli/InvalidOptionValueException.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/InvalidOptionValueException.java
@@ -1,0 +1,26 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.core.cli;
+
+/**
+ * Signals that the value given for a command line option cannot be used, e.g. because it is not a
+ * number or outside the allowed range. The message is meant to be printed to the user as it is.
+ */
+public class InvalidOptionValueException extends RuntimeException {
+
+    public InvalidOptionValueException(String message) {
+        super(message);
+    }
+}

--- a/core/src/main/java/com/predic8/membrane/core/cli/MembraneCommandLine.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/MembraneCommandLine.java
@@ -92,8 +92,4 @@ public class MembraneCommandLine {
     public CliCommand getCommand() {
         return currentNamespace;
     }
-
-    public boolean noCommand() {
-        return currentNamespace == rootNamespace;
-    }
 }

--- a/core/src/main/java/com/predic8/membrane/core/cli/MembraneCommandLine.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/MembraneCommandLine.java
@@ -13,11 +13,12 @@
    limitations under the License. */
 package com.predic8.membrane.core.cli;
 
-import org.apache.commons.cli.*;
-import org.jetbrains.annotations.*;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.jetbrains.annotations.NotNull;
 
 import static com.predic8.membrane.core.util.OSUtil.isWindows;
-import static org.apache.commons.cli.Option.*;
+import static org.apache.commons.cli.Option.builder;
 
 public class MembraneCommandLine {
     private final CliCommand rootNamespace;
@@ -52,7 +53,7 @@ public class MembraneCommandLine {
             addSubcommand(new CliCommand("oas", "Use a single OpenAPI document to configure and start gateway") {{
                 addOption(builder("h").longOpt("help").desc("Display this text").build())
                         .addOption(builder("l").longOpt("location").argName("OpenAPI location").hasArg().required().desc("(Required) Set URL or path to an OpenAPI document").build())
-                        .addOption(builder("p").longOpt("port").argName("API port").hasArg().desc("Listen port").build())
+                        .addOption(builder("p").longOpt("port").argName("API port").hasArg().desc("Listen port (1-65535, default: 2000)").build())
                         .addOption(builder("v").longOpt("validate-requests").desc("Validate requests against OpenAPI").build())
                         .addOption(builder("V").longOpt("validate-responses").desc("Validate responses against OpenAPI").build());
 
@@ -60,7 +61,7 @@ public class MembraneCommandLine {
 
             addSubcommand(new CliCommand("generate-jwk", "Generate a JSON Web Key and write it to a file") {{
                 addOption(builder("o").longOpt("output").argName("file").hasArg().required().desc("Output file for JWK").build());
-                addOption(builder("b").longOpt("bits").argName("bitlength").hasArg().desc("Key length in bits (default: 2048)").build());
+                addOption(builder("b").longOpt("bits").argName("bitlength").hasArg().desc("Key length in bits (2048-16384, default: 2048)").build());
                 addOption(builder("overwrite").desc("Overwrite the output file, if it exists.").build());
             }});
 

--- a/core/src/main/java/com/predic8/membrane/core/cli/MembraneCommandLine.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/MembraneCommandLine.java
@@ -70,7 +70,7 @@ public class MembraneCommandLine {
 
             addSubcommand(new CliCommand("argon2id", "Computes an Argon2id hash value.") {{
                 addOption(builder("pass").longOpt("password").argName("password").hasArg().desc("Password to hash.").build());
-                addOption(builder("v").longOpt("version").argName("version").hasArg().desc("Version (decimal, default: 19).").build());
+                addOption(builder("v").longOpt("version").argName("version").hasArg().desc("Version (decimal, 16 or 19, default: 19).").build());
                 addOption(builder("s").longOpt("salt").argName("salt").hasArg().desc("Salt to hash with (hex string, default: random 16 bytes).").build());
                 addOption(builder("i").longOpt("iterations").argName("iterations").hasArg().desc("Number of iterations (default: 3).").build());
                 addOption(builder("m").longOpt("memory").argName("memory").hasArg().desc("Memory in KiB (default: 65536).").build());

--- a/core/src/main/java/com/predic8/membrane/core/cli/MembraneCommandLine.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/MembraneCommandLine.java
@@ -64,8 +64,9 @@ public class MembraneCommandLine {
             }});
 
             addSubcommand(new CliCommand("private-jwk-to-public", "Convert a private JWK to a public JWK.") {{
-                addOption(builder("i").longOpt("input").argName("file").hasArg().desc("Input file (JWK, private).").build());
-                addOption(builder("o").longOpt("output").argName("file").hasArg().desc("Output file (JWK, public).").build());
+                addOption(builder("i").longOpt("input").argName("file").hasArg().required().desc("Input file (JWK, private).").build());
+                addOption(builder("o").longOpt("output").argName("file").hasArg().required().desc("Output file (JWK, public).").build());
+                addOption(builder("overwrite").longOpt("overwrite").desc("Overwrite the output file, if it exists.").build());
             }});
 
             addSubcommand(new CliCommand("argon2id", "Computes an Argon2id hash value.") {{

--- a/core/src/main/java/com/predic8/membrane/core/cli/MembraneCommandLine.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/MembraneCommandLine.java
@@ -60,7 +60,7 @@ public class MembraneCommandLine {
             addSubcommand(new CliCommand("generate-jwk", "Generate a JSON Web Key and write it to a file") {{
                 addOption(builder("o").longOpt("output").argName("file").hasArg().required().desc("Output file for JWK").build());
                 addOption(builder("b").longOpt("bits").argName("bitlength").hasArg().desc("Key length in bits (2048-16384, default: 2048)").build());
-                addOption(builder("overwrite").desc("Overwrite the output file, if it exists.").build());
+                addOption(builder("overwrite").longOpt("overwrite").desc("Overwrite the output file, if it exists.").build());
             }});
 
             addSubcommand(new CliCommand("private-jwk-to-public", "Convert a private JWK to a public JWK.") {{

--- a/core/src/main/java/com/predic8/membrane/core/cli/MembraneCommandLine.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/MembraneCommandLine.java
@@ -29,8 +29,7 @@ public class MembraneCommandLine {
     }
 
     private static Options getRootOptions() {
-        return new Options().addOption(builder("h").longOpt("help").desc("Display this text").build())
-                .addOption(builder("c").longOpt("config").argName("apis.yaml or proxies.xml").hasArg().desc("Location of the configuration file").build())
+        return new Options().addOption(builder("c").longOpt("config").argName("apis.yaml or proxies.xml").hasArg().desc("Location of the configuration file").build())
                 .addOption(builder("t").longOpt("test").argName("apis.yaml or proxies.xml").hasArg().desc("Verifies configuration file and terminates").build());
     }
 
@@ -51,8 +50,7 @@ public class MembraneCommandLine {
             }});
 
             addSubcommand(new CliCommand("oas", "Use a single OpenAPI document to configure and start gateway") {{
-                addOption(builder("h").longOpt("help").desc("Display this text").build())
-                        .addOption(builder("l").longOpt("location").argName("OpenAPI location").hasArg().required().desc("(Required) Set URL or path to an OpenAPI document").build())
+                addOption(builder("l").longOpt("location").argName("OpenAPI location").hasArg().required().desc("(Required) Set URL or path to an OpenAPI document").build())
                         .addOption(builder("p").longOpt("port").argName("API port").hasArg().desc("Listen port (1-65535, default: 2000)").build())
                         .addOption(builder("v").longOpt("validate-requests").desc("Validate requests against OpenAPI").build())
                         .addOption(builder("V").longOpt("validate-responses").desc("Validate responses against OpenAPI").build());

--- a/core/src/main/java/com/predic8/membrane/core/cli/MissingRequiredOptionException.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/MissingRequiredOptionException.java
@@ -13,17 +13,13 @@
    limitations under the License. */
 package com.predic8.membrane.core.cli;
 
-import org.apache.commons.cli.MissingOptionException;
-
-public class MissingRequiredOptionException extends MissingOptionException {
-    private final CliCommand command;
+/**
+ * Signals that a required option was not given. Reported like any other
+ * {@link CommandParseException}: with the message and the help of the affected command.
+ */
+public class MissingRequiredOptionException extends CommandParseException {
 
     public MissingRequiredOptionException(String message, CliCommand command) {
-        super(message);
-        this.command = command;
-    }
-
-    public CliCommand getCommand() {
-      return command;
+        super(message, command);
     }
 }

--- a/core/src/main/java/com/predic8/membrane/core/cli/RouterCLI.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/RouterCLI.java
@@ -85,8 +85,7 @@ public class RouterCLI {
             System.exit(0);
         }
 
-        // Dry run
-        if (commandLine.noCommand() && commandLine.getCommand().isOptionSet("t")) {
+        if (isDryRun(commandLine)) {
             dryRun(commandLine);
         }
 
@@ -105,6 +104,15 @@ public class RouterCLI {
 
         if (getRouter(commandLine) instanceof DefaultRouter dr)
             dr.waitFor();
+    }
+
+    /**
+     * The {@code start} command is documented as behaving exactly like the command being omitted, so
+     * {@code -t} must terminate after verifying the configuration there too, see issue #3217. Only the
+     * root command and {@code start} declare {@code -t}, so the option alone decides.
+     */
+    static boolean isDryRun(MembraneCommandLine commandLine) {
+        return commandLine.getCommand().isOptionSet("t");
     }
 
     private static void privateJwkToPublic(MembraneCommandLine commandLine) {

--- a/core/src/main/java/com/predic8/membrane/core/cli/RouterCLI.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/RouterCLI.java
@@ -107,15 +107,10 @@ public class RouterCLI {
     }
 
     private static void privateJwkToPublic(MembraneCommandLine commandLine) {
-        String input = commandLine.getCommand().getTrimmedOptionValue("i");
-        String output = commandLine.getCommand().getTrimmedOptionValue("o");
-        if (input == null || output == null) {
-            log.error("Both input (-i) and output (-o) files must be specified.");
-            System.exit(1);
-        }
         privateJWKtoPublic(
-                input,
-                output);
+                commandLine.getCommand().getTrimmedOptionValue("i"),
+                commandLine.getCommand().getTrimmedOptionValue("o"),
+                commandLine.getCommand().isOptionSet("overwrite"));
         System.exit(0);
     }
 

--- a/core/src/main/java/com/predic8/membrane/core/cli/RouterCLI.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/RouterCLI.java
@@ -57,6 +57,7 @@ import static com.predic8.membrane.core.util.OSUtil.fixBackslashes;
 import static com.predic8.membrane.core.util.URIUtil.pathFromFileURI;
 import static com.predic8.membrane.core.util.text.TerminalColors.*;
 import static java.lang.Integer.MAX_VALUE;
+import static java.lang.Integer.MIN_VALUE;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getMessage;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMessage;
 
@@ -68,13 +69,21 @@ public class RouterCLI {
         try {
             start(args);
         } catch (InvalidOptionValueException e) {
-            System.err.println(e.getMessage());
-            System.exit(1);
+            fail(e.getMessage());
         } catch (ExitException ignored) {
             // Nothing logged on purpose. The exception is just to trigger exit at one place.
             // Do logging where the exception is thrown.
             System.exit(1);
         }
+    }
+
+    /**
+     * Reports a usage error to the user and terminates. Not for internal failures: those belong in
+     * the log, together with their stack trace.
+     */
+    private static void fail(String message) {
+        System.err.println(message);
+        System.exit(1);
     }
 
     private static void start(String[] args) {
@@ -146,11 +155,9 @@ public class RouterCLI {
 
             System.out.println(buildArgon2idPCH(password.getBytes(StandardCharsets.UTF_8), s, v, i, m, p));
         } catch (InvalidOptionValueException e) {
-            System.err.println(e.getMessage());
-            System.exit(1);
+            fail(e.getMessage());
         } catch (Exception e) {
-            System.err.println(getExceptionMessageWithCauses(e));
-            System.exit(1);
+            fail(getExceptionMessageWithCauses(e));
         }
         System.exit(0);
     }
@@ -159,7 +166,7 @@ public class RouterCLI {
      * Argon2 defines only the versions 0x10 (16) and 0x13 (19); Bouncy Castle rejects any other value.
      */
     static int getArgon2Version(MembraneCommandLine commandLine) {
-        int version = commandLine.getCommand().getIntOptionValue("v", 19, 16, 19);
+        int version = commandLine.getCommand().getIntOptionValue("v", 19, MIN_VALUE, MAX_VALUE);
         if (version != 16 && version != 19)
             throw new InvalidOptionValueException("Invalid value for -v: %d is not a supported Argon2 version. Use 16 (0x10) or 19 (0x13).".formatted(version));
         return version;
@@ -225,7 +232,7 @@ public class RouterCLI {
         } catch (ExitException ignored) {
             // do nothing
         } catch (InvalidOptionValueException e) {
-            System.err.println(e.getMessage());
+            fail(e.getMessage());
         } catch (Exception ex) {
             SpringConfigurationErrorHandler.handleRootCause(ex, log);
         }
@@ -314,9 +321,6 @@ public class RouterCLI {
 
         try {
             cl.parse(args);
-        } catch (MissingRequiredOptionException e) {
-            e.getCommand().printHelp();
-            System.exit(1);
         } catch (CommandParseException e) {
             System.err.println(e.getMessage());
             e.getCommand().printHelp();

--- a/core/src/main/java/com/predic8/membrane/core/cli/RouterCLI.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/RouterCLI.java
@@ -124,7 +124,7 @@ public class RouterCLI {
             String password = commandLine.getCommand().getOptionValue("pass");
             String salt = commandLine.getCommand().getOptionValue("s");
 
-            int v = commandLine.getCommand().getIntOptionValue("v", 19, 16, 19); // Argon2 only defines 0x10 and 0x13
+            int v = getArgon2Version(commandLine);
             int i = commandLine.getCommand().getIntOptionValue("i", 3, 1, MAX_VALUE);
             int m = commandLine.getCommand().getIntOptionValue("m", 65536, 1, MAX_VALUE);
             int p = commandLine.getCommand().getIntOptionValue("p", 1, 1, MAX_VALUE);
@@ -149,6 +149,16 @@ public class RouterCLI {
             System.exit(1);
         }
         System.exit(0);
+    }
+
+    /**
+     * Argon2 defines only the versions 0x10 (16) and 0x13 (19); Bouncy Castle rejects any other value.
+     */
+    static int getArgon2Version(MembraneCommandLine commandLine) {
+        int version = commandLine.getCommand().getIntOptionValue("v", 19, 16, 19);
+        if (version != 16 && version != 19)
+            throw new InvalidOptionValueException("Invalid value for -v: %d is not a supported Argon2 version. Use 16 (0x10) or 19 (0x13).".formatted(version));
+        return version;
     }
 
     private static void dryRun(MembraneCommandLine commandLine) {

--- a/core/src/main/java/com/predic8/membrane/core/cli/RouterCLI.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/RouterCLI.java
@@ -308,6 +308,10 @@ public class RouterCLI {
         } catch (MissingRequiredOptionException e) {
             e.getCommand().printHelp();
             System.exit(1);
+        } catch (CommandParseException e) {
+            System.err.println(e.getMessage());
+            e.getCommand().printHelp();
+            System.exit(1);
         } catch (ParseException e) {
             System.err.println("Error parsing commandline " + e.getMessage());
             cl.getRootNamespace().printHelp();

--- a/core/src/main/java/com/predic8/membrane/core/cli/RouterCLI.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/RouterCLI.java
@@ -107,8 +107,8 @@ public class RouterCLI {
     }
 
     private static void privateJwkToPublic(MembraneCommandLine commandLine) {
-        String input = commandLine.getCommand().getOptionValue("i");
-        String output = commandLine.getCommand().getOptionValue("o");
+        String input = commandLine.getCommand().getTrimmedOptionValue("i");
+        String output = commandLine.getCommand().getTrimmedOptionValue("o");
         if (input == null || output == null) {
             log.error("Both input (-i) and output (-o) files must be specified.");
             System.exit(1);
@@ -122,7 +122,7 @@ public class RouterCLI {
     private static void argon2id(MembraneCommandLine commandLine) {
         try {
             String password = commandLine.getCommand().getOptionValue("pass");
-            String salt = commandLine.getCommand().getOptionValue("s");
+            String salt = commandLine.getCommand().getTrimmedOptionValue("s");
 
             int v = getArgon2Version(commandLine);
             int i = commandLine.getCommand().getIntOptionValue("i", 3, 1, MAX_VALUE);
@@ -253,7 +253,7 @@ public class RouterCLI {
     }
 
     private static Router initRouterByYAML(MembraneCommandLine commandLine, String option) throws Exception {
-        return initRouterByYAML(commandLine.getCommand().getOptionValue(option));
+        return initRouterByYAML(commandLine.getCommand().getTrimmedOptionValue(option));
     }
 
     static Router initRouterByYAML(String location) throws Exception {
@@ -284,7 +284,7 @@ public class RouterCLI {
     }
 
     static String getLocation(MembraneCommandLine commandLine) throws IOException {
-        String location = commandLine.getCommand().getOptionValue("l");
+        String location = commandLine.getCommand().getTrimmedOptionValue("l");
 
         if (location == null || location.isEmpty())
             throw new InvalidOptionValueException("Invalid value for -l: the OpenAPI location must not be empty.");
@@ -389,8 +389,8 @@ public class RouterCLI {
 
     private static String getConfiguration(MembraneCommandLine cl) {
         return cl.getCommand().isOptionSet("c") ?
-                cl.getCommand().getOptionValue("c") :
-                cl.getCommand().getOptionValue("t");
+                cl.getCommand().getTrimmedOptionValue("c") :
+                cl.getCommand().getTrimmedOptionValue("t");
     }
 
     private static boolean hasConfiguration(MembraneCommandLine cl) {

--- a/core/src/main/java/com/predic8/membrane/core/cli/RouterCLI.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/RouterCLI.java
@@ -50,6 +50,7 @@ import static com.predic8.membrane.core.interceptor.authentication.SecurityUtils
 import static com.predic8.membrane.core.openapi.serviceproxy.OpenAPISpec.YesNoOpenAPIOption.YES;
 import static com.predic8.membrane.core.openapi.util.OpenAPIUtil.isOpenAPIMisplacedError;
 import static com.predic8.membrane.core.proxies.ApiInfo.logInfosAboutStartedProxies;
+import static com.predic8.membrane.core.proxies.RuleManager.RuleDefinitionSource.MANUAL;
 import static com.predic8.membrane.core.router.YamlRouterBootstrap.loadIntoRouter;
 import static com.predic8.membrane.core.util.ExceptionUtil.concatMessageAndCauseMessages;
 import static com.predic8.membrane.core.util.OSUtil.fixBackslashes;
@@ -238,10 +239,10 @@ public class RouterCLI {
         throw new RuntimeException("Unsupported file extension.");
     }
 
-    private static Router initRouterByOpenApiSpec(MembraneCommandLine commandLine) throws Exception {
+    static Router initRouterByOpenApiSpec(MembraneCommandLine commandLine) throws Exception {
         var router = new DefaultRouter();
-        router.getRuleManager().addProxyAndOpenPortIfNew(getApiProxy(commandLine));
-        router.init();
+        router.getRuleManager().addProxy(getApiProxy(commandLine), MANUAL);
+        router.start();
         logInfosAboutStartedProxies(router.getRuleManager());
         logStartupMessage();
         return router;

--- a/core/src/main/java/com/predic8/membrane/core/cli/RouterCLI.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/RouterCLI.java
@@ -55,7 +55,7 @@ import static com.predic8.membrane.core.util.ExceptionUtil.concatMessageAndCause
 import static com.predic8.membrane.core.util.OSUtil.fixBackslashes;
 import static com.predic8.membrane.core.util.URIUtil.pathFromFileURI;
 import static com.predic8.membrane.core.util.text.TerminalColors.*;
-import static java.lang.Integer.parseInt;
+import static java.lang.Integer.MAX_VALUE;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getMessage;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMessage;
 
@@ -66,6 +66,9 @@ public class RouterCLI {
     public static void main(String[] args) {
         try {
             start(args);
+        } catch (InvalidOptionValueException e) {
+            System.err.println(e.getMessage());
+            System.exit(1);
         } catch (ExitException ignored) {
             // Nothing logged on purpose. The exception is just to trigger exit at one place.
             // Do logging where the exception is thrown.
@@ -119,16 +122,12 @@ public class RouterCLI {
     private static void argon2id(MembraneCommandLine commandLine) {
         try {
             String password = commandLine.getCommand().getOptionValue("pass");
-            String version = commandLine.getCommand().getOptionValue("v");
             String salt = commandLine.getCommand().getOptionValue("s");
-            String iterations = commandLine.getCommand().getOptionValue("i");
-            String memory = commandLine.getCommand().getOptionValue("m");
-            String parallelism = commandLine.getCommand().getOptionValue("p");
 
-            int v = version == null ? 19 : Integer.parseInt(version);
-            int i = iterations == null ? 3 : Integer.parseInt(iterations);
-            int m = memory == null ? 65536 : Integer.parseInt(memory);
-            int p = parallelism == null ? 1 : Integer.parseInt(parallelism);
+            int v = commandLine.getCommand().getIntOptionValue("v", 19, 16, 19); // Argon2 only defines 0x10 and 0x13
+            int i = commandLine.getCommand().getIntOptionValue("i", 3, 1, MAX_VALUE);
+            int m = commandLine.getCommand().getIntOptionValue("m", 65536, 1, MAX_VALUE);
+            int p = commandLine.getCommand().getIntOptionValue("p", 1, 1, MAX_VALUE);
             if (password == null) {
                 System.out.println("Enter password to hash:");
                 Scanner s = new Scanner(System.in);
@@ -142,6 +141,9 @@ public class RouterCLI {
             }
 
             System.out.println(buildArgon2idPCH(password.getBytes(StandardCharsets.UTF_8), s, v, i, m, p));
+        } catch (InvalidOptionValueException e) {
+            System.err.println(e.getMessage());
+            System.exit(1);
         } catch (Exception e) {
             System.err.println(getExceptionMessageWithCauses(e));
             System.exit(1);
@@ -208,6 +210,8 @@ public class RouterCLI {
             log.error("{}", "%s%s%s\n%s".formatted(RED(), e.getMessage(), RESET(), report));
         } catch (ExitException ignored) {
             // do nothing
+        } catch (InvalidOptionValueException e) {
+            System.err.println(e.getMessage());
         } catch (Exception ex) {
             SpringConfigurationErrorHandler.handleRootCause(ex, log);
         }
@@ -253,8 +257,7 @@ public class RouterCLI {
 
     private static @NotNull APIProxy getApiProxy(MembraneCommandLine commandLine) throws IOException {
         APIProxy api = new APIProxy();
-        api.setPort(commandLine.getCommand().isOptionSet("p") ?
-                parseInt(commandLine.getCommand().getOptionValue("p")) : 2000);
+        api.setPort(commandLine.getCommand().getIntOptionValue("p", 2000, 1, 65535));
         api.setOpenapi(List.of(getOpenAPISpec(commandLine)));
         return api;
     }
@@ -270,10 +273,11 @@ public class RouterCLI {
         return spec;
     }
 
-    private static String getLocation(MembraneCommandLine commandLine) throws IOException {
+    static String getLocation(MembraneCommandLine commandLine) throws IOException {
         String location = commandLine.getCommand().getOptionValue("l");
 
-        if (location == null || location.isEmpty()) throw new RuntimeException(); // unreachable
+        if (location == null || location.isEmpty())
+            throw new InvalidOptionValueException("Invalid value for -l: the OpenAPI location must not be empty.");
         if (location.startsWith("http://") || location.startsWith("https://")) return location;
 
         File locFile = new File(location);

--- a/core/src/main/java/com/predic8/membrane/core/cli/util/JwkGenerator.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/util/JwkGenerator.java
@@ -28,7 +28,6 @@ import java.nio.file.Path;
 import java.security.SecureRandom;
 import java.util.Map;
 
-import static java.lang.Integer.parseInt;
 import static java.lang.System.exit;
 import static java.nio.file.Files.writeString;
 import static java.nio.file.Paths.get;
@@ -40,11 +39,7 @@ public class JwkGenerator {
     private static final Logger log = LoggerFactory.getLogger(JwkGenerator.class);
 
     public static void generateJWK(MembraneCommandLine commandLine) {
-        int bits = 2048;
-        String bitsArg = commandLine.getCommand().getOptionValue("b");
-        if (bitsArg != null) {
-            bits = parseInt(bitsArg);
-        }
+        int bits = commandLine.getCommand().getIntOptionValue("b", 2048, 2048, 16384);
 
         boolean overwrite = commandLine.getCommand().isOptionSet("overwrite");
         String outputFile = commandLine.getCommand().getOptionValue("o");

--- a/core/src/main/java/com/predic8/membrane/core/cli/util/JwkGenerator.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/util/JwkGenerator.java
@@ -15,6 +15,7 @@
 package com.predic8.membrane.core.cli.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.predic8.membrane.core.cli.InvalidOptionValueException;
 import com.predic8.membrane.core.cli.MembraneCommandLine;
 import org.jose4j.jwk.RsaJsonWebKey;
 import org.jose4j.lang.JoseException;
@@ -29,7 +30,7 @@ import java.security.SecureRandom;
 import java.util.Map;
 
 import static java.lang.System.exit;
-import static java.nio.file.Files.writeString;
+import static java.nio.file.Files.*;
 import static java.nio.file.Paths.get;
 import static org.jose4j.jwk.JsonWebKey.OutputControlLevel.INCLUDE_PRIVATE;
 import static org.jose4j.jwk.JsonWebKey.OutputControlLevel.PUBLIC_ONLY;
@@ -73,7 +74,8 @@ public class JwkGenerator {
         }
     }
 
-    public static void privateJWKtoPublic(String input, String output) {
+    public static void privateJWKtoPublic(String input, String output, boolean overwrite) {
+        checkFiles(input, output, overwrite);
         try {
             Map map = new ObjectMapper().readValue(new File(input), Map.class);
             RsaJsonWebKey rsa = new RsaJsonWebKey(map);
@@ -81,6 +83,36 @@ public class JwkGenerator {
         } catch (IOException | JoseException e) {
             log.error(e.getMessage());
             exit(1);
+        }
+    }
+
+    /**
+     * Guards the conversion against destroying key material: writing the public JWK onto the input
+     * file silently discarded the private key components (see issue #3219).
+     *
+     * @throws InvalidOptionValueException if the input does not exist, or if the output is the input
+     *                                     file or an existing file the user did not allow to replace
+     */
+    static void checkFiles(String input, String output, boolean overwrite) {
+        Path in = get(input);
+        Path out = get(output);
+        if (!isRegularFile(in))
+            throw new InvalidOptionValueException("Invalid value for -i: '%s' is not a file.".formatted(input));
+        if (!exists(out))
+            return;
+        if (pointToSameFile(in, out))
+            throw new InvalidOptionValueException("Invalid value for -o: '%s' is the input file. Converting it in place would destroy the private key.".formatted(output));
+        if (!overwrite)
+            throw new InvalidOptionValueException("Output file (%s) already exists. Use -overwrite to replace it.".formatted(output));
+    }
+
+    private static boolean pointToSameFile(Path in, Path out) {
+        try {
+            return isSameFile(in, out);
+        } catch (IOException e) {
+            // Cannot tell the files apart: treat them as different and let the conversion report the real error.
+            log.debug("Could not compare input {} and output {}.", in, out, e);
+            return false;
         }
     }
 

--- a/core/src/main/java/com/predic8/membrane/core/cli/util/JwkGenerator.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/util/JwkGenerator.java
@@ -42,14 +42,9 @@ public class JwkGenerator {
     public static void generateJWK(MembraneCommandLine commandLine) {
         int bits = commandLine.getCommand().getIntOptionValue("b", 2048, 2048, 16384);
 
-        boolean overwrite = commandLine.getCommand().isOptionSet("overwrite");
-        String outputFile = commandLine.getCommand().getTrimmedOptionValue("o");
-
-        if (outputFile == null) {
-            log.error("Missing required option: -o <output file>");
-            commandLine.getCommand().printHelp();
-            exit(1);
-        }
+        // -o is a required option, so the value is always there.
+        Path output = get(commandLine.getCommand().getTrimmedOptionValue("o"));
+        checkOutput(output, commandLine.getCommand().isOptionSet("overwrite"));
 
         RsaJsonWebKey rsaJsonWebKey;
         try {
@@ -61,13 +56,8 @@ public class JwkGenerator {
         rsaJsonWebKey.setUse("sig");
         rsaJsonWebKey.setAlgorithm("RS256");
 
-        Path path = get(outputFile);
-        if (path.toFile().exists() && !overwrite) {
-            log.error("Output file ({}) already exists.", outputFile);
-            exit(1);
-        }
         try {
-            writeString(path, rsaJsonWebKey.toJson(INCLUDE_PRIVATE));
+            writeString(output, rsaJsonWebKey.toJson(INCLUDE_PRIVATE));
         } catch (IOException e) {
             log.error(e.getMessage());
             exit(1);
@@ -102,7 +92,14 @@ public class JwkGenerator {
             return;
         if (pointToSameFile(in, out))
             throw new InvalidOptionValueException("Invalid value for -o: '%s' is the input file. Converting it in place would destroy the private key.".formatted(output));
-        if (!overwrite)
+        checkOutput(out, overwrite);
+    }
+
+    /**
+     * @throws InvalidOptionValueException if the output exists and the user did not allow to replace it
+     */
+    static void checkOutput(Path output, boolean overwrite) {
+        if (exists(output) && !overwrite)
             throw new InvalidOptionValueException("Output file (%s) already exists. Use -overwrite to replace it.".formatted(output));
     }
 

--- a/core/src/main/java/com/predic8/membrane/core/cli/util/JwkGenerator.java
+++ b/core/src/main/java/com/predic8/membrane/core/cli/util/JwkGenerator.java
@@ -42,7 +42,7 @@ public class JwkGenerator {
         int bits = commandLine.getCommand().getIntOptionValue("b", 2048, 2048, 16384);
 
         boolean overwrite = commandLine.getCommand().isOptionSet("overwrite");
-        String outputFile = commandLine.getCommand().getOptionValue("o");
+        String outputFile = commandLine.getCommand().getTrimmedOptionValue("o");
 
         if (outputFile == null) {
             log.error("Missing required option: -o <output file>");

--- a/core/src/test/java/com/predic8/membrane/core/cli/CliCommandTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/cli/CliCommandTest.java
@@ -100,6 +100,37 @@ public class CliCommandTest {
         assertEquals("Unknown command: unknown", exception.getMessage());
     }
 
+    /**
+     * An unknown option used to stop the parser: everything behind it was silently dropped, so
+     * <code>--zzz -a value</code> started without the requested value, see issue #3218.
+     */
+    @Test
+    void shouldThrowParseExceptionForUnknownOption() {
+        assertEquals("Unknown option: -q",
+                assertThrows(CommandParseException.class, () -> rootCommand.parse(new String[]{"-q"})).getMessage());
+    }
+
+    @Test
+    void shouldNotDiscardOptionsFollowingAnUnknownOption() {
+        assertEquals("Unknown option: --zzz",
+                assertThrows(CommandParseException.class, () -> rootCommand.parse(new String[]{"--zzz", "-a", "value"})).getMessage());
+    }
+
+    @Test
+    void shouldReportUnknownOptionOnTheFailingSubcommand() {
+        CommandParseException exception = assertThrows(CommandParseException.class, () ->
+                rootCommand.parse(new String[]{"sub", "--nope"})
+        );
+        assertEquals("Unknown option: --nope", exception.getMessage());
+        assertEquals("sub", exception.getCommand().getName());
+    }
+
+    @Test
+    void shouldThrowParseExceptionForUnexpectedArgument() {
+        assertEquals("Unexpected argument: extra",
+                assertThrows(CommandParseException.class, () -> rootCommand.parse(new String[]{"-a", "value", "extra"})).getMessage());
+    }
+
     @Test
     void shouldReturnFullCommandPath() throws ParseException {
         CliCommand cmd = rootCommand.parse(new String[]{"sub"});

--- a/core/src/test/java/com/predic8/membrane/core/cli/CliCommandTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/cli/CliCommandTest.java
@@ -131,17 +131,34 @@ public class CliCommandTest {
     }
 
     @Test
-    void shouldPrintSubHelpWithoutOptions() throws ParseException {
+    void shouldPrintSubHelpOfCommandWithoutOwnOptions() throws ParseException {
         ByteArrayOutputStream outContent = new ByteArrayOutputStream();
         System.setOut(new PrintStream(outContent));
 
         rootCommand.parse(new String[]{"without"}).printHelp();
         String output = outContent.toString();
 
-        assertFalse(output.contains("options"));
-        assertTrue(output.contains("usage: root without"));
+        assertTrue(output.contains("usage: root without [options]"));
+        assertTrue(output.contains("--help"));
 
         System.setOut(System.out);
+    }
+
+    /**
+     * Every command supports -h, even one that declares no options of its own, see issue #3222.
+     */
+    @Test
+    void shouldParseHelpOnCommandWithoutOwnOptions() throws ParseException {
+        assertTrue(rootCommand.parse(new String[]{"without", "-h"}).isOptionSet("h"));
+        assertTrue(rootCommand.parse(new String[]{"without", "--help"}).isOptionSet("h"));
+    }
+
+    /**
+     * Asking for help must not be refused because a required option is missing, see issue #3222.
+     */
+    @Test
+    void shouldParseHelpWhenRequiredOptionIsMissing() throws ParseException {
+        assertTrue(rootCommand.parse(new String[]{"required", "-h"}).isOptionSet("h"));
     }
 
     @Test

--- a/core/src/test/java/com/predic8/membrane/core/cli/CliCommandTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/cli/CliCommandTest.java
@@ -168,6 +168,23 @@ public class CliCommandTest {
         assertNull(result.getOptionValue("a"));
     }
 
+    /**
+     * Option values must reach their consumer byte-for-byte: trimming them silently hashed a
+     * different argon2id password than the one given, see issue #3220.
+     */
+    @Test
+    void getOptionValuePreservesSurroundingWhitespace() throws ParseException {
+        assertEquals("  value  ", rootCommand.parse(new String[]{"-a", "  value  "}).getOptionValue("a"));
+    }
+
+    @Test
+    void getTrimmedOptionValueRemovesSurroundingWhitespace() throws ParseException {
+        CliCommand result = rootCommand.parse(new String[]{"-a", "  value  "});
+
+        assertEquals("value", result.getTrimmedOptionValue("a"));
+        assertNull(result.getTrimmedOptionValue("b"));
+    }
+
     @Test
     void getIntOptionValueReturnsDefaultWhenOptionNotSet() throws ParseException {
         assertEquals(2048, rootCommand.parse(new String[]{}).getIntOptionValue("a", 2048, 2048, 16384));
@@ -176,6 +193,11 @@ public class CliCommandTest {
     @Test
     void getIntOptionValueParsesNumber() throws ParseException {
         assertEquals(4096, rootCommand.parse(new String[]{"-a", "4096"}).getIntOptionValue("a", 2048, 2048, 16384));
+    }
+
+    @Test
+    void getIntOptionValueAcceptsPaddedNumber() throws ParseException {
+        assertEquals(4096, rootCommand.parse(new String[]{"-a", " 4096 "}).getIntOptionValue("a", 2048, 2048, 16384));
     }
 
     @Test

--- a/core/src/test/java/com/predic8/membrane/core/cli/CliCommandTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/cli/CliCommandTest.java
@@ -13,11 +13,14 @@
    limitations under the License. */
 package com.predic8.membrane.core.cli;
 
-import org.apache.commons.cli.MissingOptionException;
 import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -26,7 +29,18 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class CliCommandTest {
 
+    /**
+     * Kept before any test redirects it: {@code System.setOut(System.out)} restores nothing once the
+     * redirect is in place, and every later print would go to the discarded buffer.
+     */
+    private static final PrintStream STDOUT = System.out;
+
     private static CliCommand rootCommand;
+
+    @AfterEach
+    void restoreStdout() {
+        System.setOut(STDOUT);
+    }
 
     @BeforeAll
     static void setUp() {
@@ -89,15 +103,33 @@ public class CliCommandTest {
 
     @Test
     void shouldThrowErrorForMissingRequiredOption() {
-        assertThrows(MissingOptionException.class, () -> rootCommand.parse(new String[]{"required"}));
+        MissingRequiredOptionException exception = assertThrows(MissingRequiredOptionException.class,
+                () -> rootCommand.parse(new String[]{"required"}));
+
+        assertEquals("Missing required option: z", exception.getMessage());
+        assertEquals("required", exception.getCommand().getName());
     }
 
     @Test
     void shouldThrowParseExceptionForUnknownSubcommand() {
-        ParseException exception = assertThrows(ParseException.class, () ->
+        CommandParseException exception = assertThrows(CommandParseException.class, () ->
                 rootCommand.parse(new String[]{"unknown"})
         );
         assertEquals("Unknown command: unknown", exception.getMessage());
+        assertEquals("root", exception.getCommand().getName());
+    }
+
+    /**
+     * An unknown command behind a valid one must be reported with the help of that command, not with
+     * the help of the root command.
+     */
+    @Test
+    void shouldReportUnknownCommandOnTheFailingSubcommand() {
+        CommandParseException exception = assertThrows(CommandParseException.class, () ->
+                rootCommand.parse(new String[]{"sub", "extra", "-x", "value"})
+        );
+        assertEquals("Unknown command: extra", exception.getMessage());
+        assertEquals("sub", exception.getCommand().getName());
     }
 
     /**
@@ -148,8 +180,6 @@ public class CliCommandTest {
         assertTrue(output.contains("sub - Sub command"));
         assertTrue(output.contains("Example Number 1"));
         assertTrue(output.contains("Example Number 2"));
-
-        System.setOut(System.out);
     }
 
     @Test
@@ -171,8 +201,6 @@ public class CliCommandTest {
 
         assertTrue(output.contains("usage: root without [options]"));
         assertTrue(output.contains("--help"));
-
-        System.setOut(System.out);
     }
 
     /**
@@ -187,9 +215,24 @@ public class CliCommandTest {
     /**
      * Asking for help must not be refused because a required option is missing, see issue #3222.
      */
+    @ParameterizedTest
+    @ValueSource(strings = {"-h", "--help"})
+    void shouldParseHelpWhenRequiredOptionIsMissing(String spelling) throws ParseException {
+        assertTrue(rootCommand.parse(new String[]{"required", spelling}).isOptionSet("h"));
+    }
+
+    /**
+     * Adding {@code -h} must not write into the {@link Options} the caller passed in: the same
+     * instance is handed to more than one command.
+     */
     @Test
-    void shouldParseHelpWhenRequiredOptionIsMissing() throws ParseException {
-        assertTrue(rootCommand.parse(new String[]{"required", "-h"}).isOptionSet("h"));
+    void setOptionsDoesNotModifyTheGivenOptions() {
+        Options given = new Options().addOption(Option.builder("k").desc("Flag K").build());
+
+        new CliCommand("copy", "Command with options set from outside").setOptions(given);
+
+        assertEquals(1, given.getOptions().size());
+        assertFalse(given.hasShortOption("h"));
     }
 
     @Test
@@ -256,10 +299,18 @@ public class CliCommandTest {
         CliCommand tooSmall = rootCommand.parse(new String[]{"-a", "1024"});
         assertEquals("Invalid value for -a: 1024 must be between 2048 and 16384.",
                 assertThrows(InvalidOptionValueException.class, () -> tooSmall.getIntOptionValue("a", 2048, 2048, 16384)).getMessage());
+    }
 
-        // Beyond Integer.MAX_VALUE it must still be reported as out of range, not as "not a number".
-        CliCommand tooLarge = rootCommand.parse(new String[]{"-a", "99999999999"});
-        assertEquals("Invalid value for -a: 99999999999 must be between 2048 and 16384.",
-                assertThrows(InvalidOptionValueException.class, () -> tooLarge.getIntOptionValue("a", 2048, 2048, 16384)).getMessage());
+    /**
+     * However far beyond Integer.MAX_VALUE the value is, it stays an out of range number and must not
+     * be reported as not being a number.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"99999999999", "99999999999999999999999999999999"})
+    void getIntOptionValueRejectsValueTooLargeForAnInt(String value) throws ParseException {
+        CliCommand cmd = rootCommand.parse(new String[]{"-a", value});
+
+        assertEquals("Invalid value for -a: %s must be between 2048 and 16384.".formatted(value),
+                assertThrows(InvalidOptionValueException.class, () -> cmd.getIntOptionValue("a", 2048, 2048, 16384)).getMessage());
     }
 }

--- a/core/src/test/java/com/predic8/membrane/core/cli/CliCommandTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/cli/CliCommandTest.java
@@ -150,4 +150,46 @@ public class CliCommandTest {
         assertFalse(result.isOptionSet("a"));
         assertNull(result.getOptionValue("a"));
     }
+
+    @Test
+    void getIntOptionValueReturnsDefaultWhenOptionNotSet() throws ParseException {
+        assertEquals(2048, rootCommand.parse(new String[]{}).getIntOptionValue("a", 2048, 2048, 16384));
+    }
+
+    @Test
+    void getIntOptionValueParsesNumber() throws ParseException {
+        assertEquals(4096, rootCommand.parse(new String[]{"-a", "4096"}).getIntOptionValue("a", 2048, 2048, 16384));
+    }
+
+    @Test
+    void getIntOptionValueAcceptsRangeBoundaries() throws ParseException {
+        assertEquals(2048, rootCommand.parse(new String[]{"-a", "2048"}).getIntOptionValue("a", 4096, 2048, 16384));
+        assertEquals(16384, rootCommand.parse(new String[]{"-a", "16384"}).getIntOptionValue("a", 4096, 2048, 16384));
+    }
+
+    @Test
+    void getIntOptionValueRejectsNonNumber() throws ParseException {
+        CliCommand cmd = rootCommand.parse(new String[]{"-a", "abc"});
+        assertEquals("Invalid value for -a: 'abc' is not a number.",
+                assertThrows(InvalidOptionValueException.class, () -> cmd.getIntOptionValue("a", 2048, 2048, 16384)).getMessage());
+    }
+
+    @Test
+    void getIntOptionValueRejectsEmptyValue() throws ParseException {
+        CliCommand cmd = rootCommand.parse(new String[]{"-a", ""});
+        assertEquals("Invalid value for -a: '' is not a number.",
+                assertThrows(InvalidOptionValueException.class, () -> cmd.getIntOptionValue("a", 2048, 2048, 16384)).getMessage());
+    }
+
+    @Test
+    void getIntOptionValueRejectsValueOutOfRange() throws ParseException {
+        CliCommand tooSmall = rootCommand.parse(new String[]{"-a", "1024"});
+        assertEquals("Invalid value for -a: 1024 must be between 2048 and 16384.",
+                assertThrows(InvalidOptionValueException.class, () -> tooSmall.getIntOptionValue("a", 2048, 2048, 16384)).getMessage());
+
+        // Beyond Integer.MAX_VALUE it must still be reported as out of range, not as "not a number".
+        CliCommand tooLarge = rootCommand.parse(new String[]{"-a", "99999999999"});
+        assertEquals("Invalid value for -a: 99999999999 must be between 2048 and 16384.",
+                assertThrows(InvalidOptionValueException.class, () -> tooLarge.getIntOptionValue("a", 2048, 2048, 16384)).getMessage());
+    }
 }

--- a/core/src/test/java/com/predic8/membrane/core/cli/MembraneCommandLineTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/cli/MembraneCommandLineTest.java
@@ -13,10 +13,11 @@
    limitations under the License. */
 package com.predic8.membrane.core.cli;
 
+import org.apache.commons.cli.Option;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class MembraneCommandLineTest {
 
@@ -31,5 +32,33 @@ class MembraneCommandLineTest {
         cl.parse(new String[]{command, "-h"});
 
         assertTrue(cl.getCommand().isOptionSet("h"));
+    }
+
+    /**
+     * generate-jwk declared its overwrite flag without a long option, so --overwrite was an unknown
+     * token that silently swallowed the rest of the command line, see issue #3221.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"-overwrite", "--overwrite"})
+    void generateJwkAcceptsOverwriteInBothSpellings(String spelling) throws Exception {
+        MembraneCommandLine cl = new MembraneCommandLine();
+        cl.parse(new String[]{"generate-jwk", spelling, "-o", "key.json"});
+
+        assertTrue(cl.getCommand().isOptionSet("overwrite"));
+        assertEquals("key.json", cl.getCommand().getOptionValue("o"));
+    }
+
+    /**
+     * Every option must be usable in the --long spelling users expect from the rest of the CLI.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"start", "oas", "generate-jwk", "private-jwk-to-public", "argon2id"})
+    void everyOptionHasALongOption(String command) throws Exception {
+        MembraneCommandLine cl = new MembraneCommandLine();
+        cl.parse(new String[]{command, "-h"});
+
+        for (Option option : cl.getCommand().getOptions().getOptions()) {
+            assertNotNull(option.getLongOpt(), "-" + option.getOpt() + " of " + command + " has no long option");
+        }
     }
 }

--- a/core/src/test/java/com/predic8/membrane/core/cli/MembraneCommandLineTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/cli/MembraneCommandLineTest.java
@@ -1,0 +1,35 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+package com.predic8.membrane.core.cli;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MembraneCommandLineTest {
+
+    /**
+     * generate-jwk, private-jwk-to-public and argon2id used to ignore -h and run their command body
+     * instead: argon2id even prompted for a password, see issue #3222.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"start", "oas", "generate-jwk", "private-jwk-to-public", "argon2id"})
+    void everySubcommandSupportsHelp(String command) throws Exception {
+        MembraneCommandLine cl = new MembraneCommandLine();
+        cl.parse(new String[]{command, "-h"});
+
+        assertTrue(cl.getCommand().isOptionSet("h"));
+    }
+}

--- a/core/src/test/java/com/predic8/membrane/core/cli/MembraneCommandLineTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/cli/MembraneCommandLineTest.java
@@ -14,6 +14,7 @@
 package com.predic8.membrane.core.cli;
 
 import org.apache.commons.cli.Option;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -60,5 +61,17 @@ class MembraneCommandLineTest {
         for (Option option : cl.getCommand().getOptions().getOptions()) {
             assertNotNull(option.getLongOpt(), "-" + option.getOpt() + " of " + command + " has no long option");
         }
+    }
+
+    /**
+     * The argon2id password must reach the hash byte-for-byte; trimming it made two different
+     * passwords produce one identical PCH, see issue #3220.
+     */
+    @Test
+    void argon2idPasswordKeepsSurroundingWhitespace() throws Exception {
+        MembraneCommandLine cl = new MembraneCommandLine();
+        cl.parse(new String[]{"argon2id", "-pass", "  abc  "});
+
+        assertEquals("  abc  ", cl.getCommand().getOptionValue("pass"));
     }
 }

--- a/core/src/test/java/com/predic8/membrane/core/cli/MembraneCommandLineTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/cli/MembraneCommandLineTest.java
@@ -89,6 +89,32 @@ class MembraneCommandLineTest {
     }
 
     /**
+     * A typo in front of the configuration option silently discarded it, so Membrane fell back to
+     * config discovery and could start with a different configuration, see issue #3218.
+     */
+    @Test
+    void unknownRootOptionDoesNotDiscardConfigOption() {
+        MembraneCommandLine cl = new MembraneCommandLine();
+
+        assertEquals("Unknown option: --overwrite",
+                assertThrows(CommandParseException.class,
+                        () -> cl.parse(new String[]{"--overwrite", "-c", "t.apis.yaml"})).getMessage());
+    }
+
+    /**
+     * The dropped tokens made an unknown option look like a missing required one, see issue #3218.
+     */
+    @Test
+    void unknownSubcommandOptionIsReportedInsteadOfMissingRequiredOption() {
+        MembraneCommandLine cl = new MembraneCommandLine();
+
+        CommandParseException exception = assertThrows(CommandParseException.class,
+                () -> cl.parse(new String[]{"generate-jwk", "--foo", "-o", "key.json"}));
+        assertEquals("Unknown option: --foo", exception.getMessage());
+        assertEquals("generate-jwk", exception.getCommand().getName());
+    }
+
+    /**
      * The argon2id password must reach the hash byte-for-byte; trimming it made two different
      * passwords produce one identical PCH, see issue #3220.
      */

--- a/core/src/test/java/com/predic8/membrane/core/cli/MembraneCommandLineTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/cli/MembraneCommandLineTest.java
@@ -64,6 +64,31 @@ class MembraneCommandLineTest {
     }
 
     /**
+     * private-jwk-to-public relied on a runtime null check and printed its own error instead of the
+     * help text when a file was missing, see issue #3219.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"-i", "-o"})
+    void privateJwkToPublicRequiresBothFiles(String option) {
+        MembraneCommandLine cl = new MembraneCommandLine();
+
+        assertThrows(MissingRequiredOptionException.class,
+                () -> cl.parse(new String[]{"private-jwk-to-public", option, "key.json"}));
+    }
+
+    /**
+     * Replacing an existing output file needs -overwrite, as it does for generate-jwk, see issue #3219.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"-overwrite", "--overwrite"})
+    void privateJwkToPublicAcceptsOverwriteInBothSpellings(String spelling) throws Exception {
+        MembraneCommandLine cl = new MembraneCommandLine();
+        cl.parse(new String[]{"private-jwk-to-public", spelling, "-i", "key.json", "-o", "public.json"});
+
+        assertTrue(cl.getCommand().isOptionSet("overwrite"));
+    }
+
+    /**
      * The argon2id password must reach the hash byte-for-byte; trimming it made two different
      * passwords produce one identical PCH, see issue #3220.
      */

--- a/core/src/test/java/com/predic8/membrane/core/cli/RouterCLITest.java
+++ b/core/src/test/java/com/predic8/membrane/core/cli/RouterCLITest.java
@@ -23,8 +23,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.net.InetSocketAddress;
+import java.net.Socket;
 import java.time.Duration;
 
+import static com.predic8.membrane.core.util.NetworkUtil.getFreePortEqualAbove;
 import static org.junit.jupiter.api.Assertions.*;
 
 class RouterCLITest {
@@ -86,6 +89,30 @@ class RouterCLITest {
         cl.parse(new String[]{"argon2id"});
 
         assertEquals(19, RouterCLI.getArgon2Version(cl));
+    }
+
+    /**
+     * <code>oas -l ...</code> opened the port before init() had created the transport, so the
+     * subcommand always died with a NullPointerException. Starting the router must open the port
+     * and leave the router running, see issue #3216.
+     */
+    @Test
+    void initRouterByOpenApiSpecStartsRouter() throws Exception {
+        int port = getFreePortEqualAbove(3000);
+        MembraneCommandLine cl = new MembraneCommandLine();
+        cl.parse(new String[]{"oas", "-l", "src/test/resources/configuration/openapi/simple.oas.yml", "-p", String.valueOf(port)});
+
+        Router router = RouterCLI.initRouterByOpenApiSpec(cl);
+        try {
+            assertTrue(router.isRunning());
+            assertDoesNotThrow(() -> {
+                try (Socket socket = new Socket()) {
+                    socket.connect(new InetSocketAddress("localhost", port), 2000);
+                }
+            });
+        } finally {
+            router.stop();
+        }
     }
 
     /**

--- a/core/src/test/java/com/predic8/membrane/core/cli/RouterCLITest.java
+++ b/core/src/test/java/com/predic8/membrane/core/cli/RouterCLITest.java
@@ -20,6 +20,8 @@ import org.apache.commons.cli.ParseException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Logger;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
 
@@ -53,6 +55,37 @@ class RouterCLITest {
 
         assertEquals("Invalid value for -l: the OpenAPI location must not be empty.",
                 assertThrows(InvalidOptionValueException.class, () -> RouterCLI.getLocation(cl)).getMessage());
+    }
+
+    /**
+     * Argon2 defines only 0x10 and 0x13, so the range 16..19 wrongly accepted 17 and 18. Bouncy
+     * Castle then threw "unknown Argon2 version" - after the password prompt had already run.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"17", "18"})
+    void argon2VersionRejectsUndefinedVersions(String version) throws ParseException {
+        MembraneCommandLine cl = new MembraneCommandLine();
+        cl.parse(new String[]{"argon2id", "-v", version});
+
+        assertEquals("Invalid value for -v: %s is not a supported Argon2 version. Use 16 (0x10) or 19 (0x13).".formatted(version),
+                assertThrows(InvalidOptionValueException.class, () -> RouterCLI.getArgon2Version(cl)).getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {16, 19})
+    void argon2VersionAcceptsDefinedVersions(int version) throws ParseException {
+        MembraneCommandLine cl = new MembraneCommandLine();
+        cl.parse(new String[]{"argon2id", "-v", String.valueOf(version)});
+
+        assertEquals(version, RouterCLI.getArgon2Version(cl));
+    }
+
+    @Test
+    void argon2VersionDefaultsTo19() throws ParseException {
+        MembraneCommandLine cl = new MembraneCommandLine();
+        cl.parse(new String[]{"argon2id"});
+
+        assertEquals(19, RouterCLI.getArgon2Version(cl));
     }
 
     /**

--- a/core/src/test/java/com/predic8/membrane/core/cli/RouterCLITest.java
+++ b/core/src/test/java/com/predic8/membrane/core/cli/RouterCLITest.java
@@ -116,6 +116,28 @@ class RouterCLITest {
     }
 
     /**
+     * <code>start</code> is documented as "Same function as command omitted", but <code>-t</code> was
+     * gated on no command being given, so <code>start -t</code> parsed the option and then started the
+     * gateway for real instead of only verifying the configuration, see issue #3217.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"-t", "--test"})
+    void startWithTestOptionIsADryRun(String spelling) throws ParseException {
+        MembraneCommandLine cl = new MembraneCommandLine();
+        cl.parse(new String[]{"start", spelling, "src/test/resources/configuration/dry-run.apis.yaml"});
+
+        assertTrue(RouterCLI.isDryRun(cl));
+    }
+
+    @Test
+    void startWithoutTestOptionIsNoDryRun() throws ParseException {
+        MembraneCommandLine cl = new MembraneCommandLine();
+        cl.parse(new String[]{"start", "-c", "src/test/resources/configuration/dry-run.apis.yaml"});
+
+        assertFalse(RouterCLI.isDryRun(cl));
+    }
+
+    /**
      * Tests if the basepath is set on the configuration object. If not the resolving of
      * the openapi file in the config will fail.
      */

--- a/core/src/test/java/com/predic8/membrane/core/cli/RouterCLITest.java
+++ b/core/src/test/java/com/predic8/membrane/core/cli/RouterCLITest.java
@@ -63,9 +63,10 @@ class RouterCLITest {
     /**
      * Argon2 defines only 0x10 and 0x13, so the range 16..19 wrongly accepted 17 and 18. Bouncy
      * Castle then threw "unknown Argon2 version" - after the password prompt had already run.
+     * Every unsupported value gets the same message, whether it is inside that range or not.
      */
     @ParameterizedTest
-    @ValueSource(strings = {"17", "18"})
+    @ValueSource(strings = {"0", "17", "18", "20", "-1"})
     void argon2VersionRejectsUndefinedVersions(String version) throws ParseException {
         MembraneCommandLine cl = new MembraneCommandLine();
         cl.parse(new String[]{"argon2id", "-v", version});

--- a/core/src/test/java/com/predic8/membrane/core/cli/RouterCLITest.java
+++ b/core/src/test/java/com/predic8/membrane/core/cli/RouterCLITest.java
@@ -16,14 +16,14 @@ package com.predic8.membrane.core.cli;
 
 import com.predic8.membrane.core.router.Router;
 import com.predic8.membrane.test.TestAppender;
+import org.apache.commons.cli.ParseException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Logger;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class RouterCLITest {
 
@@ -40,6 +40,19 @@ class RouterCLITest {
     void verifyYamlConfiguration() {
         assertDoesNotThrow(() ->
                 RouterCLI.verifyConfiguration("src/test/resources/configuration/dry-run.apis.yaml"));
+    }
+
+    /**
+     * <code>oas -l ""</code> passes commons-cli's required check (it only guarantees presence) and
+     * used to end in a message-less RuntimeException, see issue #3224.
+     */
+    @Test
+    void getLocationRejectsEmptyLocation() throws ParseException {
+        MembraneCommandLine cl = new MembraneCommandLine();
+        cl.parse(new String[]{"oas", "-l", ""});
+
+        assertEquals("Invalid value for -l: the OpenAPI location must not be empty.",
+                assertThrows(InvalidOptionValueException.class, () -> RouterCLI.getLocation(cl)).getMessage());
     }
 
     /**

--- a/core/src/test/java/com/predic8/membrane/core/cli/util/JwkGeneratorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/cli/util/JwkGeneratorTest.java
@@ -14,6 +14,7 @@
 package com.predic8.membrane.core.cli.util;
 
 import com.predic8.membrane.core.cli.InvalidOptionValueException;
+import com.predic8.membrane.core.cli.MembraneCommandLine;
 import org.jose4j.lang.JoseException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,8 +23,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import static com.predic8.membrane.core.cli.util.JwkGenerator.checkFiles;
-import static com.predic8.membrane.core.cli.util.JwkGenerator.privateJWKtoPublic;
+import static com.predic8.membrane.core.cli.util.JwkGenerator.*;
 import static java.nio.file.Files.*;
 import static org.jose4j.jwk.JsonWebKey.OutputControlLevel.INCLUDE_PRIVATE;
 import static org.jose4j.jwk.RsaJwkGenerator.generateJwk;
@@ -93,6 +93,21 @@ class JwkGeneratorTest {
         assertEquals("Invalid value for -i: '%s' is not a file.".formatted(missing),
                 assertThrows(InvalidOptionValueException.class,
                         () -> checkFiles(missing.toString(), dir.resolve("public.json").toString(), false)).getMessage());
+    }
+
+    /**
+     * generate-jwk reports an existing output file the same way private-jwk-to-public does, and says
+     * which flag replaces it. It must do so before spending time on generating a key.
+     */
+    @Test
+    void generateJwkRefusesToReplaceExistingOutputWithoutOverwrite() throws Exception {
+        MembraneCommandLine cl = new MembraneCommandLine();
+        cl.parse(new String[]{"generate-jwk", "-o", privateJwk.toString()});
+
+        String before = readString(privateJwk);
+        assertEquals("Output file (%s) already exists. Use -overwrite to replace it.".formatted(privateJwk),
+                assertThrows(InvalidOptionValueException.class, () -> generateJWK(cl)).getMessage());
+        assertEquals(before, readString(privateJwk));
     }
 
     @Test

--- a/core/src/test/java/com/predic8/membrane/core/cli/util/JwkGeneratorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/cli/util/JwkGeneratorTest.java
@@ -1,0 +1,111 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+package com.predic8.membrane.core.cli.util;
+
+import com.predic8.membrane.core.cli.InvalidOptionValueException;
+import org.jose4j.lang.JoseException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static com.predic8.membrane.core.cli.util.JwkGenerator.checkFiles;
+import static com.predic8.membrane.core.cli.util.JwkGenerator.privateJWKtoPublic;
+import static java.nio.file.Files.*;
+import static org.jose4j.jwk.JsonWebKey.OutputControlLevel.INCLUDE_PRIVATE;
+import static org.jose4j.jwk.RsaJwkGenerator.generateJwk;
+import static org.junit.jupiter.api.Assertions.*;
+
+class JwkGeneratorTest {
+
+    @TempDir
+    Path dir;
+
+    private Path privateJwk;
+
+    @BeforeEach
+    void setUp() throws JoseException, IOException {
+        privateJwk = dir.resolve("key.json");
+        writeString(privateJwk, generateJwk(2048).toJson(INCLUDE_PRIVATE));
+    }
+
+    /**
+     * <code>private-jwk-to-public -i k.json -o k.json</code> wrote the public JWK onto its own input
+     * and destroyed the private key components, see issue #3219.
+     */
+    @Test
+    void refusesToWriteOntoItsInput() {
+        assertEquals("Invalid value for -o: '%s' is the input file. Converting it in place would destroy the private key.".formatted(privateJwk),
+                assertThrows(InvalidOptionValueException.class,
+                        () -> checkFiles(privateJwk.toString(), privateJwk.toString(), false)).getMessage());
+    }
+
+    /**
+     * Comparing the two paths as strings is not enough: different spellings of one file must be
+     * rejected as well.
+     */
+    @Test
+    void refusesToWriteOntoItsInputSpelledDifferently() throws IOException {
+        String indirect = createDirectory(dir.resolve("sub")).resolve("..").resolve("key.json").toString();
+
+        assertThrows(InvalidOptionValueException.class,
+                () -> checkFiles(privateJwk.toString(), indirect, false));
+    }
+
+    /**
+     * Replacing an existing file needs -overwrite, as it does for generate-jwk.
+     */
+    @Test
+    void refusesToReplaceExistingOutput() throws IOException {
+        Path output = dir.resolve("public.json");
+        writeString(output, "{}");
+
+        assertEquals("Output file (%s) already exists. Use -overwrite to replace it.".formatted(output),
+                assertThrows(InvalidOptionValueException.class,
+                        () -> checkFiles(privateJwk.toString(), output.toString(), false)).getMessage());
+    }
+
+    @Test
+    void replacesExistingOutputIfOverwriteIsSet() throws IOException {
+        Path output = dir.resolve("public.json");
+        writeString(output, "{}");
+
+        assertDoesNotThrow(() -> checkFiles(privateJwk.toString(), output.toString(), true));
+    }
+
+    @Test
+    void rejectsMissingInput() {
+        Path missing = dir.resolve("absent.json");
+
+        assertEquals("Invalid value for -i: '%s' is not a file.".formatted(missing),
+                assertThrows(InvalidOptionValueException.class,
+                        () -> checkFiles(missing.toString(), dir.resolve("public.json").toString(), false)).getMessage());
+    }
+
+    @Test
+    void writesPublicKeyAndLeavesInputUntouched() throws IOException {
+        String before = readString(privateJwk);
+        Path output = dir.resolve("public.json");
+
+        privateJWKtoPublic(privateJwk.toString(), output.toString(), false);
+
+        assertEquals(before, readString(privateJwk));
+        for (String privateComponent : new String[]{"\"d\"", "\"p\"", "\"q\"", "\"dp\"", "\"dq\"", "\"qi\""}) {
+            assertFalse(readString(output).contains(privateComponent), privateComponent + " leaked into the public JWK");
+        }
+        assertTrue(readString(output).contains("\"n\""));
+    }
+}

--- a/core/src/test/java/com/predic8/membrane/devtools/SingleTestRunner.java
+++ b/core/src/test/java/com/predic8/membrane/devtools/SingleTestRunner.java
@@ -48,8 +48,10 @@ public class SingleTestRunner {
         launcher.execute(discoveryRequest);
 
         TestExecutionSummary summary = listener.getSummary();
-        summary.printTo(new PrintWriter(System.out));
-        summary.printFailuresTo(new PrintWriter(System.out), 100);
+        // Autoflush: without it the buffered summary is lost when main() calls System.exit().
+        PrintWriter out = new PrintWriter(System.out, true);
+        summary.printTo(out);
+        summary.printFailuresTo(out, 100);
         return isFailure(summary) ? 1 : 0;
     }
 


### PR DESCRIPTION
Closes #3224
Closes #3219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent `-h`/`--help` support across CLI commands, including when required options are omitted.
  * Added validation for numeric command-line values, with supported ranges and defaults.
  * RSA key generation now defaults to 2048 bits and accepts sizes from 2048 to 16384 bits.

* **Bug Fixes**
  * Improved handling of whitespace in command-line values.
  * Argon2id now accepts only supported versions 16 and 19.

* **Documentation**
  * Help text now documents valid value ranges and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
