### PR TITLE
Publish the release tag to Maven Central, not whatever ref was dispatched (6.X)

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -3,13 +3,39 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish, e.g. v6.6.0. Required unless the workflow is run on the tag itself."
+        type: string
+        required: false
+        default: ''
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      # Without this the workflow deploys whatever ${{ github.ref }} points at,
+      # so dispatching it on a branch deploys that branch's SNAPSHOT to Maven
+      # Central instead of the release. Resolving an explicit tag also avoids
+      # the ambiguity of release-pr.yml creating a branch AND a tag named
+      # v<version>.
+      - name: Resolve release tag
+        id: release_version
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          RELEASE_TAG="${INPUT_TAG:-$REF_NAME}"
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::'$RELEASE_TAG' is not a release tag. Dispatch this workflow on the tag, or pass the 'tag' input (e.g. v6.6.0)."
+            exit 1
+          fi
+          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          echo "Publishing $RELEASE_TAG to Maven Central"
+
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.ref }}
+          ref: refs/tags/${{ steps.release_version.outputs.release_tag }}
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
Port of #3226 to `6.X`.

## The bug

`maven-publish.yml` checks out `${{ github.ref }}` and then runs `mvn deploy`. Every Maven Central release goes out via manual `workflow_dispatch`, and **dispatching this workflow on a branch deploys that branch's SNAPSHOT to Central**, not the release.

`6.X` is currently a snapshot version, so a dispatch on the branch would publish that.

## The fix

A `tag` input resolved exactly as in `docker-publish.yml` on this branch — falling back to `github.ref_name`, validated against a complete SemVer version — and `ref: refs/tags/<tag>` on the checkout. The validation regex is byte-identical to the one already in `docker-publish.yml` here and in #3226, so all three copies stay in sync.

An explicit tag ref also removes the latent ambiguity of `release-pr.yml` creating both a branch **and** a tag named `v<version>`.

## Scope

`6.X` needs nothing else. #3213 already landed the good shape here: a single `trigger-docker` job with job-scoped `contents: read` / `actions: write` and no workflow-level `actions: write`, plus the `Resolve release tag` step in `docker-publish.yml`. The duplicate-dispatch problem fixed in #3226 is `master`-only — it came from #3225 having been branched before the #3214 refactor and re-adding the pre-refactor step.

The change is deliberately minimal: `actions/checkout@v3` is not bumped and `persist-credentials: false` is not added, since those came to `master` from unrelated work.

## Missing from Central

`repo1.maven.org/maven2/org/membrane-soa/service-proxy-core` currently lists:

```
6.5.3  6.5.4  7.2.5  7.3.1  7.5.0
```

**6.6.0 was never published.** Once this is merged, the manual path is safe:

```sh
gh workflow run maven-publish.yml --ref 6.X -f tag=v6.6.0
```

Note this does not address the `central-publishing-maven-plugin` upload failure that made Central publishing manual in the first place — see #3226 for that.
