### PR TITLE
Validator: add `validationDetails` option to hide validation error details.

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/AbstractXMLSchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/AbstractXMLSchemaValidator.java
@@ -57,14 +57,20 @@ public abstract class AbstractXMLSchemaValidator extends AbstractMessageValidato
     protected final String location;
     protected final ResolverMap resolver;
     protected final ValidatorInterceptor.FailureHandler failureHandler;
+    protected final ErrorDetailsPolicy errorDetailsPolicy;
     protected final AtomicLong valid = new AtomicLong();
     protected final AtomicLong invalid = new AtomicLong();
     private ArrayBlockingQueue<List<Validator>> validators;
 
     public AbstractXMLSchemaValidator(ResolverMap resolver, String location, ValidatorInterceptor.FailureHandler failureHandler) {
+        this(resolver, location, failureHandler, ErrorDetailsPolicy.FULL);
+    }
+
+    public AbstractXMLSchemaValidator(ResolverMap resolver, String location, ValidatorInterceptor.FailureHandler failureHandler, ErrorDetailsPolicy errorDetailsPolicy) {
         this.location = location;
         this.resolver = resolver;
         this.failureHandler = failureHandler;
+        this.errorDetailsPolicy = errorDetailsPolicy;
         xopr = new XOPReconstitutor();
     }
 

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/ErrorDetailsPolicy.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/ErrorDetailsPolicy.java
@@ -1,0 +1,37 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.core.interceptor.schemavalidation;
+
+/**
+ * How a validation failure is reported to the client.
+ * <p>
+ * Validation errors are not confidential - the schema a message is validated against is public -
+ * so {@code production} does not suppress them; only {@code validationDetails} does. The
+ * production flag is carried here purely so the
+ * {@link com.predic8.membrane.core.exceptions.ProblemDetails} envelope (title masking,
+ * development-mode warning) is built correctly. Validators that render their own body rather than
+ * a ProblemDetails document ignore it.
+ *
+ * @param validationDetails {@code <validator validationDetails="...">}
+ * @param production        {@code router.getConfiguration().isProduction()}
+ */
+public record ErrorDetailsPolicy(boolean validationDetails, boolean production) {
+
+    /**
+     * Full disclosure, development mode. The default for validators constructed directly rather
+     * than through {@link ValidatorInterceptor}.
+     */
+    public static final ErrorDetailsPolicy FULL = new ErrorDetailsPolicy(true, false);
+}

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/ErrorDetailsPolicy.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/ErrorDetailsPolicy.java
@@ -14,6 +14,12 @@
 
 package com.predic8.membrane.core.interceptor.schemavalidation;
 
+import com.predic8.membrane.core.exceptions.ProblemDetails;
+
+import java.util.function.Consumer;
+
+import static com.predic8.membrane.core.exceptions.ProblemDetails.user;
+
 /**
  * How a validation failure is reported to the client.
  * <p>
@@ -34,4 +40,25 @@ public record ErrorDetailsPolicy(boolean validationDetails, boolean production) 
      * than through {@link ValidatorInterceptor}.
      */
     public static final ErrorDetailsPolicy FULL = new ErrorDetailsPolicy(true, false);
