### PR TITLE
Add/improve documentation for `OperationsConfig`

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/wsdl2openapi/OperationsConfig.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/wsdl2openapi/OperationsConfig.java
@@ -23,8 +23,8 @@ import java.util.Map;
 
 /**
  * @description Configures which WSDL operations are exposed via OpenAPI. Add one attribute per
- * operation you want to expose, naming it after the WSDL operation and giving it a nested
- * <code>operationSettings</code> value. Omitting this element exposes every WSDL operation with
+ * operation you want to expose, naming it after the WSDL operation and giving it an
+ * <code>OperationSettings</code> value. Omitting this element exposes every WSDL operation with
  * default settings.
  * See tutorials/wsdl-to-openapi/20-WSDL-to-OpenAPI-REST.yaml.
  * @yaml <pre><code>

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/wsdl2openapi/OperationsConfig.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/wsdl2openapi/OperationsConfig.java
@@ -22,14 +22,31 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * Named map of WSDL operations to expose via OpenAPI.
- * Each key is a WSDL operation name; the value holds its HTTP mapping settings.
+ * @description Configures which WSDL operations are exposed via OpenAPI. Add one attribute per
+ * operation you want to expose, naming it after the WSDL operation and giving it a nested
+ * <code>operationSettings</code> value. Omitting this element exposes every WSDL operation with
+ * default settings.
+ * See tutorials/wsdl-to-openapi/20-WSDL-to-OpenAPI-REST.yaml.
+ * @yaml <pre><code>
+ * operations:
+ *   getPartner:
+ *     method: GET
+ *     path: /partners/{id}
+ *     tag: Partner
+ *   createPartner:
+ *     method: POST
+ *     path: /partners
+ *     tag: Partner
+ * </code></pre>
  */
 @MCElement(name = "operations", component = false)
 public class OperationsConfig {
 
     private final Map<String, OperationSettings> map = new LinkedHashMap<>();
 
+    /**
+     * @description Each attribute name is a WSDL operation name and its value configures that operation.
+     */
     @MCOtherAttributes
     public void setEntry(Map<String, OperationSettings> entry) {
         if (entry != null) map.putAll(entry);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated configuration documentation for WSDL operations, including descriptions of the `@description` and `@yaml` attributes.
  * Added YAML examples demonstrating operation settings for `getPartner` and `createPartner`.
  * Clarified that each attribute identifies a WSDL operation and accepts operation-specific settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->