### PR TITLE
Fix/validator bugs

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/AbstractXMLSchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/AbstractXMLSchemaValidator.java
@@ -157,6 +157,13 @@ public abstract class AbstractXMLSchemaValidator extends AbstractMessageValidato
      * Takes a {@link Supplier} rather than a single {@link Source} because a {@code Source}
      * backed by a stream is consumed after one {@code validate()} call - a fresh one is needed
      * for each of the (possibly several) embedded schemas tried.
+     * <p>
+     * A schema whose validator run itself throws (as opposed to reporting validation errors
+     * through its {@link SchemaValidatorErrorHandler}) is logged immediately - unlike an ordinary
+     * validation mismatch, it signals something more serious (e.g. a schema failing to resolve an
+     * import) that must not go unnoticed just because another embedded schema goes on to match -
+     * and the remaining schemas are still tried; one broken schema must not stop a message from
+     * matching another one of the (possibly several) alternatives.
      *
      * @param exceptions collects one exception per schema the source failed against
      * @return {@code true} if the source matched at least one embedded schema
@@ -169,12 +176,15 @@ public abstract class AbstractXMLSchemaValidator extends AbstractMessageValidato
         try {
             // the message must be valid for one schema embedded into WSDL
             for (var validator : vals) {
-                if (validateOnce(validator, source.get(), exceptions)) {
-                    return true;
+                try {
+                    if (validateOnce(validator, source.get(), exceptions)) {
+                        return true;
+                    }
+                } catch (Exception e) {
+                    logValidatorFailure(e);
+                    exceptions.add(e);
                 }
             }
-        } catch (Exception e) {
-            exceptions.add(e);
         } finally {
             validators.put(vals);
         }
@@ -198,11 +208,23 @@ public abstract class AbstractXMLSchemaValidator extends AbstractMessageValidato
         try {
             return validateOnce(validator, source, exceptions);
         } catch (Exception e) {
+            logValidatorFailure(e);
             exceptions.add(e);
             return false;
         } finally {
             pool.put(validator);
         }
+    }
+
+    /**
+     * A validator throwing (rather than reporting an ordinary validation error through its
+     * {@link SchemaValidatorErrorHandler}) signals something more serious than "the message
+     * doesn't match this schema" - e.g. a schema failing to resolve an import. Unlike ordinary
+     * validation errors, which are only logged once none of the (possibly several) embedded
+     * schemas matched, this must be logged unconditionally so it isn't lost.
+     */
+    private void logValidatorFailure(Exception e) {
+        log.warn("Validator for {} threw while validating: {}", location, e.getMessage(), e);
     }
 
     /**

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/AbstractXMLSchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/AbstractXMLSchemaValidator.java
@@ -182,7 +182,9 @@ public abstract class AbstractXMLSchemaValidator extends AbstractMessageValidato
                     }
                 } catch (Exception e) {
                     logValidatorFailure(e);
-                    exceptions.add(e);
+                    if (!exceptions.contains(e)) {
+                        exceptions.add(e);
+                    }
                 }
             }
         } finally {
@@ -209,7 +211,9 @@ public abstract class AbstractXMLSchemaValidator extends AbstractMessageValidato
             return validateOnce(validator, source, exceptions);
         } catch (Exception e) {
             logValidatorFailure(e);
-            exceptions.add(e);
+            if (!exceptions.contains(e)) {
+                exceptions.add(e);
+            }
             return false;
         } finally {
             pool.put(validator);
@@ -240,6 +244,13 @@ public abstract class AbstractXMLSchemaValidator extends AbstractMessageValidato
             }
             exceptions.addAll(handler.getExceptions());
             return false;
+        } catch (IOException | SAXException e) {
+            var reported = handler.getExceptions();
+            exceptions.addAll(reported);
+            if (!reported.contains(e)) {
+                exceptions.add(e);
+            }
+            throw e;
         } finally {
             handler.reset();
         }

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/AbstractXMLSchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/AbstractXMLSchemaValidator.java
@@ -216,7 +216,7 @@ public abstract class AbstractXMLSchemaValidator extends AbstractMessageValidato
             if (handler.noErrors()) {
                 return true;
             }
-            exceptions.add(handler.getException());
+            exceptions.addAll(handler.getExceptions());
             return false;
         } finally {
             handler.reset();

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/AbstractXMLSchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/AbstractXMLSchemaValidator.java
@@ -165,7 +165,7 @@ public abstract class AbstractXMLSchemaValidator extends AbstractMessageValidato
      * and the remaining schemas are still tried; one broken schema must not stop a message from
      * matching another one of the (possibly several) alternatives.
      *
-     * @param exceptions collects one exception per schema the source failed against
+     * @param exceptions collects the errors reported for each schema the source failed against
      * @return {@code true} if the source matched at least one embedded schema
      * @throws InterruptedException if interrupted while waiting for a validator from the pool.
      *                             Validation failures are collected in {@code exceptions} instead

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/FaultDetailXMLFilter.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/FaultDetailXMLFilter.java
@@ -19,6 +19,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.XMLFilterImpl;
 
+import static com.predic8.membrane.annot.Constants.SOAP11_NS;
 import static com.predic8.membrane.annot.Constants.SOAP12_NS;
 
 /**
@@ -32,6 +33,11 @@ import static com.predic8.membrane.annot.Constants.SOAP12_NS;
  * named {@code detail} (fault schemas usually leave {@code elementFormDefault} at its
  * {@code unqualified} default), which would otherwise end the payload halfway through and emit
  * an unbalanced document.
+ * <p>
+ * The match is additionally scoped to a direct child of {@code Fault}: {@code detail} is
+ * unqualified precisely because SOAP 1.1 leaves it namespace-less, so a same-named element
+ * elsewhere in the message (e.g. in {@code soap:Header}) must not be mistaken for the fault's own
+ * {@code detail}.
  */
 public class FaultDetailXMLFilter extends XMLFilterImpl {
 
@@ -42,6 +48,15 @@ public class FaultDetailXMLFilter extends XMLFilterImpl {
      * when {@code n} levels deep inside its content.
      */
     private int depth = -1;
+
+    /**
+     * Only consulted while {@link #depth} is still {@code -1} (the detail element hasn't been
+     * found yet). {@code -1} before entering {@code Fault} (or after leaving it without finding
+     * a detail element), {@code 0} while positioned at Fault's direct children (where
+     * {@code detail} is looked for), {@code n>0} while nested deeper inside one of Fault's other
+     * children.
+     */
+    private int faultDepth = -1;
 
     public FaultDetailXMLFilter(XMLReader reader, SoapVersion version) {
         super(reader);
@@ -56,11 +71,23 @@ public class FaultDetailXMLFilter extends XMLFilterImpl {
         };
     }
 
+    private static boolean isFault(String uri, String localName) {
+        return "Fault".equals(localName) && (SOAP11_NS.equals(uri) || SOAP12_NS.equals(uri));
+    }
+
     @Override
     public void startElement(String uri, String localName, String qName, Attributes atts) throws SAXException {
         if (depth < 0) {
-            if (isDetail(uri, localName))
+            if (faultDepth == 0 && isDetail(uri, localName)) {
                 depth = 0;
+                return;
+            }
+            if (faultDepth < 0) {
+                if (isFault(uri, localName))
+                    faultDepth = 0;
+            } else {
+                faultDepth++;
+            }
             return;
         }
         depth++;
@@ -69,8 +96,14 @@ public class FaultDetailXMLFilter extends XMLFilterImpl {
 
     @Override
     public void endElement(String uri, String localName, String qName) throws SAXException {
-        if (depth < 0)
+        if (depth < 0) {
+            if (faultDepth == 0 && isFault(uri, localName)) {
+                faultDepth = -1; // left Fault without finding a detail element
+            } else if (faultDepth > 0) {
+                faultDepth--;
+            }
             return;
+        }
         if (depth == 0) {
             depth = -1; // the detail element itself: consumed, not forwarded
             return;

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONSchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONSchemaValidator.java
@@ -24,7 +24,6 @@ import com.predic8.membrane.core.exchange.Exchange;
 import com.predic8.membrane.core.http.Message;
 import com.predic8.membrane.core.interceptor.Interceptor.Flow;
 import com.predic8.membrane.core.interceptor.Outcome;
-import com.predic8.membrane.core.interceptor.schemavalidation.ValidatorInterceptor.FailureHandler;
 import com.predic8.membrane.core.resolver.Resolver;
 import com.predic8.membrane.core.util.ConfigurationException;
 import org.jetbrains.annotations.NotNull;
@@ -90,13 +89,6 @@ public class JSONSchemaValidator extends AbstractMessageValidator {
             errors = getErrors(report);
         } catch (JsonParseException e) {
             errors = List.of(e.getOriginalMessage() != null ? e.getOriginalMessage() : e.getMessage());
-        }
-
-        // What is that for? A property "error" is accessed in the elasticsearchstore?
-        if (failureHandler == FailureHandler.VOID) {
-            exc.setProperty("error", getErrorString(msg, errors));
-            invalid.incrementAndGet();
-            return ABORT;
         }
 
         if (failureHandler != null) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONSchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONSchemaValidator.java
@@ -14,27 +14,32 @@
 
 package com.predic8.membrane.core.interceptor.schemavalidation;
 
-import com.fasterxml.jackson.databind.*;
-import com.github.fge.jsonschema.core.report.*;
-import com.github.fge.jsonschema.main.*;
-import com.predic8.membrane.core.exchange.*;
-import com.predic8.membrane.core.http.*;
-import com.predic8.membrane.core.interceptor.Interceptor.*;
-import com.predic8.membrane.core.interceptor.*;
-import com.predic8.membrane.core.interceptor.schemavalidation.ValidatorInterceptor.*;
-import com.predic8.membrane.core.resolver.*;
-import com.predic8.membrane.core.util.*;
-import org.jetbrains.annotations.*;
-import org.slf4j.*;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.fge.jsonschema.core.report.ProcessingMessage;
+import com.github.fge.jsonschema.core.report.ProcessingReport;
+import com.github.fge.jsonschema.main.JsonSchema;
+import com.github.fge.jsonschema.main.JsonSchemaFactory;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.http.Message;
+import com.predic8.membrane.core.interceptor.Interceptor.Flow;
+import com.predic8.membrane.core.interceptor.Outcome;
+import com.predic8.membrane.core.interceptor.schemavalidation.ValidatorInterceptor.FailureHandler;
+import com.predic8.membrane.core.resolver.Resolver;
+import com.predic8.membrane.core.util.ConfigurationException;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.nio.charset.*;
-import java.util.*;
-import java.util.concurrent.atomic.*;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
-import static com.predic8.membrane.core.exceptions.ProblemDetails.*;
-import static com.predic8.membrane.core.interceptor.Outcome.*;
-import static java.nio.charset.StandardCharsets.*;
-import static java.util.stream.StreamSupport.*;
+import static com.predic8.membrane.core.exceptions.ProblemDetails.user;
+import static com.predic8.membrane.core.interceptor.Outcome.ABORT;
+import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.StreamSupport.stream;
 
 public class JSONSchemaValidator extends AbstractMessageValidator {
 
@@ -75,13 +80,17 @@ public class JSONSchemaValidator extends AbstractMessageValidator {
 
         Message msg = exc.getMessage(flow);
 
-        ProcessingReport report = schema.validateUnchecked(om.readTree(msg.getBodyAsStreamDecoded()));
-        if (report.isSuccess()) {
-            valid.incrementAndGet();
-            return CONTINUE;
+        List<String> errors;
+        try {
+            ProcessingReport report = schema.validateUnchecked(om.readTree(msg.getBodyAsStreamDecoded()));
+            if (report.isSuccess()) {
+                valid.incrementAndGet();
+                return CONTINUE;
+            }
+            errors = getErrors(report);
+        } catch (JsonParseException e) {
+            errors = List.of(e.getOriginalMessage() != null ? e.getOriginalMessage() : e.getMessage());
         }
-
-        List<String> errors = getErrors(report);
 
         // What is that for? A property "error" is accessed in the elasticsearchstore?
         if (failureHandler == FailureHandler.VOID) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/SchemaValidatorErrorHandler.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/SchemaValidatorErrorHandler.java
@@ -18,36 +18,39 @@ import org.slf4j.LoggerFactory;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXParseException;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class SchemaValidatorErrorHandler implements ErrorHandler {
 
 	private static final Logger log = LoggerFactory.getLogger(SchemaValidatorErrorHandler.class.getName());
 
-	private Exception exception;
+	private final List<Exception> exceptions = new ArrayList<>();
 
 	// Errors are collected here and only reported by AbstractXMLSchemaValidator once the message
 	// has failed *all* embedded schemas. Logging here would emit spurious "Error:" lines for a
 	// perfectly valid message that simply matches a different embedded schema of the same WSDL.
 	public void error(SAXParseException e) {
-		exception = e;
+		exceptions.add(e);
 	}
 
 	public void fatalError(SAXParseException e) {
-		exception = e;
+		exceptions.add(e);
 	}
 
 	public void warning(SAXParseException e) {
 		log.debug("Warning: {}", e.getMessage());
 	}
 
-	public Exception getException() {
-		return exception;
+	public List<Exception> getExceptions() {
+		return exceptions;
 	}
 
 	public boolean noErrors() {
-		return exception == null;
+		return exceptions.isEmpty();
 	}
 
 	public void reset() {
-		exception = null;
+		exceptions.clear();
 	}
 }

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/SchemaValidatorErrorHandler.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/SchemaValidatorErrorHandler.java
@@ -43,7 +43,7 @@ public class SchemaValidatorErrorHandler implements ErrorHandler {
 	}
 
 	public List<Exception> getExceptions() {
-		return exceptions;
+		return List.copyOf(exceptions);
 	}
 
 	public boolean noErrors() {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/XMLSchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/XMLSchemaValidator.java
@@ -48,7 +48,6 @@ public class XMLSchemaValidator extends AbstractXMLSchemaValidator {
 
     public XMLSchemaValidator(ResolverMap resourceResolver, String location, ValidatorInterceptor.FailureHandler failureHandler) {
         super(resourceResolver, location, failureHandler);
-        init(); // Better to call in Interceptor?
     }
 
     @Override

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/json/JSONYAMLSchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/json/JSONYAMLSchemaValidator.java
@@ -21,27 +21,30 @@ import com.networknt.schema.*;
 import com.networknt.schema.Error;
 import com.networknt.schema.path.NodePath;
 import com.networknt.schema.resource.SchemaLoader;
-import com.predic8.membrane.core.exchange.*;
-import com.predic8.membrane.core.interceptor.Interceptor.*;
-import com.predic8.membrane.core.interceptor.*;
-import com.predic8.membrane.core.interceptor.schemavalidation.*;
-import com.predic8.membrane.core.interceptor.schemavalidation.ValidatorInterceptor.*;
-import com.predic8.membrane.core.resolver.*;
-import org.jetbrains.annotations.*;
-import org.slf4j.*;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.interceptor.Interceptor.Flow;
+import com.predic8.membrane.core.interceptor.Outcome;
+import com.predic8.membrane.core.interceptor.schemavalidation.AbstractMessageValidator;
+import com.predic8.membrane.core.interceptor.schemavalidation.ValidatorInterceptor.FailureHandler;
+import com.predic8.membrane.core.resolver.Resolver;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.*;
+import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
 import java.util.*;
-import java.util.concurrent.atomic.*;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static com.fasterxml.jackson.core.StreamReadFeature.STRICT_DUPLICATE_DETECTION;
 import static com.networknt.schema.InputFormat.JSON;
 import static com.networknt.schema.InputFormat.YAML;
-import static com.predic8.membrane.core.exceptions.ProblemDetails.*;
-import static com.predic8.membrane.core.interceptor.Outcome.*;
-import static java.nio.charset.StandardCharsets.*;
+import static com.predic8.membrane.core.exceptions.ProblemDetails.user;
+import static com.predic8.membrane.core.interceptor.Outcome.ABORT;
+import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class JSONYAMLSchemaValidator extends AbstractMessageValidator {
 
@@ -119,20 +122,31 @@ public class JSONYAMLSchemaValidator extends AbstractMessageValidator {
 
     public Outcome validateMessage(Exchange exc, Flow flow, Charset ignored) throws Exception {
 
-        List<Error> assertions = inputFormat == YAML ?
-                handleMultipleYAMLDocuments(exc, flow) :
-                schema.validate(exc.getMessage(flow).getBodyAsStringDecoded(), inputFormat);
+        List<Error> assertions;
+        try {
+            assertions = inputFormat == YAML ?
+                    handleMultipleYAMLDocuments(exc, flow) :
+                    schema.validate(exc.getMessage(flow).getBodyAsStringDecoded(), inputFormat);
+        } catch (UncheckedIOException | IOException e) {
+            String detail = e instanceof UncheckedIOException uioe && uioe.getCause() != null ?
+                    uioe.getCause().getMessage() : e.getMessage();
+            log.debug("Could not parse {} body: {}", inputFormat, detail, e);
+            return reportFailure(exc, flow, List.of(Map.of("message", "Could not parse " + inputFormat + " body: " + detail)));
+        }
 
         if (assertions.isEmpty()) {
             valid.incrementAndGet();
             return CONTINUE;
         }
-        invalid.incrementAndGet();
-
 
         log.debug("Validation failed: {}", assertions);
 
-        List<Map<String, Object>> mapForProblemDetails = getMapForProblemDetails(assertions);
+        return reportFailure(exc, flow, getMapForProblemDetails(assertions));
+    }
+
+    private Outcome reportFailure(Exchange exc, Flow flow, List<Map<String, Object>> mapForProblemDetails) {
+        invalid.incrementAndGet();
+
         failureHandler.handleFailure(mapForProblemDetails.toString(), exc);
 
         user(false, getName())

--- a/core/src/main/java/com/predic8/membrane/core/util/SOAPUtil.java
+++ b/core/src/main/java/com/predic8/membrane/core/util/SOAPUtil.java
@@ -34,6 +34,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.EndElement;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 import javax.xml.transform.Source;
@@ -233,23 +234,46 @@ public class SOAPUtil {
         try {
             var parser = HardenedStaxInputFactory.inputFactory().createXMLEventReader(xopr.reconstituteIfNecessary(msg));
             int depth = -1; // -1 outside detail, 0 on the detail element, n when n levels inside it
+            // Only consulted while `depth` is still -1 (detail not found yet): -1 before/after
+            // Fault, 0 at Fault's direct children (where detail is looked for), n>0 when nested
+            // deeper inside one of Fault's other children. Scopes the match to a direct child of
+            // Fault, so a same-named element elsewhere in the message (e.g. in soap:Header) isn't
+            // mistaken for the fault's own detail.
+            int faultDepth = -1;
             while (parser.hasNext()) {
                 var event = parser.nextEvent();
                 if (event.isStartElement()) {
                     var name = ((StartElement) event).getName();
                     if (depth < 0) {
-                        if (isDetailElement(name, version))
+                        if (faultDepth == 0 && isDetailElement(name, version)) {
                             depth = 0;
+                            continue;
+                        }
+                        if (faultDepth < 0) {
+                            if (isFaultElement(name))
+                                faultDepth = 0;
+                        } else {
+                            faultDepth++;
+                        }
                         continue;
                     }
                     if (++depth == 1)
                         entries.add(name);
                     continue;
                 }
-                if (event.isEndElement() && depth >= 0) {
-                    if (depth == 0)
-                        return entries; // detail closed
-                    depth--;
+                if (event.isEndElement()) {
+                    if (depth >= 0) {
+                        if (depth == 0)
+                            return entries; // detail closed
+                        depth--;
+                        continue;
+                    }
+                    var name = ((EndElement) event).getName();
+                    if (faultDepth == 0 && isFaultElement(name)) {
+                        faultDepth = -1; // left Fault without finding a detail element
+                    } else if (faultDepth > 0) {
+                        faultDepth--;
+                    }
                 }
             }
         } catch (Exception e) {
@@ -264,6 +288,11 @@ public class SOAPUtil {
             case SOAP12 -> "Detail".equals(name.getLocalPart()) && SOAP12_NS.equals(name.getNamespaceURI());
             default -> false;
         };
+    }
+
+    private static boolean isFaultElement(QName name) {
+        return "Fault".equals(name.getLocalPart())
+                && (SOAP11_NS.equals(name.getNamespaceURI()) || SOAP12_NS.equals(name.getNamespaceURI()));
     }
 
     /**

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/AbstractXMLSchemaValidatorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/AbstractXMLSchemaValidatorTest.java
@@ -25,8 +25,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
 
 import javax.xml.XMLConstants;
+import javax.xml.transform.Result;
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.SchemaFactory;
@@ -39,6 +42,8 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -84,6 +89,26 @@ class AbstractXMLSchemaValidatorTest {
         assertTrue(appender.contains("threw while validating"),
                 "a validator throwing must be logged even though another schema went on to match: "
                         + appender.getMessages());
+    }
+
+    @Test
+    void callbackErrorReportedBeforeAThrowIsNotLost() throws Exception {
+        var validator = new CallbackThenThrowTestValidator();
+        validator.init();
+
+        var exceptions = new ArrayList<Exception>();
+
+        assertFalse(validator.validateAgainstSchemas(() -> okSource(), exceptions),
+                "the only schema throws, so nothing can have matched");
+        assertEquals(2, exceptions.size(),
+                "both the error reported through the callback and the thrown exception must be kept: "
+                        + exceptions);
+        assertTrue(exceptions.stream().anyMatch(e -> "reported through callback".equals(e.getMessage())),
+                "the callback-reported error must not be discarded when the handler is reset: " + exceptions);
+        assertTrue(exceptions.stream().anyMatch(e -> "thrown from validate()".equals(e.getMessage())),
+                "the exception thrown by validate() must still be recorded: " + exceptions);
+        assertTrue(appender.contains("threw while validating"),
+                "a validator throwing must still be logged: " + appender.getMessages());
     }
 
     private static Source failingSource() {
@@ -135,6 +160,83 @@ class AbstractXMLSchemaValidatorTest {
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
+        }
+
+        @Override
+        protected List<Element> getSchemas() {
+            throw new UnsupportedOperationException("createValidators() is overridden for this test");
+        }
+
+        @Override
+        protected Source getMessageBody(InputStream input) {
+            throw new UnsupportedOperationException("not used by this test");
+        }
+
+        @Override
+        protected void setErrorResponse(Exchange exchange, String message) {
+            throw new UnsupportedOperationException("not used by this test");
+        }
+
+        @Override
+        protected void setErrorResponse(Exchange exchange, Flow flow, List<Exception> exceptions) {
+            throw new UnsupportedOperationException("not used by this test");
+        }
+
+        @Override
+        protected String getPreliminaryError(XOPReconstitutor xopr, Message msg) {
+            throw new UnsupportedOperationException("not used by this test");
+        }
+    }
+
+    /**
+     * Sets up a single validator whose run first reports an error through the
+     * {@link SchemaValidatorErrorHandler} callback, then throws - reproducing a validator that
+     * detects an ordinary mismatch before hitting something more serious (e.g. an unresolvable
+     * import) partway through the same run.
+     */
+    private static class CallbackThenThrowTestValidator extends AbstractXMLSchemaValidator {
+
+        CallbackThenThrowTestValidator() {
+            super(new ResolverMap(), "test-location", null);
+        }
+
+        @Override
+        public String getName() {
+            return "test-validator";
+        }
+
+        @Override
+        protected List<Validator> createValidators() {
+            var handler = new SchemaValidatorErrorHandler();
+            return List.of(new Validator() {
+                @Override
+                public void validate(Source source, javax.xml.transform.Result result) throws SAXException {
+                    handler.error(new SAXParseException("reported through callback", null));
+                    throw new SAXException("thrown from validate()");
+                }
+
+                @Override
+                public void reset() {
+                }
+
+                @Override
+                public void setErrorHandler(org.xml.sax.ErrorHandler errorHandler) {
+                }
+
+                @Override
+                public org.xml.sax.ErrorHandler getErrorHandler() {
+                    return handler;
+                }
+
+                @Override
+                public void setResourceResolver(org.w3c.dom.ls.LSResourceResolver resourceResolver) {
+                }
+
+                @Override
+                public org.w3c.dom.ls.LSResourceResolver getResourceResolver() {
+                    return null;
+                }
+            });
         }
 
         @Override

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/AbstractXMLSchemaValidatorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/AbstractXMLSchemaValidatorTest.java
@@ -1,0 +1,165 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+package com.predic8.membrane.core.interceptor.schemavalidation;
+
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.http.Message;
+import com.predic8.membrane.core.interceptor.Interceptor.Flow;
+import com.predic8.membrane.core.multipart.XOPReconstitutor;
+import com.predic8.membrane.core.resolver.ResolverMap;
+import com.predic8.membrane.test.TestAppender;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Element;
+
+import javax.xml.XMLConstants;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link AbstractXMLSchemaValidator#validateAgainstSchemas} is meant to try every embedded schema
+ * until one matches. If running one schema's validator throws (as opposed to reporting an ordinary
+ * validation error through its {@link SchemaValidatorErrorHandler}), the remaining schemas must
+ * still get a chance, and the failure must be logged - unlike an ordinary per-schema mismatch, it
+ * signals something more serious (e.g. a schema failing to resolve an import).
+ */
+class AbstractXMLSchemaValidatorTest {
+
+    private Logger root;
+    private TestAppender appender;
+
+    @BeforeEach
+    void attachAppender() {
+        root = (Logger) LogManager.getRootLogger();
+        appender = new TestAppender("AbstractXMLSchemaValidatorTest");
+        appender.start();
+        root.addAppender(appender);
+    }
+
+    @AfterEach
+    void detachAppender() {
+        root.removeAppender(appender);
+        appender.stop();
+    }
+
+    @Test
+    void oneSchemaThrowingDoesNotStopTheOthersFromBeingTriedAndIsLogged() throws Exception {
+        var validator = new TestValidator();
+        validator.init();
+
+        var exceptions = new ArrayList<Exception>();
+        // The first embedded schema's validator run always throws; the underlying stream errors
+        // out instead of reporting a validation failure. The second schema, tried on a fresh
+        // Source, matches "<ok/>" cleanly.
+        var calls = new AtomicInteger();
+        Supplier<Source> source = () -> calls.incrementAndGet() == 1 ? failingSource() : okSource();
+
+        assertTrue(validator.validateAgainstSchemas(source, exceptions),
+                "the second schema should still have matched: " + exceptions);
+        assertTrue(appender.contains("threw while validating"),
+                "a validator throwing must be logged even though another schema went on to match: "
+                        + appender.getMessages());
+    }
+
+    private static Source failingSource() {
+        return new StreamSource(new InputStream() {
+            public int read() throws IOException {
+                throw new IOException("simulated I/O failure reading the first schema's source");
+            }
+        });
+    }
+
+    private static Source okSource() {
+        return new StreamSource(new StringReader("<ok/>"));
+    }
+
+    private static Validator newValidator(String schemaXml) throws Exception {
+        var sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        var validator = sf.newSchema(new StreamSource(new StringReader(schemaXml))).newValidator();
+        validator.setErrorHandler(new SchemaValidatorErrorHandler());
+        return validator;
+    }
+
+    private static class TestValidator extends AbstractXMLSchemaValidator {
+
+        TestValidator() {
+            super(new ResolverMap(), "test-location", null);
+        }
+
+        @Override
+        public String getName() {
+            return "test-validator";
+        }
+
+        @Override
+        protected List<Validator> createValidators() {
+            try {
+                // Content is irrelevant: the first validator's run always throws before it ever
+                // gets to parse anything.
+                var throwsOnRun = newValidator("""
+                        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                          <xsd:element name="ok"/>
+                        </xsd:schema>
+                        """);
+                var matchesOk = newValidator("""
+                        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                          <xsd:element name="ok"/>
+                        </xsd:schema>
+                        """);
+                return List.of(throwsOnRun, matchesOk);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        protected List<Element> getSchemas() {
+            throw new UnsupportedOperationException("createValidators() is overridden for this test");
+        }
+
+        @Override
+        protected Source getMessageBody(InputStream input) {
+            throw new UnsupportedOperationException("not used by this test");
+        }
+
+        @Override
+        protected void setErrorResponse(Exchange exchange, String message) {
+            throw new UnsupportedOperationException("not used by this test");
+        }
+
+        @Override
+        protected void setErrorResponse(Exchange exchange, Flow flow, List<Exception> exceptions) {
+            throw new UnsupportedOperationException("not used by this test");
+        }
+
+        @Override
+        protected String getPreliminaryError(XOPReconstitutor xopr, Message msg) {
+            throw new UnsupportedOperationException("not used by this test");
+        }
+    }
+}

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/FaultDetailXMLFilterTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/FaultDetailXMLFilterTest.java
@@ -127,6 +127,33 @@ class FaultDetailXMLFilterTest {
         assertFalse(out.contains("boom"), out);
     }
 
+    /**
+     * {@code detail} is unqualified precisely because SOAP 1.1 leaves it namespace-less, so a
+     * same-named element elsewhere in the message (e.g. in {@code soap:Header}) must not be
+     * mistaken for the fault's own {@code detail} — only a direct child of {@code Fault} counts.
+     */
+    @Test
+    void ignoresDetailElementOutsideFault() throws Exception {
+        String out = filterFaultDetail(SOAP11, """
+                <s11:Envelope xmlns:s11="http://schemas.xmlsoap.org/soap/envelope/">
+                  <s11:Header>
+                    <detail>unrelated header content</detail>
+                  </s11:Header>
+                  <s11:Body>
+                    <s11:Fault>
+                      <faultcode>Server</faultcode>
+                      <faultstring>City not found</faultstring>
+                      <detail><p:err xmlns:p="http://example.com/svc">boom</p:err></detail>
+                    </s11:Fault>
+                  </s11:Body>
+                </s11:Envelope>
+                """);
+
+        assertTrue(out.contains("err"), out);
+        assertTrue(out.contains("boom"), out);
+        assertFalse(out.contains("unrelated header content"), out);
+    }
+
     private static String filterFaultDetail(SoapVersion version, String soap) throws Exception {
         TransformerFactory tf = TransformerFactory.newInstance();
         tf.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONSchemaValidationTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONSchemaValidationTest.java
@@ -13,17 +13,18 @@
    limitations under the License. */
 package com.predic8.membrane.core.interceptor.schemavalidation;
 
-import com.fasterxml.jackson.databind.*;
-import com.predic8.membrane.core.exchange.*;
-import com.predic8.membrane.core.resolver.*;
-import org.jetbrains.annotations.*;
-import org.junit.jupiter.api.*;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.resolver.StaticStringResolver;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
 
-import static com.predic8.membrane.core.http.Request.*;
-import static com.predic8.membrane.core.interceptor.Interceptor.Flow.*;
+import static com.predic8.membrane.core.http.Request.post;
+import static com.predic8.membrane.core.interceptor.Interceptor.Flow.REQUEST;
 import static com.predic8.membrane.core.interceptor.Outcome.ABORT;
-import static com.predic8.membrane.core.interceptor.Outcome.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JSONSchemaValidationTest {
 
@@ -77,6 +78,28 @@ public class JSONSchemaValidationTest {
 
         assertEquals("JSON validation failed", jn.get("title").textValue());
         assertEquals("https://membrane-api.io/problems/user/validation",jn.get("type").textValue());
+        assertEquals(1, jn.get("errors").size());
+    }
+
+    @Test
+    void malformedJson() throws Exception {
+        var validator = getValidator("""
+                {
+                    "required": [ "p1" ],
+                    "properties": {
+                        "p1": {
+                            "format": "date"
+                        }
+                    }
+                }
+                """);
+        Exchange exc = post("/foo").body("{ invalid").buildExchange();
+        assertEquals(ABORT, validator.validateMessage(exc, REQUEST));
+
+        JsonNode jn = om.readTree(exc.getResponse().getBodyAsStream());
+
+        assertEquals("JSON validation failed", jn.get("title").textValue());
+        assertEquals("https://membrane-api.io/problems/user/validation", jn.get("type").textValue());
         assertEquals(1, jn.get("errors").size());
     }
 

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONSchemaValidationTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONSchemaValidationTest.java
@@ -170,6 +170,29 @@ public class JSONSchemaValidationTest {
         assertEquals(2, jn.get("errors").size());
     }
 
+    /**
+     * No caller ever constructs a validator with the {@code FailureHandler.VOID} singleton itself
+     * (by reference) - a validator built with any other {@link ValidatorInterceptor.FailureHandler},
+     * VOID included, must go through the ordinary failure-reporting path: invoke the handler and
+     * still build a ProblemDetails response, rather than silently setting an exchange property and
+     * nothing else.
+     */
+    @Test
+    void voidFailureHandlerStillReportsFailure() throws Exception {
+        var validator = new JSONSchemaValidator(new StaticStringResolver(), """
+                {
+                    "required": [ "p1" ]
+                }
+                """, ValidatorInterceptor.FailureHandler.VOID);
+        validator.init();
+
+        Exchange exc = post("/foo").body("{}").buildExchange();
+        assertEquals(ABORT, validator.validateMessage(exc, REQUEST));
+
+        JsonNode jn = om.readTree(exc.getResponse().getBodyAsStream());
+        assertEquals("JSON validation failed", jn.get("title").textValue());
+    }
+
     private static @NotNull JSONSchemaValidator getValidator(String schema) {
         var validator = new JSONSchemaValidator(new StaticStringResolver(), schema, null);
         validator.init();

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONYAMLSchemaValidatorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONYAMLSchemaValidatorTest.java
@@ -14,14 +14,16 @@
 
 package com.predic8.membrane.core.interceptor.schemavalidation;
 
-import com.predic8.membrane.core.exchange.*;
-import com.predic8.membrane.core.interceptor.schemavalidation.json.*;
-import com.predic8.membrane.core.resolver.*;
-import com.predic8.membrane.core.util.*;
-import org.junit.jupiter.api.*;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.interceptor.schemavalidation.json.JSONYAMLSchemaValidator;
+import com.predic8.membrane.core.resolver.ClasspathSchemaResolver;
+import com.predic8.membrane.core.util.ConfigurationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.predic8.membrane.core.http.Request.get;
 import static com.predic8.membrane.core.interceptor.Interceptor.Flow.REQUEST;
+import static com.predic8.membrane.core.interceptor.Outcome.ABORT;
 import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -73,5 +75,16 @@ class JSONYAMLSchemaValidatorTest {
                 }
                 """).buildExchange();
         validator.validateMessage( exc, REQUEST);
+    }
+
+    @Test
+    void malformedJson() throws Exception {
+        Exchange exc = get("/foo").body("""
+                {
+                    "name":
+                """).buildExchange();
+        assertEquals(ABORT, validator.validateMessage(exc, REQUEST));
+        assertEquals(1, validator.getInvalid());
+        assertEquals(0, validator.getValid());
     }
 }

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONYAMLSchemaValidatorYAMLTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONYAMLSchemaValidatorYAMLTest.java
@@ -14,7 +14,6 @@
 
 package com.predic8.membrane.core.interceptor.schemavalidation;
 
-import com.networknt.schema.InputFormat;
 import com.predic8.membrane.core.exchange.Exchange;
 import com.predic8.membrane.core.interceptor.schemavalidation.json.JSONYAMLSchemaValidator;
 import com.predic8.membrane.core.resolver.ClasspathSchemaResolver;
@@ -25,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import static com.networknt.schema.InputFormat.YAML;
 import static com.predic8.membrane.core.http.Request.get;
 import static com.predic8.membrane.core.interceptor.Interceptor.Flow.REQUEST;
+import static com.predic8.membrane.core.interceptor.Outcome.ABORT;
 import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
 import static com.predic8.membrane.core.interceptor.schemavalidation.json.JSONYAMLSchemaValidator.SCHEMA_VERSION_2020_12;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -95,5 +95,18 @@ class JSONYAMLSchemaValidatorYAMLTest {
                 """).buildExchange();
         validator.validateMessage( exc, REQUEST);
         assertEquals(1, validator.getValid());
+    }
+
+    @Test
+    void malformedYaml() throws Exception {
+        // A duplicate key is not a schema violation but a YAML *parse* error, since this
+        // validator's YAMLFactory has STRICT_DUPLICATE_DETECTION enabled.
+        Exchange exc = get("/foo").body("""
+                "name": "Robert"
+                "name": "Eve"
+                """).buildExchange();
+        assertEquals(ABORT, validator.validateMessage(exc, REQUEST));
+        assertEquals(1, validator.getInvalid());
+        assertEquals(0, validator.getValid());
     }
 }

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/SOAPUtilTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/SOAPUtilTest.java
@@ -288,6 +288,32 @@ public class SOAPUtilTest {
                         """), SOAP11));
     }
 
+    /**
+     * {@code detail} is unqualified precisely because SOAP 1.1 leaves it namespace-less, so a
+     * same-named element elsewhere in the message (e.g. in {@code soap:Header}) must not be
+     * mistaken for the fault's own {@code detail} — only a direct child of {@code Fault} counts.
+     */
+    @Test
+    void faultDetailEntriesIgnoresDetailOutsideFault() {
+        assertEquals(List.of(new QName(TB_NS, "notFound")),
+                extractFaultDetailElements(new XOPReconstitutor(), getMessageFromString("""
+                        <s11:Envelope xmlns:s11="http://schemas.xmlsoap.org/soap/envelope/">
+                          <s11:Header>
+                            <detail>unrelated header content</detail>
+                          </s11:Header>
+                          <s11:Body>
+                            <s11:Fault>
+                              <faultcode>Server</faultcode>
+                              <faultstring>Not found</faultstring>
+                              <detail>
+                                <ns1:notFound xmlns:ns1="http://thomas-bayer.com/blz/"/>
+                              </detail>
+                            </s11:Fault>
+                          </s11:Body>
+                        </s11:Envelope>
+                        """), SOAP11));
+    }
+
     @Test
     void faultDetailEntriesSoap12() {
         assertEquals(List.of(new QName(MEMBRANE_NS, "hint")),

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/SchemaValidatorErrorHandlerTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/SchemaValidatorErrorHandlerTest.java
@@ -1,0 +1,83 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+package com.predic8.membrane.core.interceptor.schemavalidation;
+
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXParseException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SchemaValidatorErrorHandlerTest {
+
+    @Test
+    void collectsAllErrorsInsteadOfOnlyTheLast() {
+        SchemaValidatorErrorHandler handler = new SchemaValidatorErrorHandler();
+        SAXParseException first = new SAXParseException("first violation", null);
+        SAXParseException second = new SAXParseException("second violation", null);
+
+        handler.error(first);
+        handler.error(second);
+
+        assertEquals(2, handler.getExceptions().size());
+        assertEquals(first, handler.getExceptions().get(0));
+        assertEquals(second, handler.getExceptions().get(1));
+    }
+
+    @Test
+    void fatalErrorContributesToTheSameListAsError() {
+        SchemaValidatorErrorHandler handler = new SchemaValidatorErrorHandler();
+        SAXParseException error = new SAXParseException("validity error", null);
+        SAXParseException fatal = new SAXParseException("well-formedness error", null);
+
+        handler.error(error);
+        handler.fatalError(fatal);
+
+        assertEquals(2, handler.getExceptions().size());
+        assertEquals(error, handler.getExceptions().get(0));
+        assertEquals(fatal, handler.getExceptions().get(1));
+    }
+
+    @Test
+    void warningDoesNotCountAsAnError() {
+        SchemaValidatorErrorHandler handler = new SchemaValidatorErrorHandler();
+
+        handler.warning(new SAXParseException("just a warning", null));
+
+        assertTrue(handler.noErrors());
+        assertTrue(handler.getExceptions().isEmpty());
+    }
+
+    @Test
+    void noErrorsReflectsWhetherAnyErrorWasReported() {
+        SchemaValidatorErrorHandler handler = new SchemaValidatorErrorHandler();
+
+        assertTrue(handler.noErrors());
+
+        handler.error(new SAXParseException("violation", null));
+
+        assertFalse(handler.noErrors());
+    }
+
+    @Test
+    void resetClearsAccumulatedErrorsForTheNextBorrowedUse() {
+        SchemaValidatorErrorHandler handler = new SchemaValidatorErrorHandler();
+        handler.error(new SAXParseException("first use violation", null));
+        handler.error(new SAXParseException("first use violation 2", null));
+
+        handler.reset();
+
+        assertTrue(handler.noErrors());
+        assertTrue(handler.getExceptions().isEmpty());
+    }
+}

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/XMLSchemaValidatorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/XMLSchemaValidatorTest.java
@@ -48,6 +48,7 @@ class XMLSchemaValidatorTest {
     void setUp() {
         validator = new XMLSchemaValidator(new ResolverMap(), "src/test/resources/validation/order.xsd",
                 (message, exc) -> log.info("Validation failure: {}", message));
+        validator.init();
     }
 
     @Test

--- a/core/src/test/java/com/predic8/membrane/core/resolver/ResolverTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/resolver/ResolverTest.java
@@ -13,24 +13,33 @@
    limitations under the License. */
 package com.predic8.membrane.core.resolver;
 
-import com.predic8.membrane.core.exchange.*;
-import com.predic8.membrane.core.interceptor.*;
-import com.predic8.membrane.core.interceptor.schemavalidation.*;
-import com.predic8.membrane.core.interceptor.server.*;
-import com.predic8.membrane.core.proxies.*;
-import com.predic8.membrane.core.router.*;
-import com.predic8.membrane.core.util.*;
-import org.junit.jupiter.api.*;
-import org.junit.jupiter.params.*;
-import org.junit.jupiter.params.provider.*;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.interceptor.AbstractInterceptor;
+import com.predic8.membrane.core.interceptor.Outcome;
+import com.predic8.membrane.core.interceptor.schemavalidation.XMLSchemaValidator;
+import com.predic8.membrane.core.interceptor.server.WebServerInterceptor;
+import com.predic8.membrane.core.proxies.ServiceProxy;
+import com.predic8.membrane.core.proxies.ServiceProxyKey;
+import com.predic8.membrane.core.router.Router;
+import com.predic8.membrane.core.router.TestRouter;
+import com.predic8.membrane.core.util.OSUtil;
+import com.predic8.membrane.core.util.URIFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import java.io.*;
-import java.security.*;
-import java.util.*;
+import java.io.File;
+import java.io.IOException;
+import java.security.InvalidParameterException;
+import java.util.ArrayList;
+import java.util.List;
 
-import static com.predic8.membrane.core.interceptor.Outcome.*;
-import static com.predic8.membrane.test.TestUtil.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
+import static com.predic8.membrane.test.TestUtil.getPathFromResource;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ResolverTest {
 
@@ -126,7 +135,8 @@ public class ResolverTest {
             return;
 
         try {
-            new XMLSchemaValidator(resolverMap, xsdLocation, null);
+            XMLSchemaValidator validator = new XMLSchemaValidator(resolverMap, xsdLocation, null);
+            validator.init();
         } catch (Exception e) {
             throw new RuntimeException("xsdLocation = " + xsdLocation, e);
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JSON and YAML validation now handles malformed request bodies as validation failures instead of unexpected exceptions.
  * Validation reports now include all applicable schema errors, rather than only one.
  * Validation continues across available schemas when an individual schema check fails.
  * Malformed input produces consistent failure responses and correctly updates validation metrics.
  * SOAP fault processing now extracts details only from the actual fault element, ignoring similarly named elements elsewhere in the message.

* **Tests**
  * Added coverage for malformed input, accumulated schema errors, error handling, and SOAP fault-detail extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->