### PR TITLE
fix(http): honor Content-Type charset when parsing XmlDomBody

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/http/XmlDomBody.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/XmlDomBody.java
@@ -88,7 +88,7 @@ public class XmlDomBody extends AbstractBody {
         if (msg.getBody() instanceof XmlDomBody xmlDomBody)
             return xmlDomBody.getDocument();
         byte[] content = msg.getBody().getContent();
-        Document doc = msg.isEncoded() ? parseDecoded(msg) : parse(content);
+        Document doc = msg.isEncoded() ? parseDecoded(msg) : parse(msg, content);
         msg.setBody(new XmlDomBody(doc, content)); // Bytes unchanged, so the header still fits
         return doc;
     }
@@ -209,8 +209,19 @@ public class XmlDomBody extends AbstractBody {
         }
     }
 
-    private static Document parse(byte[] content) {
-        return HardenedXmlParser.getInstance().parse(new InputSource(new ByteArrayInputStream(content)));
+    /**
+     * Parses bytes the caller already read, so the {@code Content-Type} charset has to be applied
+     * here explicitly instead of via {@link XMLUtil#getInputSource(Message)}, which reads the
+     * message's body stream itself. Per RFC 7303 that charset takes precedence over the XML
+     * declaration, so it must win over the SAX parser's own detection.
+     */
+    private static Document parse(Message msg, byte[] content) {
+        InputSource source = new InputSource(new ByteArrayInputStream(content));
+        String charset = msg.getHeader().getCharset();
+        if (charset != null) {
+            source.setEncoding(charset);
+        }
+        return HardenedXmlParser.getInstance().parse(source);
     }
 
     /**
@@ -243,10 +254,15 @@ public class XmlDomBody extends AbstractBody {
      * Parses the decoded body, streaming it into the parser rather than materializing it as a
      * second array. The stream is closed because for a gzip or brotli body it holds a native
      * decompressor, which is then released here instead of whenever the Cleaner gets to it.
+     * <p>
+     * {@link XMLUtil#getInputSource(Message)} builds the {@link InputSource}, so the
+     * {@code Content-Type} charset takes precedence over the XML declaration here the same way it
+     * does for every other XPath/XML consumer of a {@link Message}.
      */
     private static Document parseDecoded(Message msg) {
-        try (InputStream in = msg.getBodyAsStreamDecoded()) {
-            return HardenedXmlParser.getInstance().parse(new InputSource(in));
+        InputSource source = XMLUtil.getInputSource(msg);
+        try (InputStream in = source.getByteStream()) {
+            return HardenedXmlParser.getInstance().parse(source);
         } catch (IOException e) {
             throw new ReadingBodyException(e);
         }

--- a/core/src/test/java/com/predic8/membrane/core/http/XmlDomBodyTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/http/XmlDomBodyTest.java
@@ -45,6 +45,25 @@ class XmlDomBodyTest {
             <?xml version="1.0" encoding="ISO-8859-1"?>
             <greeting>Grüße</greeting>""";
 
+    /**
+     * Declares ISO-8859-1 but is actually ISO-8859-15: byte 0xA4 is the currency sign (¤) in the
+     * former and the euro sign (€) in the latter, one of the few code points the two disagree on.
+     * Neither is multi-byte, so misreading the charset silently swaps one character for the other
+     * rather than failing to parse.
+     */
+    private static final byte[] CONTRADICTING_CHARSET_XML = concat(
+            "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><price>".getBytes(ISO_8859_1),
+            new byte[]{(byte) 0xA4},
+            "</price>".getBytes(ISO_8859_1));
+
+    private static byte[] concat(byte[]... parts) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        for (byte[] part : parts) {
+            out.writeBytes(part);
+        }
+        return out.toByteArray();
+    }
+
     private static Request requestWith(byte[] content) {
         Request req = new Request();
         req.setBodyContent(content);
@@ -110,9 +129,14 @@ class XmlDomBodyTest {
     @Test
     void replaceBodyCorrectsAContentTypeCharsetThatContradictsTheBytes() {
         Request req = requestWith(LATIN1_XML.getBytes(ISO_8859_1));
+        // Parsed while the header still agrees with the declaration; the contradiction below is
+        // introduced only afterwards, e.g. by an interceptor that touches the header but not the
+        // body - documentOf() honors the (correct) header at parse time, so this must not be set
+        // any earlier or the message would be genuinely malformed and fail to parse.
+        Document doc = XmlDomBody.documentOf(req);
         req.getHeader().setContentType("text/xml; charset=UTF-8");
 
-        XmlDomBody.replaceBody(req, XmlDomBody.documentOf(req));
+        XmlDomBody.replaceBody(req, doc);
 
         assertEquals("ISO-8859-1", req.getHeader().getCharset());
         assertTrue(req.getHeader().getContentType().startsWith("text/xml"), req.getHeader().getContentType());
@@ -128,9 +152,13 @@ class XmlDomBodyTest {
     @Test
     void replaceBodyCorrectsTheCharsetOfAnUndeclaredDocumentToUtf8() {
         Request req = requestWith("<greeting>Grüße</greeting>".getBytes(UTF_8));
+        // See replaceBodyCorrectsAContentTypeCharsetThatContradictsTheBytes(): the contradicting
+        // header is introduced only after parsing, so documentOf() still sees a header-free (and
+        // so correctly UTF-8-decoded) message.
+        Document doc = XmlDomBody.documentOf(req);
         req.getHeader().setContentType("text/xml; charset=ISO-8859-1");
 
-        XmlDomBody.replaceBody(req, XmlDomBody.documentOf(req));
+        XmlDomBody.replaceBody(req, doc);
 
         assertEquals("UTF-8", req.getHeader().getCharset());
         assertTrue(new String(req.getBody().getContent(), UTF_8).contains("Grüße"),
@@ -340,6 +368,36 @@ class XmlDomBodyTest {
 
         assertSame(first, XmlDomBody.documentOf(req));
         assertArrayEquals(original, req.getBody().getContent());
+    }
+
+    /**
+     * RFC 7303 gives the {@code Content-Type} charset precedence over the XML declaration - the
+     * read-side mirror of {@link #replaceBodyCorrectsAContentTypeCharsetThatContradictsTheBytes()}.
+     * Issue #3141: {@code documentOf}'s non-encoded path used to build its {@code InputSource}
+     * straight from the bytes, ignoring the header and letting the (wrong) declaration decide.
+     */
+    @Test
+    void documentOfHonorsTheContentTypeCharsetOverAContradictingXmlDeclaration() {
+        Request req = requestWith(CONTRADICTING_CHARSET_XML);
+        req.getHeader().setContentType("text/xml; charset=ISO-8859-15");
+
+        Document doc = XmlDomBody.documentOf(req);
+
+        assertEquals("€", doc.getDocumentElement().getTextContent());
+    }
+
+    /**
+     * Same precedence rule, but through the encoded/streaming path ({@code parseDecoded}).
+     */
+    @Test
+    void gzippedDocumentOfHonorsTheContentTypeCharsetOverAContradictingXmlDeclaration() throws IOException {
+        Request req = requestWith(gzip(CONTRADICTING_CHARSET_XML));
+        req.getHeader().setValue(CONTENT_ENCODING, "gzip");
+        req.getHeader().setContentType("text/xml; charset=ISO-8859-15");
+
+        Document doc = XmlDomBody.documentOf(req);
+
+        assertEquals("€", doc.getDocumentElement().getTextContent());
     }
 
     /**


### PR DESCRIPTION
## Problem

`XmlDomBody`'s read path (`parse(byte[])` / `parseDecoded(Message)`) built its `InputSource` directly from the raw bytes/stream without ever consulting the message's declared charset, so decoding fell back entirely to the SAX parser's own detection (BOM / XML declaration / UTF-8 default). Per RFC 7303, a charset on `Content-Type` should take precedence over the XML declaration — this is exactly the bug fixed for `XMLUtil.getInputSource` in #3129, but `XmlDomBody` has its own, separate parsing path that was not covered by that fix.

A body whose `Content-Type` charset differs from (or is present when the XML declaration omits) the actual encoding could be misdecoded by any interceptor/expression that goes through `XmlDomBody.documentOf`/`XmlDomBody.xpath`.

## Fix

- `parse(byte[])` now sets `InputSource.setEncoding(...)` from `msg.getHeader().getCharset()`.
- `parseDecoded(Message)` now delegates `InputSource` construction to `XMLUtil.getInputSource(msg)` (the same helper #3129 fixed), while preserving its stream-closing behavior via `source.getByteStream()`.

## Tests

Added two regression tests using a body whose XML declaration falsely claims ISO-8859-1 while the actual bytes are ISO-8859-15 (byte `0xA4` decodes as `¤` vs `€` — a single-byte encoding pair chosen so a wrong charset silently swaps the character instead of throwing a parse error): one for the non-encoded path, one for the gzip/streamed path. Both fail without the fix, pass with it.

Fixing the read path exposed that two pre-existing write-side tests (`replaceBodyCorrectsAContentTypeCharsetThatContradictsTheBytes`, `replaceBodyCorrectsTheCharsetOfAnUndeclaredDocumentToUtf8`) set a contradicting `Content-Type` charset *before* parsing, which only worked because the read path used to ignore it. Reordered both to set the contradicting header *after* parsing (simulating an interceptor that touches the header but not the body), preserving their original intent of testing the write-side charset-correction logic.

`XmlDomBodyTest`: 25/25 passing.

Closes #3141

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * XML content now consistently honors the message’s declared `Content-Type` charset when it conflicts with the encoding specified in the XML document.
  * Improved charset handling for both regular and compressed/streaming XML responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->