+
+    /**
+     * The {@link ProblemDetails} envelope reporting a rejected message: a user error naming the
+     * validator and carrying {@code title}, with {@code details} applied only when the
+     * configuration allows the validation details to be disclosed. Every validator that answers
+     * with a ProblemDetails document builds its response here, so that the disclosure decision is
+     * made in one place.
+     *
+     * @param component the validator's name
+     * @param title     what went wrong in general terms - never a message-specific detail, since
+     *                  the title is reported whether the details are disclosed or not
+     * @param details   adds the top-level members describing what was wrong with the message
+     */
+    public ProblemDetails problemDetails(String component, String title, Consumer<ProblemDetails> details) {
+        var pd = user(production, component)
+                .title(title)
+                .addSubType("validation");
+        if (validationDetails)
+            details.accept(pd);
+        return pd;
+    }
 }

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONSchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONSchemaValidator.java
@@ -50,14 +50,20 @@ public class JSONSchemaValidator extends AbstractMessageValidator {
     private final Resolver resolver;
     private final String jsonSchema;
     private final ValidatorInterceptor.FailureHandler failureHandler;
+    private final ErrorDetailsPolicy errorDetailsPolicy;
 
     private final AtomicLong valid = new AtomicLong();
     private final AtomicLong invalid = new AtomicLong();
 
     public JSONSchemaValidator(Resolver resolver, String jsonSchema, ValidatorInterceptor.FailureHandler failureHandler) {
+        this(resolver, jsonSchema, failureHandler, ErrorDetailsPolicy.FULL);
+    }
+
+    public JSONSchemaValidator(Resolver resolver, String jsonSchema, ValidatorInterceptor.FailureHandler failureHandler, ErrorDetailsPolicy errorDetailsPolicy) {
         this.resolver = resolver;
         this.jsonSchema = jsonSchema;
         this.failureHandler = failureHandler;
+        this.errorDetailsPolicy = errorDetailsPolicy;
     }
 
     @Override
@@ -93,21 +99,17 @@ public class JSONSchemaValidator extends AbstractMessageValidator {
 
         if (failureHandler != null) {
             failureHandler.handleFailure(getErrorString(msg, errors), exc);
-            user(false,getName())
-                    .title(getErrorTitle())
-                    .addSubType("validation")
-                    .buildAndSetResponse(exc);
-            invalid.incrementAndGet();
-            return ABORT;
         }
 
-        user(false,getName())
+        var pd = user(errorDetailsPolicy.production(), getName())
                 .title(getErrorTitle())
                 .addSubType("validation")
-                .component(getName())
-                .internal("flow", flow.name())
-                .internal("errors", errors)
-                .buildAndSetResponse(exc);
+                .component(getName());
+        if (errorDetailsPolicy.validationDetails()) {
+            pd.topLevel("flow", flow.name());
+            pd.topLevel("errors", errors);
+        }
+        pd.buildAndSetResponse(exc);
 
         invalid.incrementAndGet();
         return ABORT;

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONSchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONSchemaValidator.java
@@ -34,7 +34,6 @@ import java.nio.charset.Charset;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static com.predic8.membrane.core.exceptions.ProblemDetails.user;
 import static com.predic8.membrane.core.interceptor.Outcome.ABORT;
 import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -97,21 +96,21 @@ public class JSONSchemaValidator extends AbstractMessageValidator {
             errors = List.of(e.getOriginalMessage() != null ? e.getOriginalMessage() : e.getMessage());
         }
 
+        return reportFailure(exc, flow, msg, errors);
+    }
+
+    private Outcome reportFailure(Exchange exc, Flow flow, Message msg, List<String> errors) {
+        invalid.incrementAndGet();
+        log.info("{} message did not validate against {}: {}", flow, jsonSchema, errors);
+
         if (failureHandler != null) {
             failureHandler.handleFailure(getErrorString(msg, errors), exc);
         }
 
-        var pd = user(errorDetailsPolicy.production(), getName())
-                .title(getErrorTitle())
-                .addSubType("validation")
-                .component(getName());
-        if (errorDetailsPolicy.validationDetails()) {
-            pd.topLevel("flow", flow.name());
-            pd.topLevel("errors", errors);
-        }
-        pd.buildAndSetResponse(exc);
+        errorDetailsPolicy.problemDetails(getName(), getErrorTitle(),
+                        pd -> pd.topLevel("flow", flow.name()).topLevel("errors", errors))
+                .buildAndSetResponse(exc);
 
-        invalid.incrementAndGet();
         return ABORT;
     }
 

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/SchematronValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/SchematronValidator.java
@@ -44,6 +44,7 @@ public class SchematronValidator extends AbstractMessageValidator {
 	private final ArrayBlockingQueue<Transformer> transformers;
 	private final XMLInputFactory xmlInputFactory;
 	private final ValidatorInterceptor.FailureHandler failureHandler;
+	private final ErrorDetailsPolicy errorDetailsPolicy;
 	private final XOPReconstitutor xopr = new XOPReconstitutor();
 
 	private final AtomicLong valid = new AtomicLong();
@@ -54,8 +55,9 @@ public class SchematronValidator extends AbstractMessageValidator {
 		return "Schematron Validator";
 	}
 
-	public SchematronValidator(String schematron, ValidatorInterceptor.FailureHandler failureHandler, Router router, BeanFactory beanFactory) throws Exception {
+	public SchematronValidator(String schematron, ValidatorInterceptor.FailureHandler failureHandler, Router router, BeanFactory beanFactory, ErrorDetailsPolicy errorDetailsPolicy) throws Exception {
 		this.failureHandler = failureHandler;
+		this.errorDetailsPolicy = errorDetailsPolicy;
 
 		//works as standalone "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl"
 		TransformerFactory fac;
@@ -141,10 +143,9 @@ public class SchematronValidator extends AbstractMessageValidator {
 
 		if (failureHandler != null) {
 			failureHandler.handleFailure(message, exc);
-			exc.setResponse(Response.badRequest().contentType(TEXT_XML_UTF8).body((MSG_HEADER + MSG_FOOTER).getBytes(UTF_8)).build());
-		} else {
-			exc.setResponse(Response.badRequest().contentType(TEXT_XML_UTF8).body(message.getBytes(UTF_8)).build());
 		}
+		String body = errorDetailsPolicy.validationDetails() ? message : MSG_HEADER + MSG_FOOTER;
+		exc.setResponse(Response.badRequest().contentType(TEXT_XML_UTF8).body(body.getBytes(UTF_8)).build());
 		if (!escape)
 			exc.getResponse().getHeader().add(VALIDATION_ERROR_SOURCE, source);
 	}

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/ValidatorInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/ValidatorInterceptor.java
@@ -46,13 +46,16 @@ import static com.predic8.membrane.core.util.text.TextUtil.linkURL;
  * @description Validates request and response message bodies against a schema. The schema type is selected by the
  * attribute you set: <code>wsdl</code> for SOAP messages, <code>schema</code> for XML against an XSD,
  * <code>jsonSchema</code> for JSON or YAML, or <code>schematron</code>. Exactly one of them must be configured; inside a
- * soapProxy the WSDL is taken from the proxy automatically. An empty body passes; an invalid body is rejected, either
- * with a detailed error response or a generic one plus a log entry, depending on <code>failureHandler</code>. See the
- * examples under examples/validation, examples/xml/xml-validation, and examples/web-services-soap/soap-wsdl-validation.
+ * soapProxy the WSDL is taken from the proxy automatically. An empty body passes; an invalid body is rejected with an
+ * error response that lists what was wrong. Set <code>validationDetails</code> to <code>false</code> to reject with a
+ * bare error instead, and <code>failureHandler</code> to control where the failure is logged. See
+ * distribution/tutorials/xml/50-XSD-Schema-validation.yaml and
+ * distribution/tutorials/soap/40-WSDL-Message-Validation.yaml.
  * <pre>
  * validator:
  *   wsdl: &lt;url&gt; | schema: &lt;url&gt; | jsonSchema: &lt;url&gt; | schematron: &lt;url&gt;   # choose one
- *   [ failureHandler: response | log ]   # default: response
+ *   [ validationDetails: true | false ]   # default: true
+ *   [ failureHandler: response | log ]    # default: response
  * </pre>
  * @topic 3. Security and Validation
  * @yaml
@@ -85,6 +88,7 @@ public class ValidatorInterceptor extends AbstractInterceptor implements Applica
     private String schematron;
     private String failureHandler;
     private boolean skipFaults;
+    private boolean validationDetails = true;
 
     private MessageValidator validator;
     private ResolverMap resourceResolver;
@@ -124,22 +128,22 @@ public class ValidatorInterceptor extends AbstractInterceptor implements Applica
         if (wsdl != null) {
             if (schemaMappings != null)
                 logIgnoringRefSchemas();
-            return new WSDLValidator(resourceResolver, combine(router.getConfiguration().getUriFactory(), getBeanBaseLocation(), wsdl), serviceName, createFailureHandler(), skipFaults);
+            return new WSDLValidator(resourceResolver, combine(router.getConfiguration().getUriFactory(), getBeanBaseLocation(), wsdl), serviceName, createFailureHandler(), skipFaults, errorDetailsPolicy());
         }
         if (schema != null) {
             if (schemaMappings != null)
                 logIgnoringRefSchemas();
-            return new XMLSchemaValidator(resourceResolver, combine(router.getConfiguration().getUriFactory(), getBeanBaseLocation(), schema), createFailureHandler());
+            return new XMLSchemaValidator(resourceResolver, combine(router.getConfiguration().getUriFactory(), getBeanBaseLocation(), schema), createFailureHandler(), errorDetailsPolicy());
         }
         if (jsonSchema != null) {
-            return new JSONYAMLSchemaValidator(resourceResolver, combine(router.getConfiguration().getUriFactory(), getBeanBaseLocation(), jsonSchema), createFailureHandler(), schemaVersion) {{
+            return new JSONYAMLSchemaValidator(resourceResolver, combine(router.getConfiguration().getUriFactory(), getBeanBaseLocation(), jsonSchema), createFailureHandler(), schemaVersion, errorDetailsPolicy()) {{
                 if(schemaMappings != null) setSchemaMappings(schemaMappings.getSchemaMap());
             }};
         }
         if (schematron != null) {
             if (schemaMappings != null)
                 logIgnoringRefSchemas();
-            return new SchematronValidator(combine(router.getConfiguration().getUriFactory(), getBeanBaseLocation(), schematron), createFailureHandler(), router, applicationContext);
+            return new SchematronValidator(combine(router.getConfiguration().getUriFactory(), getBeanBaseLocation(), schematron), createFailureHandler(), router, applicationContext, errorDetailsPolicy());
         }
 
         var validator = getWsdlValidatorFromSOAPProxy();
@@ -156,7 +160,11 @@ public class ValidatorInterceptor extends AbstractInterceptor implements Applica
         if(soapProxy == null) return null;
         wsdl = soapProxy.getResolvedWsdl();
         name = "soap validator";
-        return new WSDLValidator(resourceResolver, combine(router.getConfiguration().getUriFactory(), resolveBaseLocation(soapProxy, router), wsdl), serviceName, createFailureHandler(), skipFaults);
+        return new WSDLValidator(resourceResolver, combine(router.getConfiguration().getUriFactory(), resolveBaseLocation(soapProxy, router), wsdl), serviceName, createFailureHandler(), skipFaults, errorDetailsPolicy());
+    }
+
+    private ErrorDetailsPolicy errorDetailsPolicy() {
+        return new ErrorDetailsPolicy(validationDetails, router.getConfiguration().isProduction());
     }
 
     @Override
@@ -228,8 +236,9 @@ public class ValidatorInterceptor extends AbstractInterceptor implements Applica
     }
 
     /**
-     * @description How a validation failure is reported. <code>response</code> returns a detailed error to the client;
-     * <code>log</code> returns a generic error and writes the details to the log.
+     * @description Where a validation failure is reported in addition to the error response.
+     * <code>log</code> writes the details to the log, <code>response</code> does not. What the client receives is
+     * controlled by <code>validationDetails</code>.
      * @default response
      * @example log
      */
@@ -276,6 +285,22 @@ public class ValidatorInterceptor extends AbstractInterceptor implements Applica
     @MCAttribute
     public void setSchematron(String schematron) {
         this.schematron = schematron;
+    }
+
+    public boolean isValidationDetails() {
+        return validationDetails;
+    }
+
+    /**
+     * @description Whether validation error responses list what was wrong with the message. Set to <code>false</code>
+     * to reject with a bare error instead. The details are not hidden by production mode, because the schema a message
+     * is validated against is public.
+     * @default true
+     * @example false
+     */
+    @MCAttribute
+    public void setValidationDetails(boolean validationDetails) {
+        this.validationDetails = validationDetails;
     }
 
     public boolean isSkipFaults() {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidator.java
@@ -110,7 +110,11 @@ public class WSDLValidator extends AbstractXMLSchemaValidator {
     private final com.predic8.membrane.core.util.wsdl.parser.Definitions definitions;
 
     public WSDLValidator(ResolverMap resourceResolver, String location, String serviceName, ValidatorInterceptor.FailureHandler failureHandler, boolean skipFaults) {
-        super(resourceResolver, location, failureHandler);
+        this(resourceResolver, location, serviceName, failureHandler, skipFaults, ErrorDetailsPolicy.FULL);
+    }
+
+    public WSDLValidator(ResolverMap resourceResolver, String location, String serviceName, ValidatorInterceptor.FailureHandler failureHandler, boolean skipFaults, ErrorDetailsPolicy errorDetailsPolicy) {
+        super(resourceResolver, location, failureHandler, errorDetailsPolicy);
         this.skipFaults = skipFaults;
 
         try {
@@ -339,12 +343,22 @@ public class WSDLValidator extends AbstractXMLSchemaValidator {
 
     @Override
     protected void setErrorResponse(Exchange exchange, Interceptor.Flow flow, String message) {
-        exchange.setResponse(createSOAPFaultResponse(Client, getErrorTitle(), Map.of("error", message), soapVersionOf(exchange)));
+        setFaultResponse(exchange, Map.of("error", message));
     }
 
     @Override
     protected void setErrorResponse(Exchange exchange, Interceptor.Flow flow, List<Exception> exceptions) {
-        exchange.setResponse(createSOAPFaultResponse(Client, getErrorTitle(), Map.of("validation", convertExceptionsToMap(exceptions)), soapVersionOf(exchange)));
+        setFaultResponse(exchange, Map.of("validation", convertExceptionsToMap(exceptions)));
+    }
+
+    /**
+     * Sends a SOAP fault reporting the rejection. The fault code and reason always identify the
+     * rejection; the {@code detail} content is only filled in when the configuration allows the
+     * validation details to be disclosed.
+     */
+    private void setFaultResponse(Exchange exchange, Map<String, Object> detail) {
+        exchange.setResponse(createSOAPFaultResponse(Client, getErrorTitle(),
+                errorDetailsPolicy.validationDetails() ? detail : Map.of(), soapVersionOf(exchange)));
     }
 
     /**

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/XMLSchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/XMLSchemaValidator.java
@@ -50,6 +50,10 @@ public class XMLSchemaValidator extends AbstractXMLSchemaValidator {
         super(resourceResolver, location, failureHandler);
     }
 
+    public XMLSchemaValidator(ResolverMap resourceResolver, String location, ValidatorInterceptor.FailureHandler failureHandler, ErrorDetailsPolicy errorDetailsPolicy) {
+        super(resourceResolver, location, failureHandler, errorDetailsPolicy);
+    }
+
     @Override
     public String getName() {
         return "xml-schema-validator";
@@ -105,20 +109,22 @@ public class XMLSchemaValidator extends AbstractXMLSchemaValidator {
 
     @Override
     protected void setErrorResponse(Exchange exchange, Interceptor.Flow flow, String message) {
-        user(false,getName())
+        var pd = user(errorDetailsPolicy.production(), getName())
                 .title(getErrorTitle())
                 .addSubType("validation")
-                .component(getName())
-                .internal("error", message)
-                .buildAndSetResponse(exchange);
+                .component(getName());
+        if (errorDetailsPolicy.validationDetails())
+            pd.topLevel("error", message);
+        pd.buildAndSetResponse(exchange);
     }
 
     @Override
     protected void setErrorResponse(Exchange exchange, Interceptor.Flow flow, List<Exception> exceptions) {
-        user(false,getName())
-                .title(getErrorTitle())
-                .internal("validation", convertExceptionsToMap(exceptions))
-                .buildAndSetResponse(exchange);
+        var pd = user(errorDetailsPolicy.production(), getName())
+                .title(getErrorTitle());
+        if (errorDetailsPolicy.validationDetails())
+            pd.topLevel("validation", convertExceptionsToMap(exceptions));
+        pd.buildAndSetResponse(exchange);
     }
 
     @Override

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/XMLSchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/XMLSchemaValidator.java
@@ -40,7 +40,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.predic8.membrane.annot.Constants.XSD_NS;
-import static com.predic8.membrane.core.exceptions.ProblemDetails.user;
 
 public class XMLSchemaValidator extends AbstractXMLSchemaValidator {
 
@@ -109,22 +108,15 @@ public class XMLSchemaValidator extends AbstractXMLSchemaValidator {
 
     @Override
     protected void setErrorResponse(Exchange exchange, Interceptor.Flow flow, String message) {
-        var pd = user(errorDetailsPolicy.production(), getName())
-                .title(getErrorTitle())
-                .addSubType("validation")
-                .component(getName());
-        if (errorDetailsPolicy.validationDetails())
-            pd.topLevel("error", message);
-        pd.buildAndSetResponse(exchange);
+        errorDetailsPolicy.problemDetails(getName(), getErrorTitle(), pd -> pd.topLevel("error", message))
+                .buildAndSetResponse(exchange);
     }
 
     @Override
     protected void setErrorResponse(Exchange exchange, Interceptor.Flow flow, List<Exception> exceptions) {
-        var pd = user(errorDetailsPolicy.production(), getName())
-                .title(getErrorTitle());
-        if (errorDetailsPolicy.validationDetails())
-            pd.topLevel("validation", convertExceptionsToMap(exceptions));
-        pd.buildAndSetResponse(exchange);
+        errorDetailsPolicy.problemDetails(getName(), getErrorTitle(),
+                        pd -> pd.topLevel("validation", convertExceptionsToMap(exceptions)))
+                .buildAndSetResponse(exchange);
     }
 
     @Override

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/json/JSONYAMLSchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/json/JSONYAMLSchemaValidator.java
@@ -55,6 +55,8 @@ public class JSONYAMLSchemaValidator extends AbstractMessageValidator {
 
     public static final String SCHEMA_VERSION_2020_12 = "2020-12";
 
+    private static final Set<String> LOGGED_ERROR_FIELDS = Set.of("message", "key", "keyword", "pointer");
+
     private final Resolver resolver;
     private final String jsonSchema;
     private final FailureHandler failureHandler;
@@ -154,7 +156,7 @@ public class JSONYAMLSchemaValidator extends AbstractMessageValidator {
 
     private Outcome reportFailure(Exchange exc, Flow flow, List<Map<String, Object>> mapForProblemDetails) {
         invalid.incrementAndGet();
-        log.info("{} message did not validate against {}: {}", flow, jsonSchema, mapForProblemDetails);
+        log.info("{} message did not validate against {}: {}", flow, jsonSchema, failedConstraints(mapForProblemDetails));
 
         failureHandler.handleFailure(mapForProblemDetails.toString(), exc);
 
@@ -178,6 +180,14 @@ public class JSONYAMLSchemaValidator extends AbstractMessageValidator {
             parser.nextToken();
         }
         return assertions;
+    }
+
+    private static List<Map<String, Object>> failedConstraints(List<Map<String, Object>> errors) {
+        return errors.stream().<Map<String, Object>>map(error -> {
+            var constraint = new LinkedHashMap<>(error);
+            constraint.keySet().retainAll(LOGGED_ERROR_FIELDS);
+            return constraint;
+        }).toList();
     }
 
     private @NotNull List<Map<String, Object>> getMapForProblemDetails(List<Error> assertions) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/json/JSONYAMLSchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/json/JSONYAMLSchemaValidator.java
@@ -25,6 +25,7 @@ import com.predic8.membrane.core.exchange.Exchange;
 import com.predic8.membrane.core.interceptor.Interceptor.Flow;
 import com.predic8.membrane.core.interceptor.Outcome;
 import com.predic8.membrane.core.interceptor.schemavalidation.AbstractMessageValidator;
+import com.predic8.membrane.core.interceptor.schemavalidation.ErrorDetailsPolicy;
 import com.predic8.membrane.core.interceptor.schemavalidation.ValidatorInterceptor.FailureHandler;
 import com.predic8.membrane.core.resolver.Resolver;
 import org.jetbrains.annotations.NotNull;
@@ -58,6 +59,7 @@ public class JSONYAMLSchemaValidator extends AbstractMessageValidator {
     private final Resolver resolver;
     private final String jsonSchema;
     private final FailureHandler failureHandler;
+    private final ErrorDetailsPolicy errorDetailsPolicy;
 
     private final AtomicLong valid = new AtomicLong();
     private final AtomicLong invalid = new AtomicLong();
@@ -73,15 +75,24 @@ public class JSONYAMLSchemaValidator extends AbstractMessageValidator {
     InputFormat inputFormat;
 
     public JSONYAMLSchemaValidator(Resolver resolver, String jsonSchema, FailureHandler failureHandler, String schemaVersion, InputFormat inputFormat) {
+        this(resolver, jsonSchema, failureHandler, schemaVersion, inputFormat, ErrorDetailsPolicy.FULL);
+    }
+
+    public JSONYAMLSchemaValidator(Resolver resolver, String jsonSchema, FailureHandler failureHandler, String schemaVersion, InputFormat inputFormat, ErrorDetailsPolicy errorDetailsPolicy) {
         this.resolver = resolver;
         this.jsonSchema = jsonSchema;
         this.failureHandler = failureHandler;
         this.schemaId = JSONSchemaVersionParser.parse(schemaVersion);
         this.inputFormat = inputFormat;
+        this.errorDetailsPolicy = errorDetailsPolicy;
     }
 
     public JSONYAMLSchemaValidator(Resolver resolver, String jsonSchema, FailureHandler failureHandler, String schemaVersion) {
         this(resolver, jsonSchema, failureHandler, schemaVersion, JSON);
+    }
+
+    public JSONYAMLSchemaValidator(Resolver resolver, String jsonSchema, FailureHandler failureHandler, String schemaVersion, ErrorDetailsPolicy errorDetailsPolicy) {
+        this(resolver, jsonSchema, failureHandler, schemaVersion, JSON, errorDetailsPolicy);
     }
 
     public JSONYAMLSchemaValidator(Resolver resolver, String jsonSchema, FailureHandler failureHandler) {
@@ -149,13 +160,15 @@ public class JSONYAMLSchemaValidator extends AbstractMessageValidator {
 
         failureHandler.handleFailure(mapForProblemDetails.toString(), exc);
 
-        user(false, getName())
+        var pd = user(errorDetailsPolicy.production(), getName())
                 .title(getErrorTitle())
                 .addSubType("validation")
-                .component(getName())
-                .internal("flow", flow.name())
-                .internal("errors", mapForProblemDetails)
-                .buildAndSetResponse(exc);
+                .component(getName());
+        if (errorDetailsPolicy.validationDetails()) {
+            pd.topLevel("flow", flow.name());
+            pd.topLevel("errors", mapForProblemDetails);
+        }
+        pd.buildAndSetResponse(exc);
 
         return ABORT;
     }

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/json/JSONYAMLSchemaValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/json/JSONYAMLSchemaValidator.java
@@ -42,7 +42,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import static com.fasterxml.jackson.core.StreamReadFeature.STRICT_DUPLICATE_DETECTION;
 import static com.networknt.schema.InputFormat.JSON;
 import static com.networknt.schema.InputFormat.YAML;
-import static com.predic8.membrane.core.exceptions.ProblemDetails.user;
 import static com.predic8.membrane.core.interceptor.Outcome.ABORT;
 import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -150,25 +149,18 @@ public class JSONYAMLSchemaValidator extends AbstractMessageValidator {
             return CONTINUE;
         }
 
-        log.debug("Validation failed: {}", assertions);
-
         return reportFailure(exc, flow, getMapForProblemDetails(assertions));
     }
 
     private Outcome reportFailure(Exchange exc, Flow flow, List<Map<String, Object>> mapForProblemDetails) {
         invalid.incrementAndGet();
+        log.info("{} message did not validate against {}: {}", flow, jsonSchema, mapForProblemDetails);
 
         failureHandler.handleFailure(mapForProblemDetails.toString(), exc);
 
-        var pd = user(errorDetailsPolicy.production(), getName())
-                .title(getErrorTitle())
-                .addSubType("validation")
-                .component(getName());
-        if (errorDetailsPolicy.validationDetails()) {
-            pd.topLevel("flow", flow.name());
-            pd.topLevel("errors", mapForProblemDetails);
-        }
-        pd.buildAndSetResponse(exc);
+        errorDetailsPolicy.problemDetails(getName(), getErrorTitle(),
+                        pd -> pd.topLevel("flow", flow.name()).topLevel("errors", mapForProblemDetails))
+                .buildAndSetResponse(exc);
 
         return ABORT;
     }

--- a/core/src/main/java/com/predic8/membrane/core/util/SOAPUtil.java
+++ b/core/src/main/java/com/predic8/membrane/core/util/SOAPUtil.java
@@ -104,7 +104,7 @@ public class SOAPUtil {
         body.appendChild(fault);
 
         Element faultCode = doc.createElement("faultcode");
-        faultCode.setTextContent(faultcode.name());
+        faultCode.setTextContent("soap:" + faultcode.name());
         fault.appendChild(faultCode);
 
         Element faultString = doc.createElement("faultstring");

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONSchemaValidationTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONSchemaValidationTest.java
@@ -24,7 +24,9 @@ import static com.predic8.membrane.core.http.Request.post;
 import static com.predic8.membrane.core.interceptor.Interceptor.Flow.REQUEST;
 import static com.predic8.membrane.core.interceptor.Outcome.ABORT;
 import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
+import static com.predic8.membrane.core.interceptor.schemavalidation.ValidatorInterceptor.FailureHandler.VOID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class JSONSchemaValidationTest {
 
@@ -183,7 +185,7 @@ public class JSONSchemaValidationTest {
                 {
                     "required": [ "p1" ]
                 }
-                """, ValidatorInterceptor.FailureHandler.VOID);
+                """, VOID);
         validator.init();
 
         Exchange exc = post("/foo").body("{}").buildExchange();
@@ -191,6 +193,43 @@ public class JSONSchemaValidationTest {
 
         JsonNode jn = om.readTree(exc.getResponse().getBodyAsStream());
         assertEquals("JSON validation failed", jn.get("title").textValue());
+        assertEquals(1, jn.get("errors").size(), "a failure handler must not swallow the validation details");
+    }
+
+    @Test
+    void validationDetailsOffOmitsErrors() throws Exception {
+        var validator = new JSONSchemaValidator(new StaticStringResolver(), """
+                {
+                    "required": [ "p1" ]
+                }
+                """, VOID, new ErrorDetailsPolicy(false, false));
+        validator.init();
+
+        Exchange exc = post("/foo").body("{}").buildExchange();
+        assertEquals(ABORT, validator.validateMessage(exc, REQUEST));
+
+        JsonNode jn = om.readTree(exc.getResponse().getBodyAsStream());
+        assertEquals("JSON validation failed", jn.get("title").textValue());
+        assertEquals("https://membrane-api.io/problems/user/validation", jn.get("type").textValue());
+        assertNull(jn.get("errors"));
+        assertNull(jn.get("flow"));
+    }
+
+    @Test
+    void productionModeKeepsErrors() throws Exception {
+        var validator = new JSONSchemaValidator(new StaticStringResolver(), """
+                {
+                    "required": [ "p1" ]
+                }
+                """, VOID, new ErrorDetailsPolicy(true, true));
+        validator.init();
+
+        Exchange exc = post("/foo").body("{}").buildExchange();
+        assertEquals(ABORT, validator.validateMessage(exc, REQUEST));
+
+        JsonNode jn = om.readTree(exc.getResponse().getBodyAsStream());
+        assertEquals(1, jn.get("errors").size(), "the schema is public, so its errors stay visible in production");
+        assertNull(jn.get("attention"), "no development-mode warning on a production router");
     }
 
     private static @NotNull JSONSchemaValidator getValidator(String schema) {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONYAMLSchemaValidatorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONYAMLSchemaValidatorTest.java
@@ -14,6 +14,8 @@
 
 package com.predic8.membrane.core.interceptor.schemavalidation;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.predic8.membrane.core.exchange.Exchange;
 import com.predic8.membrane.core.interceptor.schemavalidation.json.JSONYAMLSchemaValidator;
 import com.predic8.membrane.core.resolver.ClasspathSchemaResolver;
@@ -25,7 +27,9 @@ import static com.predic8.membrane.core.http.Request.get;
 import static com.predic8.membrane.core.interceptor.Interceptor.Flow.REQUEST;
 import static com.predic8.membrane.core.interceptor.Outcome.ABORT;
 import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
+import static com.predic8.membrane.core.interceptor.schemavalidation.json.JSONYAMLSchemaValidator.SCHEMA_VERSION_2020_12;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class JSONYAMLSchemaValidatorTest {
@@ -53,6 +57,44 @@ class JSONYAMLSchemaValidatorTest {
                 """).buildExchange();
         assertEquals(CONTINUE, validator.validateMessage( exc, REQUEST));
         assertEquals(1, validator.getValid());
+    }
+
+    @Test
+    void detailsOnByDefault() throws Exception {
+        assertEquals(1, invalidAge(validator).get("errors").size());
+    }
+
+    @Test
+    void validationDetailsOffOmitsErrors() throws Exception {
+        JsonNode jn = invalidAge(build(new ErrorDetailsPolicy(false, false)));
+        assertEquals("JSON validation failed", jn.get("title").asText());
+        assertNull(jn.get("errors"));
+        assertNull(jn.get("flow"));
+    }
+
+    @Test
+    void productionModeKeepsErrors() throws Exception {
+        JsonNode jn = invalidAge(build(new ErrorDetailsPolicy(true, true)));
+        assertEquals(1, jn.get("errors").size(), "the schema is public, so its errors stay visible in production");
+        assertNull(jn.get("attention"), "no development-mode warning on a production router");
+    }
+
+    private static JSONYAMLSchemaValidator build(ErrorDetailsPolicy policy) {
+        var v = new JSONYAMLSchemaValidator(new ClasspathSchemaResolver(),
+                "classpath:/validation/json-schema/simple-schema.json", (a, b) -> {},
+                SCHEMA_VERSION_2020_12, policy);
+        v.init();
+        return v;
+    }
+
+    private static JsonNode invalidAge(JSONYAMLSchemaValidator v) throws Exception {
+        Exchange exc = get("/foo").body("""
+                {
+                    "age": -1
+                }
+                """).buildExchange();
+        assertEquals(ABORT, v.validateMessage(exc, REQUEST));
+        return new ObjectMapper().readTree(exc.getResponse().getBodyAsStreamDecoded());
     }
 
     @Test

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONYAMLSchemaValidatorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONYAMLSchemaValidatorTest.java
@@ -20,6 +20,9 @@ import com.predic8.membrane.core.exchange.Exchange;
 import com.predic8.membrane.core.interceptor.schemavalidation.json.JSONYAMLSchemaValidator;
 import com.predic8.membrane.core.resolver.ClasspathSchemaResolver;
 import com.predic8.membrane.core.util.ConfigurationException;
+import com.predic8.membrane.test.TestAppender;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,6 +34,7 @@ import static com.predic8.membrane.core.interceptor.schemavalidation.json.JSONYA
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JSONYAMLSchemaValidatorTest {
 
@@ -77,6 +81,23 @@ class JSONYAMLSchemaValidatorTest {
         JsonNode jn = invalidAge(build(new ErrorDetailsPolicy(true, true)));
         assertEquals(1, jn.get("errors").size(), "the schema is public, so its errors stay visible in production");
         assertNull(jn.get("attention"), "no development-mode warning on a production router");
+    }
+
+    @Test
+    void validationDetailsOffStillLogsTheErrors() throws Exception {
+        Logger root = (Logger) LogManager.getRootLogger();
+        var appender = new TestAppender("JSONYAMLSchemaValidatorTest");
+        appender.start();
+        root.addAppender(appender);
+        try {
+            invalidAge(build(new ErrorDetailsPolicy(false, false)));
+        } finally {
+            root.removeAppender(appender);
+            appender.stop();
+        }
+
+        assertTrue(appender.contains("message did not validate against"), appender.getMessages().toString());
+        assertTrue(appender.contains("minimum"), appender.getMessages().toString());
     }
 
     private static JSONYAMLSchemaValidator build(ErrorDetailsPolicy policy) {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONYAMLSchemaValidatorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONYAMLSchemaValidatorTest.java
@@ -26,12 +26,15 @@ import org.apache.logging.log4j.core.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.Callable;
+
 import static com.predic8.membrane.core.http.Request.get;
 import static com.predic8.membrane.core.interceptor.Interceptor.Flow.REQUEST;
 import static com.predic8.membrane.core.interceptor.Outcome.ABORT;
 import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
 import static com.predic8.membrane.core.interceptor.schemavalidation.json.JSONYAMLSchemaValidator.SCHEMA_VERSION_2020_12;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -83,21 +86,55 @@ class JSONYAMLSchemaValidatorTest {
         assertNull(jn.get("attention"), "no development-mode warning on a production router");
     }
 
+    /**
+     * Withholding the details from the client must not withhold the failed constraint from the
+     * operator: the failure handler is a no-op by default, so the log is the only place left where
+     * the reason for the rejection can be found.
+     */
     @Test
-    void validationDetailsOffStillLogsTheErrors() throws Exception {
+    void validationDetailsOffStillLogsTheFailedConstraint() throws Exception {
+        var appender = captureLog(() -> invalidAge(build(new ErrorDetailsPolicy(false, false))));
+
+        assertTrue(appender.contains("message did not validate against"), appender.getMessages().toString());
+        assertTrue(appender.contains("minimum"), appender.getMessages().toString());
+    }
+
+    /**
+     * What the log must not carry is the message being validated. An {@code additionalProperties}
+     * violation reports the whole body as the offending node, so a rejected login would otherwise
+     * put the submitted password in the log.
+     */
+    @Test
+    void submittedValuesAreNotLogged() throws Exception {
+        var appender = captureLog(() -> {
+            Exchange exc = get("/foo").body("""
+                    {
+                        "name": "Bob",
+                        "secret": "hunter2"
+                    }
+                    """).buildExchange();
+            assertEquals(ABORT, build(new ErrorDetailsPolicy(false, false)).validateMessage(exc, REQUEST));
+            return null;
+        });
+
+        String logged = appender.getMessages().toString();
+        assertTrue(logged.contains("additionalProperties"), logged);
+        assertFalse(logged.contains("hunter2"), "the submitted value must not be logged: " + logged);
+        assertFalse(logged.contains("node="), "the offending node must not be logged: " + logged);
+    }
+
+    private static TestAppender captureLog(Callable<?> validation) throws Exception {
         Logger root = (Logger) LogManager.getRootLogger();
         var appender = new TestAppender("JSONYAMLSchemaValidatorTest");
         appender.start();
         root.addAppender(appender);
         try {
-            invalidAge(build(new ErrorDetailsPolicy(false, false)));
+            validation.call();
         } finally {
             root.removeAppender(appender);
             appender.stop();
         }
-
-        assertTrue(appender.contains("message did not validate against"), appender.getMessages().toString());
-        assertTrue(appender.contains("minimum"), appender.getMessages().toString());
+        return appender;
     }
 
     private static JSONYAMLSchemaValidator build(ErrorDetailsPolicy policy) {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/SOAPUtilTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/SOAPUtilTest.java
@@ -235,6 +235,19 @@ public class SOAPUtilTest {
     }
 
     /**
+     * faultcode is xs:QName (soap11-fault.xsd); SOAP 1.1 SS4.4.1 requires its value to be
+     * qualified with the SOAP envelope namespace prefix, e.g. "soap:Client" - an unprefixed
+     * "Client" is a syntactically valid QName too, but means "no namespace", not "in the SOAP
+     * envelope namespace".
+     */
+    @Test
+    void createSOAP11FaultQualifiesFaultCodeValue() throws Exception {
+        var doc = SOAPUtil.createSOAP11Fault(SOAPUtil.FaultCode.Client, "failed", null);
+        var faultCode = doc.getElementsByTagName("faultcode").item(0);
+        assertEquals("soap:Client", faultCode.getTextContent());
+    }
+
+    /**
      * createSOAP12Fault's Fault element must carry the SOAP 1.2 envelope namespace, matching the
      * bundled soap12-fault.xsd - otherwise Membrane-generated faults fail their own structural
      * validation. Also checks that FaultCode.Client/Server are translated to the SOAP 1.2

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/SchematronValidatorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/SchematronValidatorTest.java
@@ -1,0 +1,105 @@
+/* Copyright 2026 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.core.interceptor.schemavalidation;
+
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.router.TestRouter;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+
+import javax.xml.transform.TransformerFactory;
+
+import static com.predic8.membrane.core.http.Header.VALIDATION_ERROR_SOURCE;
+import static com.predic8.membrane.core.http.Request.post;
+import static com.predic8.membrane.core.interceptor.Interceptor.Flow.REQUEST;
+import static com.predic8.membrane.core.interceptor.Outcome.ABORT;
+import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SchematronValidatorTest {
+
+    private static final String SCHEMATRON = "src/test/resources/validation/order.sch";
+
+    private static final String ORDER_WITHOUT_ITEM = """
+            <order />
+            """;
+
+    private static final String ORDER_WITH_ITEM = """
+            <order><item /></order>
+            """;
+
+    @Test
+    void valid() throws Exception {
+        Exchange exc = post("/foo").body(ORDER_WITH_ITEM).buildExchange();
+        assertEquals(CONTINUE, createValidator(ErrorDetailsPolicy.FULL).validateMessage(exc, REQUEST));
+    }
+
+    /**
+     * A non-null {@link ValidatorInterceptor.FailureHandler} used to suppress the report, which
+     * made {@code <validator schematron="...">} always answer with an empty {@code <error/>}:
+     * {@code createFailureHandler()} never returns null, not even for {@code failureHandler="response"}.
+     */
+    @Test
+    void failureHandlerDoesNotSuppressTheReport() throws Exception {
+        Exchange exc = post("/foo").body(ORDER_WITHOUT_ITEM).buildExchange();
+        var validator = createValidator(ErrorDetailsPolicy.FULL);
+
+        assertEquals(ABORT, validator.validateMessage(exc, REQUEST));
+
+        String body = exc.getResponse().getBodyAsStringDecoded();
+        assertEquals(400, exc.getResponse().getStatusCode());
+        assertEquals(REQUEST.name().toLowerCase(), exc.getResponse().getHeader().getFirstValue(VALIDATION_ERROR_SOURCE));
+        assertTrue(body.contains("failed-assert"), body);
+        assertTrue(body.contains("An order must contain at least one item."), body);
+        assertEquals(1, validator.getInvalid());
+    }
+
+    @Test
+    void validationDetailsOffOmitsTheReport() throws Exception {
+        Exchange exc = post("/foo").body(ORDER_WITHOUT_ITEM).buildExchange();
+
+        assertEquals(ABORT, createValidator(new ErrorDetailsPolicy(false, false)).validateMessage(exc, REQUEST));
+
+        String body = exc.getResponse().getBodyAsStringDecoded();
+        assertEquals(400, exc.getResponse().getStatusCode());
+        assertFalse(body.contains("failed-assert"), body);
+        assertFalse(body.contains("An order must contain at least one item."), body);
+        assertTrue(body.contains("<error></error>"), body);
+    }
+
+    @Test
+    void productionModeKeepsTheReport() throws Exception {
+        Exchange exc = post("/foo").body(ORDER_WITHOUT_ITEM).buildExchange();
+
+        assertEquals(ABORT, createValidator(new ErrorDetailsPolicy(true, true)).validateMessage(exc, REQUEST));
+
+        assertTrue(exc.getResponse().getBodyAsStringDecoded().contains("An order must contain at least one item."),
+                "the schematron is public, so its errors stay visible in production");
+    }
+
+    private static SchematronValidator createValidator(ErrorDetailsPolicy policy) throws Exception {
+        return new SchematronValidator(SCHEMATRON, ValidatorInterceptor.FailureHandler.VOID,
+                new TestRouter(), transformerFactoryBean(), policy);
+    }
+
+    private static BeanFactory transformerFactoryBean() {
+        var beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerSingleton("transformerFactory", TransformerFactory.newInstance());
+        return beanFactory;
+    }
+}

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/ValidatorInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/ValidatorInterceptorTest.java
@@ -14,6 +14,8 @@
 
 package com.predic8.membrane.core.interceptor.schemavalidation;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.predic8.membrane.core.exchange.Exchange;
 import com.predic8.membrane.core.http.Request;
 import com.predic8.membrane.core.http.Response;
@@ -34,6 +36,8 @@ import static com.predic8.membrane.core.interceptor.Outcome.ABORT;
 import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
 import static com.predic8.membrane.test.TestUtil.getPathFromResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class ValidatorInterceptorTest {
@@ -143,6 +147,34 @@ public class ValidatorInterceptorTest {
     void testSchemaValidation() throws Exception {
         assertEquals(CONTINUE, getOutcome(requestTB, createSchemaValidatorInterceptor(getPathFromResource("/validation/order.xsd")), getPathFromResource("validation/order.xml")));
         assertEquals(ABORT, getOutcome(requestTB, createSchemaValidatorInterceptor(getPathFromResource("/validation/order.xsd")), getPathFromResource("validation/invalid-order.xml")));
+    }
+
+    /**
+     * The {@code validationDetails} attribute must reach the validator that actually renders the
+     * error response.
+     */
+    @Test
+    void validationDetailsIsPassedToTheValidator() throws Exception {
+        var interceptor = createSchemaValidatorInterceptor(getPathFromResource("/validation/order.xsd"));
+        interceptor.setValidationDetails(false);
+        interceptor.init(router);
+
+        assertEquals(ABORT, getOutcome(post("http://thomas-bayer.com").build(), interceptor, getPathFromResource("validation/invalid-order.xml")));
+
+        JsonNode jn = new ObjectMapper().readTree(exc.getResponse().getBodyAsStreamDecoded());
+        assertEquals("XML message validation failed", jn.get("title").asText());
+        assertNull(jn.get("validation"));
+    }
+
+    @Test
+    void validationDetailsDefaultsToOn() throws Exception {
+        var interceptor = createSchemaValidatorInterceptor(getPathFromResource("/validation/order.xsd"));
+        assertTrue(interceptor.isValidationDetails());
+
+        assertEquals(ABORT, getOutcome(post("http://thomas-bayer.com").build(), interceptor, getPathFromResource("validation/invalid-order.xml")));
+
+        JsonNode jn = new ObjectMapper().readTree(exc.getResponse().getBodyAsStreamDecoded());
+        assertEquals(1, jn.get("validation").size());
     }
 
     private Outcome getOutcome(Request request, Interceptor interceptor, String fileName) throws Exception {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/ValidatorInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/ValidatorInterceptorTest.java
@@ -155,13 +155,8 @@ public class ValidatorInterceptorTest {
      */
     @Test
     void validationDetailsIsPassedToTheValidator() throws Exception {
-        var interceptor = createSchemaValidatorInterceptor(getPathFromResource("/validation/order.xsd"));
-        interceptor.setValidationDetails(false);
-        interceptor.init(router);
+        JsonNode jn = rejectInvalidOrder(createSchemaValidatorInterceptor(getPathFromResource("/validation/order.xsd"), false));
 
-        assertEquals(ABORT, getOutcome(post("http://thomas-bayer.com").build(), interceptor, getPathFromResource("validation/invalid-order.xml")));
-
-        JsonNode jn = new ObjectMapper().readTree(exc.getResponse().getBodyAsStreamDecoded());
         assertEquals("XML message validation failed", jn.get("title").asText());
         assertNull(jn.get("validation"));
     }
@@ -171,10 +166,17 @@ public class ValidatorInterceptorTest {
         var interceptor = createSchemaValidatorInterceptor(getPathFromResource("/validation/order.xsd"));
         assertTrue(interceptor.isValidationDetails());
 
-        assertEquals(ABORT, getOutcome(post("http://thomas-bayer.com").build(), interceptor, getPathFromResource("validation/invalid-order.xml")));
+        assertEquals(1, rejectInvalidOrder(interceptor).get("validation").size());
+    }
 
-        JsonNode jn = new ObjectMapper().readTree(exc.getResponse().getBodyAsStreamDecoded());
-        assertEquals(1, jn.get("validation").size());
+    private JsonNode rejectInvalidOrder(ValidatorInterceptor interceptor) throws Exception {
+        Exchange exchange = new Exchange(null);
+        exchange.setRequest(post("http://thomas-bayer.com")
+                .body(getContent(getPathFromResource("validation/invalid-order.xml"))).build());
+
+        assertEquals(ABORT, interceptor.handleRequest(exchange));
+
+        return new ObjectMapper().readTree(exchange.getResponse().getBodyAsStreamDecoded());
     }
 
     private Outcome getOutcome(Request request, Interceptor interceptor, String fileName) throws Exception {
@@ -188,9 +190,14 @@ public class ValidatorInterceptorTest {
     }
 
     private ValidatorInterceptor createSchemaValidatorInterceptor(String schema) {
+        return createSchemaValidatorInterceptor(schema, true);
+    }
+
+    private ValidatorInterceptor createSchemaValidatorInterceptor(String schema, boolean validationDetails) {
         ValidatorInterceptor interceptor = new ValidatorInterceptor();
         interceptor.setResourceResolver(new ResolverMap());
         interceptor.setSchema(schema);
+        interceptor.setValidationDetails(validationDetails);
         interceptor.init(router);
         return interceptor;
     }

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidatorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidatorTest.java
@@ -100,7 +100,7 @@ public class WSDLValidatorTest {
 
         String body = exc.getResponse().getBodyAsStringDecoded();
         assertEquals(200, exc.getResponse().getStatusCode());
-        assertTrue(body.contains("<faultcode>Client</faultcode>"), body);
+        assertTrue(body.contains("<faultcode>soap:Client</faultcode>"), body);
         assertTrue(body.contains("WSDL message validation failed"), body);
         assertFalse(body.contains("cvc-"), "schema error codes must not leak when details are off: " + body);
         assertFalse(body.contains("<detail>"), body);

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidatorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/WSDLValidatorTest.java
@@ -91,6 +91,35 @@ public class WSDLValidatorTest {
     };
 
     @Test
+    void validationDetailsOffKeepsFaultButDropsDetail() throws Exception {
+        var exc = getRequestExchange(soap11("""
+                    <cit:getCity xmlns:cit="https://predic8.de/cities"><wrong/></cit:getCity>
+                """));
+
+        assertEquals(ABORT, createValidator(new ErrorDetailsPolicy(false, false)).validateMessage(exc, REQUEST));
+
+        String body = exc.getResponse().getBodyAsStringDecoded();
+        assertEquals(200, exc.getResponse().getStatusCode());
+        assertTrue(body.contains("<faultcode>Client</faultcode>"), body);
+        assertTrue(body.contains("WSDL message validation failed"), body);
+        assertFalse(body.contains("cvc-"), "schema error codes must not leak when details are off: " + body);
+        assertFalse(body.contains("<detail>"), body);
+    }
+
+    @Test
+    void validationDetailsOnKeepsFaultDetail() throws Exception {
+        var exc = getRequestExchange(soap11("""
+                    <cit:getCity xmlns:cit="https://predic8.de/cities"><wrong/></cit:getCity>
+                """));
+
+        assertEquals(ABORT, createValidator(new ErrorDetailsPolicy(true, true)).validateMessage(exc, REQUEST));
+
+        String body = exc.getResponse().getBodyAsStringDecoded();
+        assertTrue(body.contains("<detail>"), body);
+        assertTrue(body.contains("cvc-"), "the WSDL is public, so its errors stay visible in production: " + body);
+    }
+
+    @Test
     void invalidRequestElement() throws Exception {
         var exc = getRequestExchange(soap11("""
                     <foo:notInSchema xmlns:foo="http://membrane-api.io/foo"/>
@@ -664,6 +693,13 @@ public class WSDLValidatorTest {
 
     private static WSDLValidator createValidator(String location, String serviceName, boolean skipFaults) {
         var validator = new WSDLValidator(new ResolverMap(), location, serviceName, (msg, exc) -> log.info("Validation failure: {}", msg), skipFaults);
+        validator.init();
+        return validator;
+    }
+
+    private static WSDLValidator createValidator(ErrorDetailsPolicy policy) {
+        var validator = new WSDLValidator(new ResolverMap(), CITIES_WSDL, null,
+                (msg, exc) -> log.info("Validation failure: {}", msg), false, policy);
         validator.init();
         return validator;
     }

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/XMLSchemaValidatorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/XMLSchemaValidatorTest.java
@@ -89,6 +89,46 @@ class XMLSchemaValidatorTest {
     }
 
     @Test
+    void validationDetailsOffOmitsValidationMember() throws Exception {
+        Exchange exc = invalidOrder(new ErrorDetailsPolicy(false, false));
+
+        assertEquals(APPLICATION_PROBLEM_JSON, exc.getResponse().getHeader().getContentType());
+        assertEquals(400, exc.getResponse().getStatusCode());
+        assertEquals(REQUEST.name(), exc.getResponse().getHeader().getFirstValue(VALIDATION_ERROR_SOURCE));
+
+        JsonNode jn = om.readTree(exc.getResponse().getBodyAsStreamDecoded());
+        assertEquals("XML message validation failed", jn.get("title").asText());
+        assertEquals("https://membrane-api.io/problems/user", jn.get("type").asText());
+        assertNull(jn.get("validation"));
+    }
+
+    @Test
+    void productionModeKeepsValidationMember() throws Exception {
+        Exchange exc = invalidOrder(new ErrorDetailsPolicy(true, true));
+
+        JsonNode jn = om.readTree(exc.getResponse().getBodyAsStreamDecoded());
+        assertEquals(1, jn.get("validation").size(), "the XSD is public, so its errors stay visible in production");
+        assertTrue(jn.get("validation").get(0).get("message").asText().contains("illegal"));
+        assertNull(jn.get("attention"), "no development-mode warning on a production router");
+    }
+
+    private Exchange invalidOrder(ErrorDetailsPolicy policy) throws Exception {
+        var v = new XMLSchemaValidator(new ResolverMap(), "src/test/resources/validation/order.xsd",
+                (message, exc) -> log.info("Validation failure: {}", message), policy);
+        v.init();
+        Exchange exc = post("/foo").body("""
+                <order xmlns="http://membrane-soa.org/router/validation/order/1/">
+                	<items>
+                		<item id="3" />
+                		<illegal/>
+                	</items>
+                </order>
+                """).buildExchange();
+        assertEquals(ABORT, v.validateMessage(exc, REQUEST));
+        return exc;
+    }
+
+    @Test
     void doesNotFetchExternalDtdInInstanceDocument() throws Exception {
         var received = new AtomicBoolean(false);
         int port = freePort();

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/XMLSchemaValidatorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/schemavalidation/XMLSchemaValidatorTest.java
@@ -76,7 +76,7 @@ class XMLSchemaValidatorTest {
         JsonNode jn = om.readTree(exc.getResponse().getBodyAsStreamDecoded());
 
         assertEquals("XML message validation failed", jn.get("title").asText());
-        assertEquals("https://membrane-api.io/problems/user", jn.get("type").asText());
+        assertEquals("https://membrane-api.io/problems/user/validation", jn.get("type").asText());
 
         JsonNode validation = jn.get("validation");
 
@@ -98,7 +98,7 @@ class XMLSchemaValidatorTest {
 
         JsonNode jn = om.readTree(exc.getResponse().getBodyAsStreamDecoded());
         assertEquals("XML message validation failed", jn.get("title").asText());
-        assertEquals("https://membrane-api.io/problems/user", jn.get("type").asText());
+        assertEquals("https://membrane-api.io/problems/user/validation", jn.get("type").asText());
         assertNull(jn.get("validation"));
     }
 

--- a/core/src/test/java/com/predic8/membrane/core/ws/SoapProxyInvocationTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/ws/SoapProxyInvocationTest.java
@@ -208,7 +208,7 @@ public class SoapProxyInvocationTest {
                 .post("http://localhost:2000/services/a")
         .then().statusCode(200)
                 .contentType(TEXT_XML)
-                .body("Envelope.Body.Fault.faultcode", equalTo("Client"))
+                .body("Envelope.Body.Fault.faultcode", equalTo("soap:Client"))
                 .body("Envelope.Body.Fault.faultstring", equalTo("WSDL message validation failed"));
         // @formatter:on
     }

--- a/core/src/test/resources/validation/order.sch
+++ b/core/src/test/resources/validation/order.sch
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.ascc.net/xml/schematron">
+    <pattern name="Order">
+        <rule context="order">
+            <assert test="count(item) &gt; 0">An order must contain at least one item.</assert>
+        </rule>
+    </pattern>
+</schema>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a validation-details setting for schema validation responses.
  * Validation error responses can include or omit detailed validation information across XML, JSON, YAML, SOAP/WSDL, and Schematron validation.
  * Production-mode responses retain validation errors while excluding development-only attention notices.

* **Bug Fixes**
  * Standardized validation failure response formatting across supported validation types.
  * SOAP 1.1 fault codes now use the correctly qualified `soap:` format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->