### PR TITLE
Share one HttpClient per BrowserMock instead of building one per request

### DIFF
--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/BrowserMock.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/BrowserMock.java
@@ -33,13 +33,14 @@ import static java.nio.charset.StandardCharsets.*;
 import static java.util.stream.Collectors.*;
 import static org.apache.commons.text.StringEscapeUtils.*;
 
-public class BrowserMock implements Function<Exchange, Exchange> {
+public class BrowserMock implements Function<Exchange, Exchange>, AutoCloseable {
 
     public static final Pattern INPUT_PATTERN = Pattern.compile("<input type=\"hidden\" name=\"([-a-zA-Z0-9&;_]*)\" value=\"([-a-zA-Z ._~=0-9&/;]*)\"/>");
     public static final Pattern FORM_PATTERN = Pattern.compile("<form method=\"post\" action=\"([a-z:/0-9]*)\"");
     final Logger LOG = LoggerFactory.getLogger(BrowserMock.class);
     final Map<String, Map<String, String>> cookie = new HashMap<>();
-    final Function<Exchange, Exchange> cookieHandlingHttpClient = exc -> cookieManager(httpClient(), exc);
+    final HttpClient httpClient = new HttpClient(getHttpClientConfiguration());
+    final Function<Exchange, Exchange> cookieHandlingHttpClient = exc -> cookieManager(this::call, exc);
     final Function<Exchange, Exchange> cookieHandlingRedirectingHttpClient = outerExc -> handleFormPost(innerExc -> handleRedirect(cookieHandlingHttpClient, innerExc, new ArrayList<>()), outerExc);
 
     /**
@@ -350,20 +351,18 @@ public class BrowserMock implements Function<Exchange, Exchange> {
         return location;
     }
 
-    private Function<Exchange, Exchange> httpClient() {
-        return new Function<>() {
-            final HttpClient httpClient = new HttpClient(getHttpClientConfiguration());
+    private Exchange call(Exchange exchange) {
+        try {
+            ConnectRetry.call(httpClient, exchange);
+            return exchange;
+        } catch (Exception e) {
+            throw new RuntimeException("while calling " + exchange.getOriginalRelativeURI(), e);
+        }
+    }
 
-            @Override
-            public Exchange apply(Exchange exchange) {
-                try {
-                    ConnectRetry.call(httpClient, exchange);
-                    return exchange;
-                } catch (Exception e) {
-                    throw new RuntimeException("while calling " + exchange.getOriginalRelativeURI(), e);
-                }
-            }
-        };
+    @Override
+    public void close() {
+        httpClient.close();
     }
 
     private static @NotNull HttpClientConfiguration getHttpClientConfiguration() {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/OAuth2ResourceErrorForwardingTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/OAuth2ResourceErrorForwardingTest.java
@@ -82,6 +82,7 @@ public class OAuth2ResourceErrorForwardingTest {
 
     @AfterEach
     public void done() {
+        browser.close();
         if (mockAuthServer != null)
             mockAuthServer.stop();
         if (oauth2Resource != null)

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/OAuth2ResourceRpIniLogoutTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/OAuth2ResourceRpIniLogoutTest.java
@@ -94,6 +94,7 @@ public class OAuth2ResourceRpIniLogoutTest {
 
     @AfterEach
     public void done() {
+        browser.close();
         if (mockAuthServer != null)
             mockAuthServer.stop();
         if (oauth2Resource != null)

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/OAuth2ResourceTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/OAuth2ResourceTest.java
@@ -83,6 +83,7 @@ public abstract class OAuth2ResourceTest {
 
     @AfterEach
     public void done() {
+        browser.close();
         if (mockAuthServer != null)
             mockAuthServer.stop();
         if (oauth2Resource != null)

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/b2c/OAuth2ResourceB2CTestSetup.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/client/b2c/OAuth2ResourceB2CTestSetup.java
@@ -44,6 +44,7 @@ public abstract class OAuth2ResourceB2CTestSetup {
 
     @AfterEach
     void done() {
+        browser.close();
         mockAuthorizationServer.stop();
         b2cMembrane.stop();
     }


### PR DESCRIPTION
Test-scope leak fix. Stacked on #3237, which introduces the `ConnectRetry` helper this touches; merge that one first and this retargets to `master` automatically.

> Verification was still running when this was opened — results will be posted as a comment.

## The leak

`BrowserMock` routed every request through

```java
    final Function<Exchange, Exchange> cookieHandlingHttpClient = exc -> cookieManager(httpClient(), exc);
```

and `httpClient()` constructed a **new `HttpClient` on every call**, i.e. one per HTTP request, never closed:

```java
    private Function<Exchange, Exchange> httpClient() {
        return new Function<>() {
            final HttpClient httpClient = new HttpClient(getHttpClientConfiguration());
            ...
```

Each of those carries its own `ConnectionFactory` → `ConnectionManager`, and since no `TimerManager` is passed, the `ConnectionManager` creates its own `Timer` thread:

```java
        var autoCloseInterval = keepAliveTimeout * 2;
        if (timerManager == null)
            selfCreatedTimerManager = timerManager = new TimerManager();
        timerManager.schedulePeriodicTask(..., autoCloseInterval, "Connection Closer");
```

It also holds pooled keep-alive connections for `keepAliveTimeout` (4 s by default). The B2C tests drive 500 workers through a redirect, form-post and token-refresh chain, so one test run leaked thousands of clients, sockets and timer threads.

## The fix

Hold one `HttpClient` per `BrowserMock` and reuse it — which is how the gateway itself uses the class: a single instance serves every request thread. The anonymous `Function` collapses into a private `call(Exchange)` method with the same body and the same `RuntimeException("while calling " + ...)` wrapping.

`BrowserMock` becomes `AutoCloseable`, and its four users close it in their `@AfterEach`, so the one remaining client and its timer go away with the test: `OAuth2ResourceTest`, `OAuth2ResourceErrorForwardingTest`, `OAuth2ResourceRpIniLogoutTest`, `OAuth2ResourceB2CTestSetup`.

## Not the cause of the Windows failures

This was found while diagnosing #3237 and was explicitly cleared of causing those failures: every lost request there was a `ConnectException` from the accept queue Windows caps at 200, with no `BindException` and no thread-creation failure anywhere in the evidence. It is a leak worth fixing on its own terms, which is why it is not bundled into #3237.

## Review focus

The interesting risk is the opposite of the leak: a single `HttpClient` is now shared across 500 concurrent workers, and `close()` calls `shutdownWhenDone()` on the connection manager. Verification therefore targets

- `InMemB2CResourceIntegrationTest` and `JwtB2CResourceIntegrationTest` under full 500-way concurrency, watching for any new pool or keep-alive exception type
- the three non-B2C `BrowserMock` users, whose teardown changed
- `InMemB2CResourceTest` as a second regression check

Note that `SyncB2CResourceIntegrationTest` fails in roughly half of runs for an unrelated reason tracked in #3238 (lost session updates breaking OAuth2 CSRF state); a CSRF failure there is not attributable to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved OAuth2 test cleanup by consistently releasing browser resources after each test.
  - Reused a shared HTTP client during browser-mock interactions, reducing repeated client creation.
  - Added automatic resource closing support to the test browser utility.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->