### PR TITLE
fix(annot): map boxed and integral @MCAttribute types correctly in the JSON schema

### DIFF
--- a/annot/src/main/java/com/predic8/membrane/annot/model/AttributeInfo.java
+++ b/annot/src/main/java/com/predic8/membrane/annot/model/AttributeInfo.java
@@ -65,9 +65,9 @@ public class AttributeInfo extends AbstractJavadocedInfo {
             return "boolean";
         }
         return switch (getXSDType(typeUtils)) {
-            case "spel_number", "xsd:double", "xsd:float", "xsd:decimal" -> "number";
-            case "spel_boolean", "xsd:boolean" -> "boolean";
-            case "xsd:int", "xsd:integer", "xsd:long" -> "integer";
+            case "spel_number" -> "integer"; // spel_number is emitted for integral types only
+            case "xsd:double", "xsd:float" -> "number";
+            case "spel_boolean" -> "boolean";
             default -> "string";
         };
     }
@@ -130,8 +130,16 @@ public class AttributeInfo extends AbstractJavadocedInfo {
                     return;
                 }
 
-                if (e.getQualifiedName().toString().equals("java.lang.String")) {
+                String qualifiedName = e.getQualifiedName().toString();
+
+                if (qualifiedName.equals("java.lang.String")) {
                     xsdType = "xsd:string";
+                    return;
+                }
+
+                String boxedXsdType = boxedXSDType(qualifiedName);
+                if (boxedXsdType != null) {
+                    xsdType = boxedXsdType;
                     return;
                 }
 
@@ -160,6 +168,22 @@ public class AttributeInfo extends AbstractJavadocedInfo {
             default:
                 throw new ProcessingException("Not implemented: XSD type for " + ve.asType().getKind().toString(), this.getE());
         }
+    }
+
+    /**
+     * Boxed scalars are configured by value, exactly like their primitive counterparts. Without this
+     * they would fall through to the bean reference fallback of analyze() and be declared as strings.
+     *
+     * @return the XSD type of the boxed scalar, or {@code null} if the type is not a boxed scalar
+     */
+    private static String boxedXSDType(String qualifiedName) {
+        return switch (qualifiedName) {
+            case "java.lang.Integer", "java.lang.Long", "java.lang.Short", "java.lang.Byte" -> "spel_number";
+            case "java.lang.Double" -> "xsd:double";
+            case "java.lang.Float" -> "xsd:float";
+            case "java.lang.Boolean" -> "spel_boolean";
+            default -> null;
+        };
     }
 
     private static List<String> getEnumValues(TypeElement te) {

--- a/annot/src/test/java/com/predic8/membrane/annot/generator/JsonSchemaGeneratorTest.java
+++ b/annot/src/test/java/com/predic8/membrane/annot/generator/JsonSchemaGeneratorTest.java
@@ -1,0 +1,86 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.annot.generator;
+
+import com.fasterxml.jackson.databind.*;
+import com.predic8.membrane.annot.util.*;
+import org.junit.jupiter.api.*;
+
+import java.io.*;
+
+import static com.predic8.membrane.annot.SpringConfigurationXSDGeneratingAnnotationProcessorTest.*;
+import static com.predic8.membrane.annot.util.CompilerHelper.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class JsonSchemaGeneratorTest {
+
+    private static final String SCHEMA_RESOURCE = "com/predic8/membrane/demo/config/json/membrane.schema.json";
+
+    /**
+     * Boxed attribute types have to yield the same schema type as their primitive counterparts,
+     * instead of falling through to the bean reference branch and becoming strings.
+     */
+    @Test
+    void boxedAttributesAreScalars() throws Exception {
+        var result = compile(splitSources(MC_MAIN_DEMO + """
+                package com.predic8.membrane.demo;
+                import com.predic8.membrane.annot.*;
+                @MCElement(name="demo", topLevel=true, component=false)
+                public class DemoElement {
+                    @MCAttribute
+                    public void setBoxedInt(Integer value) {}
+                    public Integer getBoxedInt() { return null; }
+                
+                    @MCAttribute
+                    public void setPrimitiveInt(int value) {}
+                    public int getPrimitiveInt() { return 0; }
+                
+                    @MCAttribute
+                    public void setBoxedLong(Long value) {}
+                    public Long getBoxedLong() { return null; }
+                
+                    @MCAttribute
+                    public void setBoxedDouble(Double value) {}
+                    public Double getBoxedDouble() { return null; }
+                
+                    @MCAttribute
+                    public void setBoxedBoolean(Boolean value) {}
+                    public Boolean getBoxedBoolean() { return null; }
+                
+                    @MCAttribute
+                    public void setText(String value) {}
+                    public String getText() { return null; }
+                }
+                """), false);
+        assertCompilerResult(true, result);
+
+        JsonNode properties = schema(result)
+                .at("/$defs/com_predic8_membrane_demo_config_spring_DemoParser/properties");
+
+        assertEquals("[\"integer\",\"string\"]", properties.at("/primitiveInt/type").toString());
+        assertEquals(properties.at("/primitiveInt/type"), properties.at("/boxedInt/type"));
+        assertEquals(properties.at("/primitiveInt/type"), properties.at("/boxedLong/type"));
+        assertEquals("[\"number\",\"string\"]", properties.at("/boxedDouble/type").toString());
+        assertEquals("[\"boolean\",\"string\"]", properties.at("/boxedBoolean/type").toString());
+        assertEquals("\"string\"", properties.at("/text/type").toString());
+    }
+
+    private static JsonNode schema(CompilerResult result) throws IOException {
+        try (InputStream is = result.classLoader().getResourceAsStream(SCHEMA_RESOURCE)) {
+            assertNotNull(is, "membrane.schema.json was not generated");
+            return new ObjectMapper().readTree(is);
+        }
+    }
+}

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/json/rpc/BatchRule.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/json/rpc/BatchRule.java
@@ -26,7 +26,7 @@ public class BatchRule {
 
     private boolean enabled = true;
 
-    private Integer maxSize = 100;
+    private int maxSize = 100;
 
     /**
      * @description Enables or disables JSON-RPC batch requests.
@@ -43,14 +43,14 @@ public class BatchRule {
      * @example 50
      */
     @MCAttribute
-    public void setMaxSize(Integer maxSize) {
-        if (maxSize == null || maxSize < 1) {
+    public void setMaxSize(int maxSize) {
+        if (maxSize < 1) {
             throw new ConfigurationException("batch maxSize must be greater than 0");
         }
         this.maxSize = maxSize;
     }
 
-    public Integer getMaxSize() {
+    public int getMaxSize() {
         return maxSize;
     }
 


### PR DESCRIPTION
Closes #3230

## Problem

An `@MCAttribute` setter taking a **boxed** type (`Integer`, `Boolean`, …) is `TypeKind.DECLARED`, so `AttributeInfo.analyze()` ran past the enum/String checks into the bean-reference fallback: `isBeanReference = true; xsdType = "xsd:string"`. Consequences:

- `membrane.schema.json` declared `"type": "string"` (and `router-conf.xsd` `xsd:string`), so correct YAML such as `maxSize: 10` was flagged as an error by the `yaml-language-server` schema used in `conf/apis.yaml` and the tutorials, while `maxSize: "abc"` was accepted.
- In XML the generated parser emitted `addPropertyReference("maxSize", "10")` — the value was treated as a Spring bean name. YAML binding was correct only because `ScalarValueConverter` checks `isNumber` before `isBeanReference`.

`BatchRule.maxSize` (`<jsonRPCProtection><batch maxSize="…">`) was the only affected attribute in `core`.

## Changes

1. **`AttributeInfo.analyze()`** recognises the boxed scalars in the `DECLARED` branch, before the bean-reference fallback, and maps them to the same XSD type as their primitive counterparts (`Integer`/`Long`/`Short`/`Byte` → `spel_number`, `Double`/`Float` → `xsd:double`/`xsd:float`, `Boolean` → `spel_boolean`).
2. **`BatchRule.maxSize` is an `int`** (field, setter, getter). The `maxSize == null` half of its guard was unreachable, and `getMaxSize()` no longer unboxes on every batch request.
3. **`getSchemaType()`**: `spel_number` now maps to `"integer"` — it is emitted for integral types only, its XSD pattern is `-?[0-9]+|#{…}|${…}` — and the unreachable `xsd:int`/`xsd:integer`/`xsd:long`/`xsd:decimal`/`xsd:boolean` arms are gone. `analyze()` is the only writer of `xsdType` and never produced those values.

`getXSDType()` is untouched, so the `| string` SpEL union still applies (`integer` is already in `AbstractSchema.STRING_ALLOWED_TYPES`): `maxSize` is now `["integer","string"]`.

### Schema impact

119 attributes move from `["number","string"]` to `["integer","string"]`; 3 genuine `double`/`float` attributes stay `["number","string"]`. Strings, booleans and arrays are unchanged.

## Verification

- New `annot/src/test/java/com/predic8/membrane/annot/generator/JsonSchemaGeneratorTest` compiles a demo element with boxed and primitive attributes through the annotation processor and asserts the generated `membrane.schema.json` types.
- `annot` module: 150 tests, 0 failures, 1 skipped.
- `core` package `com.predic8.membrane.core.interceptor.json.rpc`: 45/46 — the one failure is a `PortOccupiedException` on `*:2000` from a locally running gateway, unrelated.
- All 212 shipped YAML configs under `distribution/tutorials`, `distribution/router/conf` and `distribution/examples` that reference the schema were validated against the regenerated schema with the same fge validator the distribution test uses: 0 errors.

## Side finding (not addressed here)

`ConfigSerializationTestYaml` scans for `proxies.yaml` under `examples`/`router`; no such file exists any more, so the parameterized test yields zero cases and fails with *"must configure at least one set of arguments"*. Dead coverage, independent of this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected generated JSON schemas for boxed numeric and Boolean properties, ensuring they use the appropriate scalar types instead of being represented as strings.
  - Improved schema type mapping for integer and floating-point values.

- **Validation**
  - Batch processing size configuration now consistently requires a positive numeric value, with a default limit of 100.
  - Added coverage confirming equivalent schema output for primitive and boxed property types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->