### PR TITLE
fix: check whole validation array in XsdSchemaValidationTutorialTest

### DIFF
--- a/distribution/src/test/java/com/predic8/membrane/tutorials/xml/XsdSchemaValidationTutorialTest.java
+++ b/distribution/src/test/java/com/predic8/membrane/tutorials/xml/XsdSchemaValidationTutorialTest.java
@@ -55,7 +55,7 @@ public class XsdSchemaValidationTutorialTest extends AbstractXmlTutorialTest{
             .body("status", equalTo(400))
             .body("title", containsStringIgnoringCase("validation"))
             .body("validation.size()", greaterThan(0))
-            .body("validation[0].message", containsString("year"));
+            .body("validation.message", hasItem(containsString("year")));
         // @formatter:on
     }
 }


### PR DESCRIPTION
## Problem

`XsdSchemaValidationTutorialTest.invalidXmlFailsValidation()` failed deterministically. The
fixture `distribution/tutorials/xml/book-invalid.xml` has `<year>Not released yet</year>`,
validated against `YearType` (an `xs:gYear` restriction). Xerces reports **two** SAX errors for
that single bad value:

1. `cvc-datatype-valid.1.2.1: 'Not released yet' is not a valid value for 'gYear'.` (index 0 —
   names only the type)
2. `cvc-type.3.1.3: The value 'Not released yet' of element 'year' is not valid.` (index 1 —
   names the element)

`AbstractXMLSchemaValidator` maps both into the `validation[]` JSON array in that order, but the
test asserted `validation[0].message` contains `"year"` — a substring that only appears in
`validation[1]`.

This was a test-assertion bug, not a product bug: the validator correctly reports both schema
violations; the test just assumed the element-naming error would be first.

## Fix

Assert over the whole `validation` array instead of a fixed index:

```java
// before
.body("validation[0].message", containsString("year"));

// after
.body("validation.message", hasItem(containsString("year")));
```

## Testing

Rebuilt the distribution zip and ran `XsdSchemaValidationTutorialTest` in isolation: both
`validXmlPassesValidation` and `invalidXmlFailsValidation` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated XML schema validation testing to verify that the expected `year` validation message appears anywhere in the collection of validation messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->